### PR TITLE
fix: align audio recording presets with expo-av

### DIFF
--- a/src/components/AudioAttach.tsx
+++ b/src/components/AudioAttach.tsx
@@ -6,9 +6,22 @@ import {
   useAudioRecorderState,
   AudioModule,
   setAudioModeAsync,
-  RecordingPresets,
   type RecordingOptions,
 } from 'expo-audio';
+import { Audio } from 'expo-av';
+
+type RecorderOptions = Parameters<typeof useAudioRecorder>[0];
+
+function resolveRecorderOptions(): RecorderOptions {
+  const presets = Audio.RecordingOptionsPresets as Record<string, Audio.RecordingOptions | undefined> | undefined;
+  const preset = presets?.HIGH_QUALITY ?? Object.values(presets ?? {}).find((opt): opt is Audio.RecordingOptions => Boolean(opt));
+  if (!preset) {
+    throw new Error('Expo AV recording presets unavailable');
+  }
+  return preset as unknown as RecorderOptions;
+}
+
+const REC_OPTS = resolveRecorderOptions();
 
 type Props = {
   onRecorded: (uri: string) => void;
@@ -21,9 +34,7 @@ export default function AudioAttach({
   startLabel = 'Grabar audio',
   stopLabel = 'Detener y adjuntar',
 }: Props) {
-  const presets = RecordingPresets as Record<string, RecordingOptions | undefined>;
-  const preset = (presets.HIGH_QUALITY ?? presets.LOW_QUALITY ?? Object.values(presets)[0]) as RecordingOptions;
-  const recorder = useAudioRecorder(preset);
+  const recorder = useAudioRecorder(REC_OPTS as RecordingOptions);
   const state = useAudioRecorderState(recorder);
 
   useEffect(() => {

--- a/src/components/withAppFrame.tsx
+++ b/src/components/withAppFrame.tsx
@@ -1,8 +1,8 @@
 // FILE: src/components/withAppFrame.tsx
-import React from 'react';
+import React, { type JSX as JSXNamespace } from 'react';
 import AppFrame from './AppFrame';
 
-export function withAppFrame<P extends Record<string, unknown>>(
+export function withAppFrame<P extends JSXNamespace.IntrinsicAttributes>(
   Screen: React.ComponentType<P>,
 ) {
   const Wrapped: React.FC<P> = (props) => (

--- a/src/screens/AudioNote.tsx
+++ b/src/screens/AudioNote.tsx
@@ -6,18 +6,29 @@ import {
   useAudioRecorderState,
   AudioModule,
   setAudioModeAsync,
-  RecordingPresets,
   type RecordingOptions,
 } from "expo-audio";
+import { Audio } from "expo-av";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "./PatientList";
+
+type RecorderOptions = Parameters<typeof useAudioRecorder>[0];
+
+function resolveRecorderOptions(): RecorderOptions {
+  const presets = Audio.RecordingOptionsPresets as Record<string, Audio.RecordingOptions | undefined> | undefined;
+  const preset = presets?.HIGH_QUALITY ?? Object.values(presets ?? {}).find((opt): opt is Audio.RecordingOptions => Boolean(opt));
+  if (!preset) {
+    throw new Error("Expo AV recording presets unavailable");
+  }
+  return preset as unknown as RecorderOptions;
+}
+
+const REC_OPTS = resolveRecorderOptions();
 
 type Props = NativeStackScreenProps<RootStackParamList, "AudioNote">;
 
 export default function AudioNote({ navigation }: Props) {
-  const presets = RecordingPresets as Record<string, RecordingOptions | undefined>;
-  const preset = (presets.HIGH_QUALITY ?? presets.LOW_QUALITY ?? Object.values(presets)[0]) as RecordingOptions;
-  const recorder = useAudioRecorder(preset);
+  const recorder = useAudioRecorder(REC_OPTS as RecordingOptions);
   const state = useAudioRecorderState(recorder);
 
   useEffect(() => {

--- a/src/validation/form-hooks.ts
+++ b/src/validation/form-hooks.ts
@@ -2,18 +2,18 @@ import { useForm, type UseFormReturn, type DefaultValues, type FieldValues } fro
 import { z, type ZodTypeAny } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 
-type InferFieldValues<TSchema extends ZodTypeAny> = z.infer<TSchema> & FieldValues;
+type FormValues<TSchema extends ZodTypeAny> = z.output<TSchema> & FieldValues;
 
 type ZodFormOptions<TSchema extends ZodTypeAny> = {
-  defaultValues?: DefaultValues<InferFieldValues<TSchema>>;
+  defaultValues?: DefaultValues<FormValues<TSchema>>;
 };
 
 export function useZodForm<TSchema extends ZodTypeAny>(
   schema: TSchema,
   options?: ZodFormOptions<TSchema>,
-): UseFormReturn<InferFieldValues<TSchema>> {
+): UseFormReturn<FormValues<TSchema>> {
   const resolver = zodResolver(schema as any) as any;
-  return useForm<InferFieldValues<TSchema>>({
+  return useForm<FormValues<TSchema>>({
     resolver,
     defaultValues: options?.defaultValues,
   });


### PR DESCRIPTION
## Summary
- ensure audio recorder hooks use expo-av recording presets with safe fallbacks
- update withAppFrame and zod form helper typing to satisfy strict mode

## Testing
- pnpm -s tsc --noEmit
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68fa822a575c83219095e75fe7ad0c07