### PR TITLE
test: mock react-native for vitest suites

### DIFF
--- a/tests/__mocks__/react-native.ts
+++ b/tests/__mocks__/react-native.ts
@@ -1,0 +1,3 @@
+export const Platform = { OS: 'test', select: (o: any) => ('test' in o ? o.test : o.default) };
+export const StyleSheet = { create: (s: any) => s };
+export default {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config';
-import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
@@ -9,23 +9,25 @@ export default defineConfig({
       '**/__tests__/**/sync.*.(spec|test).ts',
     ],
     exclude: [
+      'src/screens/**',
+      'src/validation/**',
+      'src/security/**',
+      'src/**/__tests__/**/fhir-map.test.ts',
       'src/**/__tests__/**/news2.test.ts',
       'src/**/__tests__/**/prefill.test.ts',
       'src/**/__tests__/**/media.test.ts',
       'src/**/__tests__/**/fetchPatientsFromFHIR.test.ts',
       'src/**/__tests__/**/queue.test.ts',
       'src/**/__tests__/**/patient-filters.test.ts',
-      'src/**/__tests__/**/fhir-map.test.ts',
-      'src/**/__tests__/**/drafts.test.ts',
-      'src/security/**/__tests__/**',
-      'src/validation/**/__tests__/**',
-      'src/screens/**/__tests__/**',
     ],
     setupFiles: ['./vitest.setup.ts'],
   },
   resolve: {
     alias: {
-      '@/src': path.resolve(__dirname, 'src'),
+      'react-native': fileURLToPath(new URL('./tests/__mocks__/react-native.ts', import.meta.url)),
+      '@/src': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  optimizeDeps: { exclude: ['react-native'] },
+  ssr: { external: ['react-native'] },
 });


### PR DESCRIPTION
## Summary
- add a local mock implementation of `react-native` used during Vitest runs
- update the Vitest configuration to resolve the mock and exclude the native module from optimization
- keep the existing vitals/sync test filters while honoring the requested exclusions

## Testing
- pnpm -s vitest run src/lib/__tests__ --reporter=verbose *(fails: existing suites still contain assertion failures after the environment loads)*

------
https://chatgpt.com/codex/tasks/task_e_68f9bf1d207483219623dea54b409df1