### PR TITLE
Add quickstart env setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Backend Django
 
+## Guía rápida
+
+1. Copia `.env.example` a `.env` y ajusta las variables necesarias:
+   ```bash
+   cp .env.example .env
+   # edita EXPO_PUBLIC_API_BASE_URL si tu backend corre en otra IP
+   ```
+2. Inicia el backend de Django:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   pip install -r requirements.txt
+   python manage.py migrate
+   python manage.py runserver 0.0.0.0:8000
+   ```
+3. Levanta el frontend móvil con Expo:
+   ```bash
+   pnpm install
+   pnpm expo start -c
+   ```
+4. Verifica conectividad haciendo `GET` a `http://127.0.0.1:8000/api/ping` (o la IP que definas).
+
 ## Requisitos
 - Python 3.10/3.11/3.12
 


### PR DESCRIPTION
## Summary
- add a quickstart section to README covering env variables, backend, and Expo startup

## Testing
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68fc7b797d688321bf8ee9fc9496d784