### PR TITLE
Restore navigation providers in App

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { NavigationContainer } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { AppThemeProvider } from "@/src/theme";
-import HomeScreen from "@/src/screens/HomeScreen";
-import HandoverScreen from "@/src/screens/HandoverScreen";
 
-const Stack = createNativeStackNavigator();
+import RootNavigator from "@/src/navigation/RootNavigator";
+import { AppThemeProvider } from "@/src/theme";
+import { navigationRef } from "@/src/navigation/navigation";
 
 export default function App() {
   return (
     <SafeAreaProvider>
       <AppThemeProvider>
-        <NavigationContainer>
-          <Stack.Navigator screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="Home" component={HomeScreen} />
-            <Stack.Screen name="Handover" component={HandoverScreen} />
-          </Stack.Navigator>
+        <NavigationContainer ref={navigationRef}>
+          <RootNavigator />
         </NavigationContainer>
       </AppThemeProvider>
     </SafeAreaProvider>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Backend Django
 
+## Guía rápida
+
+1. Copia `.env.example` a `.env` y ajusta las variables necesarias:
+   ```bash
+   cp .env.example .env
+   # edita EXPO_PUBLIC_API_BASE_URL si tu backend corre en otra IP
+   ```
+2. Inicia el backend de Django:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   pip install -r requirements.txt
+   python manage.py migrate
+   python manage.py runserver 0.0.0.0:8000
+   ```
+3. Levanta el frontend móvil con Expo:
+   ```bash
+   pnpm install
+   pnpm expo start -c
+   ```
+4. Verifica conectividad haciendo `GET` a `http://127.0.0.1:8000/api/ping` (o la IP que definas).
+
 ## Requisitos
 - Python 3.10/3.11/3.12
 


### PR DESCRIPTION
## Summary
- restore App.tsx to use RootNavigator with the navigation ref and provider wrappers

## Testing
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68fc7b797d688321bf8ee9fc9496d784