### PR TITLE
Fix redeclared FHIR map constants

### DIFF
--- a/src/lib/fhir-map.ts
+++ b/src/lib/fhir-map.ts
@@ -15,6 +15,7 @@ const UCUM_SYSTEM = "http://unitsofmeasure.org";
 const OBS_CAT_SYSTEM = "http://terminology.hl7.org/CodeSystem/observation-category";
 const OBS_CAT_VITALS = "vital-signs";
 const OBS_CAT_LAB = "laboratory";
+const GLUCOSE_CONVERSION_FACTOR = 18.0182;
 
 const ACVPU_TEXT = {
   A: "Alert",
@@ -222,21 +223,7 @@ function resolveAttachmentContentType(att: AttachmentInput): string {
 // Alias de unidades y CODES mínimos para los tests
 ////////////////////////////////////////////////////
 
-const UCUM_SYSTEM = "http://unitsofmeasure.org";
-const LOINC_SYSTEM = "http://loinc.org";
-const SNOMED_SYSTEM = "http://snomed.info/sct";
-const OBS_CAT_SYSTEM = "http://terminology.hl7.org/CodeSystem/observation-category";
-const OBS_CAT_VITALS = "vital-signs";
-const OBS_CAT_LAB = "laboratory";
-const GLUCOSE_CONVERSION_FACTOR = 18.0182;
-
 export const __test__ = {
-  UCUM_SYSTEM,
-  LOINC_SYSTEM,
-  SNOMED_SYSTEM,
-  OBS_CAT_SYSTEM,
-  OBS_CAT_VITALS,
-  OBS_CAT_LAB,
   UNITS: {
     PER_MIN: "/min",
     MMHG: "mm[Hg]",
@@ -250,6 +237,12 @@ export const __test__ = {
     MMOLL: "mmol/L",
     MMOL_L: "mmol/L"          // alias
   } as const,
+  UCUM_SYSTEM,
+  LOINC_SYSTEM,
+  SNOMED_SYSTEM,
+  OBS_CAT_SYSTEM,
+  OBS_CAT_VITALS,
+  OBS_CAT_LAB,
   LOINC: {
     PANEL_VS: "85353-1",
     BP_PANEL: "85354-9",
@@ -265,47 +258,12 @@ export const __test__ = {
     O2_FLOW: "19849-6",
     ACVPU: "67775-7"
   } as const,
-  CODES: {
-    PANEL_VS: { code: "85353-1", display: "Vital signs panel" },
-    PANEL_BP: { code: "85354-9", display: "Blood pressure panel" },
-    SBP: { code: "8480-6", display: "Systolic blood pressure" },
-    DBP: { code: "8462-4", display: "Diastolic blood pressure" },
-    HR: { code: "8867-4", display: "Heart rate" },
-    RR: { code: "9279-1", display: "Respiratory rate" },
-    TEMP: { code: "8310-5", display: "Body temperature" },
-    SPO2: { code: "59408-5", display: "Oxygen saturation" },
-    GLU_MASS_BLD: { code: "2339-0", display: "Glucose [Mass/volume] in Blood" },
-    GLU_MOLES_BLDC_GLUCOMETER: { code: "14743-9", display: "Glucose [Moles/volume] in Blood" },
-    FIO2: { code: "3150-0", display: "Inhaled oxygen concentration" },
-    O2_FLOW: { code: "19849-6", display: "Oxygen flow rate" },
-    ACVPU: { code: "67775-7", display: "ACVPU level of consciousness" }
-  } as const,
-  ACVPU_LOINC: {
-    A: { code: "LA9340-6", display: "Alert" },
-    C: { code: "LA6560-2", display: "Confusion" },
-    V: { code: "LA17108-4", display: "Responds to voice" },
-    P: { code: "LA17107-6", display: "Responds to pain" },
-    U: { code: "LA9343-0", display: "Unresponsive" }
-  } as const,
-  ACVPU_SNOMED: {
-    A: { code: "248234009", display: "Alert (finding)" },
-    C: { code: "162214003", display: "Confused (finding)" },
-    V: { code: "248238005", display: "Responds to voice (finding)" },
-    P: { code: "248241002", display: "Responds to pain (finding)" },
-    U: { code: "420512000", display: "Unresponsive (finding)" }
-  } as const,
-  SNOMED: {
-    O2_ADMINISTRATION: "243120004" // Administration of oxygen (procedure)
-  } as const,
-  LOINC_SYSTEM,
-  UCUM_SYSTEM,
-  OBS_CAT_SYSTEM,
-  OBS_CAT_VITALS,
-  OBS_CAT_LAB,
-  SNOMED_SYSTEM,
   CODES,
   ACVPU_LOINC,
-  ACVPU_SNOMED
+  ACVPU_SNOMED,
+  SNOMED: {
+    O2_ADMINISTRATION: "243120004" // Administration of oxygen (procedure)
+  } as const
 } as const;
 
 /////////////////////////////////////
@@ -883,6 +841,8 @@ export function buildHandoverBundle(
     : values.meds;
 
   const resources: any[] = [];
+
+  const opts = options ?? {};
 
   // 1) Observations de signos vitales (incluye FiO2/Flow si presentes)
   const obs = mapObservationVitals(values, opts);


### PR DESCRIPTION
## Summary
- define FHIR system constants once and expose them through the `__test__` helper without redeclarations
- ensure `buildHandoverBundle` forwards its build options to the vitals and oxygen mappers

## Testing
- pnpm -s vitest run   src/lib/__tests__/fhir-map.acvpu.spec.ts   src/lib/__tests__/fhir-map.loinc-extra.spec.ts   src/lib/__tests__/fhir-map.edge.spec.ts   src/lib/__tests__/fhir-map.glucose.normalize.spec.ts   src/lib/__tests__/fhir-map.unit.spec.ts   src/lib/__tests__/fhir-map.vitals.core.spec.ts   --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68f947ff461883219c4e757b4bd687fe