### PR TITLE
fix: remove node crypto dependency from RN bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
     "uuid": "^13.0.0",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "react-native-web": "~0.21.0"
   },
   "devDependencies": {
     "@expo/cli": "^54.0.11",

--- a/src/lib/fhir-map.ts
+++ b/src/lib/fhir-map.ts
@@ -1,5 +1,6 @@
-import { createHash } from 'node:crypto';
 import { z } from 'zod';
+
+import { hashString } from './hash';
 
 /* [NURSEOS PRO PATCH 2025-10-22] fhir-map.ts
    - Tipos y exports alineados con tests (HandoverValues, AttachmentInput, HandoverInput)
@@ -588,8 +589,6 @@ export function mapObservationVitals(
   const opts2 = { ...DEFAULT_OPTS, ...opts };
   if (!values?.patientId) return [];
 
-  const opts2 = { ...DEFAULT_OPTS, ...opts };
-
   const vitals = normalizeVitalsInput(values.vitals);
   const observations: Observation[] = [];
 
@@ -1063,7 +1062,6 @@ export function buildHandoverBundle(
     };
   }
 
-  const opts2 = { ...DEFAULT_OPTS, ...options };
   const patientId = values.patientId;
   const now = resolveNow(opts2.now) ?? nowISO();
 
@@ -1467,6 +1465,6 @@ function stableStringify(value: any): string {
 }
 
 function deterministicHash(value: any): string {
-  return createHash('sha1').update(stableStringify(value)).digest('hex');
+  return hashString(stableStringify(value));
 }
 

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,6 @@
+// Hash no-criptográfico y determinístico (djb2) para IDs locales en RN.
+export function hashString(input: string): string {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) h = (h * 33) ^ input.charCodeAt(i);
+  return (h >>> 0).toString(16); // uint32 → hex
+}


### PR DESCRIPTION
## Summary
- add the Expo-recommended `react-native-web` dependency to enable the web bundler
- introduce a deterministic `hashString` helper usable in React Native environments and update the FHIR mapper to consume it
- drop duplicate `opts2` redeclarations that conflicted with strict builds

## Testing
- pnpm vitest run --reporter=verbose *(fails: existing FHIR mapper panel expectations and Zod validation errors in test suite)*
- pnpm dlx expo start -c --tunnel *(fails: npm registry returned 403 when resolving the Expo CLI package)*

------
https://chatgpt.com/codex/tasks/task_e_68f9f462ac80832197f88c63e7c48139