### PR TITLE
Align fhir-map LOINC extra spec with shared test helpers

### DIFF
--- a/src/lib/__tests__/fhir-map.loinc-extra.spec.ts
+++ b/src/lib/__tests__/fhir-map.loinc-extra.spec.ts
@@ -1,18 +1,17 @@
 // src/lib/__tests__/fhir-map.loinc-extra.spec.ts
 import { describe, it, expect } from 'vitest';
-import { mapVitalsToObservations } from '../fhir-map';
+import { mapVitalsToObservations, __test__ } from '../fhir-map';
 
 type Ctx = {
   patientId: string;
   effectiveDateTime: string;
 };
 
-const UOM = 'http://unitsofmeasure.org';
-
 const findByLoinc = (arr: any[], code: string) =>
   arr.find((r) =>
     r?.code?.coding?.some(
-      (c: any) => c.system === 'http://loinc.org' && String(c.code) === String(code)
+      (c: any) =>
+        c.system === __test__.LOINC_SYSTEM && String(c.code) === String(code)
     )
   );
 
@@ -20,8 +19,7 @@ const hasVitalCategory = (r: any) =>
   r?.category?.some((cat: any) =>
     cat?.coding?.some(
       (c: any) =>
-        c.system === 'http://terminology.hl7.org/CodeSystem/observation-category' &&
-        c.code === 'vital-signs'
+        c.system === __test__.OBS_CAT_SYSTEM && c.code === __test__.OBS_CAT_VITALS
     )
   );
 
@@ -40,7 +38,7 @@ describe('FHIR map — Glucemia capilar y ACVPU (LOINC)', () => {
 
   it('mapea Glucemia capilar con LOINC 2339-0 y UCUM mg/dL', () => {
     const out = run({ bgMgDl: 104 }, ctx);
-    const glu = findByLoinc(out, '2339-0'); // Glucose [Mass/volume] in Blood
+    const glu = findByLoinc(out, __test__.CODES.GLU_MASS_BLD.code); // 2339-0
     expect(glu).toBeTruthy();
 
     expect(glu.status).toBe('final');
@@ -49,35 +47,38 @@ describe('FHIR map — Glucemia capilar y ACVPU (LOINC)', () => {
 
     expect(glu.valueQuantity).toMatchObject({
       value: 104,
-      unit: 'mg/dL',
-      system: UOM,
-      code: 'mg/dL',
+      unit: __test__.UNITS.MGDL,
+      system: __test__.UCUM_SYSTEM,
+      code: __test__.UNITS.MGDL,
     });
   });
 
   it('mapea ACVPU con LOINC 67775-7 y respuestas LOINC (LA codes)', () => {
     const map = (avpu: 'A' | 'C' | 'V' | 'P' | 'U') => {
       const out = run({ avpu }, ctx);
-      const obs = findByLoinc(out, '67775-7');
+      const obs = findByLoinc(out, __test__.CODES.ACVPU.code);
       expect(obs).toBeTruthy();
       expect(obs.status).toBe('final');
       expect(obs.subject?.reference).toBe('Patient/pat-001');
       expect(hasVitalCategory(obs)).toBe(true);
 
+      const acvpuCodings = obs.code?.coding ?? [];
+      expect(
+        acvpuCodings.some(
+          (c: any) => c.system === __test__.CODES.ACVPU.system && c.code === __test__.CODES.ACVPU.code
+        )
+      ).toBe(true);
+
       const coding = obs.valueCodeableConcept?.coding ?? [];
-      const has = (code: string) =>
-        coding.some(
-          (c: any) => c.system === 'http://loinc.org' && c.code === code
-        );
+      const hasCoding = (system: string, code: string) =>
+        coding.some((c: any) => c.system === system && c.code === code);
 
-      // A -> Alert, C -> Confused, V -> Verbal, P -> Painful, U -> Unresponsive
-      if (avpu === 'A') expect(has('LA9340-6')).toBe(true);
-      if (avpu === 'C') expect(has('LA6560-2')).toBe(true);
-      if (avpu === 'V') expect(has('LA17108-4')).toBe(true);
-      if (avpu === 'P') expect(has('LA17107-6')).toBe(true);
-      if (avpu === 'U') expect(has('LA9343-0')).toBe(true);
+      const loincAnswer = __test__.ACVPU_LOINC[avpu];
+      const snomedAnswer = __test__.ACVPU_SNOMED[avpu];
+      expect(hasCoding(__test__.LOINC_SYSTEM, loincAnswer.code)).toBe(true);
+      expect(hasCoding(__test__.SNOMED_SYSTEM, snomedAnswer.code)).toBe(true);
 
-      expect(obs.valueCodeableConcept?.text)?.toBeTruthy();
+      expect(obs.valueCodeableConcept?.text).toBeTruthy();
     };
 
     map('A'); map('C'); map('V'); map('P'); map('U');
@@ -85,7 +86,7 @@ describe('FHIR map — Glucemia capilar y ACVPU (LOINC)', () => {
 
   it('no crea Observations para valores inválidos o faltantes', () => {
     const out = run({ bgMgDl: undefined, avpu: 'X' as any }, ctx);
-    expect(findByLoinc(out, '2339-0')).toBeFalsy();
-    expect(findByLoinc(out, '67775-7')).toBeFalsy();
+    expect(findByLoinc(out, __test__.CODES.GLU_MASS_BLD.code)).toBeFalsy();
+    expect(findByLoinc(out, __test__.CODES.ACVPU.code)).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
- reuse the __test__ helper constants for LOINC, UCUM, and observation category values in the LOINC extra spec
- assert the ACVPU observation exposes the shared code metadata and both SNOMED and LOINC answer codings

## Testing
- pnpm -s vitest run src/lib/__tests__/fhir-map.acvpu.spec.ts src/lib/__tests__/fhir-map.loinc-extra.spec.ts --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68f9e5297ff483219fecb2d8d7fa9490