### PR TITLE
fix: align fhir-map default panel options

### DIFF
--- a/src/lib/fhir-map.ts
+++ b/src/lib/fhir-map.ts
@@ -109,6 +109,7 @@ export type BuildOptions = {
   now?: string;
   authorId?: string;
   attachments?: AttachmentInput[];
+  emitVitalsPanel?: boolean;
   emitPanel?: boolean;
   emitIndividuals?: boolean;
   emitHasMember?: boolean;
@@ -118,6 +119,12 @@ export type BuildOptions = {
   glucoseDecimals?: number;
   profileUrls?: string[] | ProfileUrlMap;
 };
+
+const DEFAULT_OPTS = {
+  emitVitalsPanel: false,
+  emitBpPanel: false,
+  emitHasMember: false,
+} as const;
 
 export type MedicationCodeInput = { system?: string; code?: string; display?: string } | string;
 
@@ -519,19 +526,21 @@ const pushIf = <T>(arr: T[], v: T | undefined | null) => {
 export function mapObservationVitals(values: HandoverValues, opts?: BuildOptions): Observation[] {
   if (!values?.patientId) return [];
 
+  const opts2: BuildOptions & typeof DEFAULT_OPTS = { ...DEFAULT_OPTS, ...opts };
+
   const vitals = normalizeVitalsInput(values.vitals);
   const observations: Observation[] = [];
 
   const subj = refPatient(values.patientId);
   const enc = refEncounter(values.encounterId);
-  const effective = opts?.now ?? nowISO();
+  const effective = opts2.now ?? nowISO();
 
-  const emitIndividuals = opts?.emitIndividuals ?? true;
+  const emitIndividuals = opts2.emitIndividuals ?? true;
 
-  const normalizeGlucoseOption = opts?.normalizeGlucoseToMgDl ?? opts?.normalizeGlucoseToMgdl;
+  const normalizeGlucoseOption = opts2.normalizeGlucoseToMgDl ?? opts2.normalizeGlucoseToMgdl;
   const normalizeGlucose =
     typeof normalizeGlucoseOption === "boolean" ? normalizeGlucoseOption : true;
-  const glucoseDecimals = opts?.glucoseDecimals ?? 0;
+  const glucoseDecimals = opts2.glucoseDecimals ?? 0;
 
   const buildObservation = (params: {
     code: FhirCodeableConcept;
@@ -892,13 +901,14 @@ function mapMedicationStatements(values: HandoverValues, medsArg?: MedicationInp
 /////////////////////////////////////////
 
 function mapOxygenProcedure(values: HandoverValues, opts?: BuildOptions): DeviceUseStatement[] {
+  const opts2: BuildOptions & typeof DEFAULT_OPTS = { ...DEFAULT_OPTS, ...opts };
   const vitals = normalizeVitalsInput(values.vitals);
   const hasO2 = Boolean(vitals.o2) || isNum(vitals.fio2) || isNum(vitals.o2FlowLpm) || !!vitals.o2Device;
   if (!hasO2) return [];
 
   const subj = refPatient(values.patientId);
   const enc = refEncounter(values.encounterId);
-  const when = opts?.now ?? nowISO();
+  const when = opts2.now ?? nowISO();
 
   const note = buildO2Note(vitals);
 
@@ -983,13 +993,14 @@ export function buildHandoverBundle(
   }
 
   const patientId = values.patientId;
-  const now = options.now ?? nowISO();
+  const opts2: BuildOptions & typeof DEFAULT_OPTS = { ...DEFAULT_OPTS, ...options };
+  const now = opts2.now ?? nowISO();
 
   const attachmentsFromValues = Array.isArray(values.attachments) ? values.attachments : [];
   const attachmentsFromInput = isWrapped && Array.isArray((input as HandoverInput).attachments)
     ? ((input as HandoverInput).attachments as AttachmentInput[])
     : [];
-  const attachmentsFromOptions = Array.isArray(options.attachments) ? options.attachments : [];
+  const attachmentsFromOptions = Array.isArray(opts2.attachments) ? opts2.attachments : [];
 
   const mergedAttachments = [...attachmentsFromValues, ...attachmentsFromInput, ...attachmentsFromOptions].filter(
     (att): att is AttachmentInput => Boolean(att),
@@ -1003,14 +1014,14 @@ export function buildHandoverBundle(
     : values.meds;
   const normalizedMeds = normalizeMedicationInputs(medsInput);
   const normalizedVitals = normalizeVitalsInput(values.vitals);
-  const profileExtras = normalizeProfileOptions(options.profileUrls);
+  const profileExtras = normalizeProfileOptions(opts2.profileUrls);
 
   const observationOptions: BuildOptions = {
     now,
-    emitIndividuals: options.emitIndividuals,
-    normalizeGlucoseToMgDl: options.normalizeGlucoseToMgDl,
-    normalizeGlucoseToMgdl: options.normalizeGlucoseToMgdl,
-    glucoseDecimals: options.glucoseDecimals,
+    emitIndividuals: opts2.emitIndividuals,
+    normalizeGlucoseToMgDl: opts2.normalizeGlucoseToMgDl,
+    normalizeGlucoseToMgdl: opts2.normalizeGlucoseToMgdl,
+    glucoseDecimals: opts2.glucoseDecimals,
   };
 
   const observationResources = mapObservationVitals(values, observationOptions);
@@ -1078,9 +1089,10 @@ export function buildHandoverBundle(
     }
   }
 
-  const emitPanel = options.emitPanel ?? true;
-  const emitBpPanel = options.emitBpPanel ?? (options.emitPanel ?? true);
-  const emitHasMember = options.emitHasMember ?? false;
+  const emitVitalsPanel =
+    opts2.emitVitalsPanel ?? opts2.emitPanel ?? DEFAULT_OPTS.emitVitalsPanel;
+  const emitBpPanel = opts2.emitBpPanel ?? emitVitalsPanel;
+  const emitHasMember = opts2.emitHasMember ?? DEFAULT_OPTS.emitHasMember;
 
   const codeDisplayMap = new Map<string, string>([
     [__test__.CODES.HR.code, __test__.CODES.HR.display],
@@ -1100,7 +1112,7 @@ export function buildHandoverBundle(
     __test__.CODES.DBP.code,
   ];
 
-  if (emitPanel) {
+  if (emitVitalsPanel) {
     const components: Observation['component'] = [];
     for (const code of vitalComponentCodes) {
       const info = observationInfo.get(code);


### PR DESCRIPTION
## Summary
- set default vitals panel, blood pressure panel, and hasMember options to false and expose emitVitalsPanel alias
- merge build options with the defaults before mapping vitals, oxygen therapy, and bundle resources

## Testing
- pnpm -s vitest run \
  src/lib/__tests__/fhir-map.unit.spec.ts \
  src/lib/__tests__/fhir-map.edge.spec.ts \
  src/lib/__tests__/fhir-map.vitals.core.spec.ts \
  --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68f9e522f33883219c99221163613479