### PR TITLE
feat(form): Patient section + QR integration (Lote 1B)

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import PatientList from '@/src/screens/PatientList';
 import HandoverForm from '@/src/screens/HandoverForm';
+import QRScan from '@/src/screens/QRScan';
 import SyncCenter from '@/src/screens/SyncCenter';
 
 type RootStackParamList = {
@@ -13,6 +14,11 @@ type RootStackParamList = {
         specialty?: string;
         unit?: string;
         shift?: string;
+      }
+    | undefined;
+  QRScan:
+    | {
+        returnTo?: 'HandoverForm';
       }
     | undefined;
   SyncCenter: undefined;
@@ -29,6 +35,7 @@ export default function RootNavigator() {
         component={HandoverForm}
         options={{ title: 'Entrega de turno' }}
       />
+      <Stack.Screen name="QRScan" component={QRScan} options={{ title: 'Escanear' }} />
       <Stack.Screen
         name="SyncCenter"
         component={SyncCenter}

--- a/src/screens/QRScan.tsx
+++ b/src/screens/QRScan.tsx
@@ -1,92 +1,79 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Alert, Pressable } from 'react-native';
-import { CameraView, useCameraPermissions } from 'expo-camera';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, StyleSheet, Text, View } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-type QRStackParamList = {
-  QRScan: undefined;
-  HandoverForm:
-    | {
-        patientId?: string;
-        specialty?: string;
-        unit?: string;
-        shift?: string;
-      }
-    | undefined;
-};
 
-type Props = NativeStackScreenProps<QRStackParamList, 'QRScan'>;
+import type { RootStackParamList } from '@/src/navigation/RootNavigator';
 
-function parsePatientIdFromQR(data: string): string | null {
-  try {
-    const m = data.match(/Patient\/([A-Za-z0-9\-\._]+)/);
-    if (m?.[1]) return m[1];
-    if (data.trim().startsWith('{')) {
-      const obj = JSON.parse(data);
-      if (obj?.resourceType === 'Patient' && typeof obj?.id === 'string') return obj.id;
-    }
-    const p = data.match(/^PAT:([A-Za-z0-9\-\._]+)/i);
-    if (p?.[1]) return p[1];
-    if (/^[A-Za-z0-9\-\._]+$/.test(data.trim())) return data.trim();
-  } catch {}
-  return null;
-}
+type Props = NativeStackScreenProps<RootStackParamList, 'QRScan'>;
 
-export default function QRScan({ navigation }: Props) {
-  const [permission, requestPermission] = useCameraPermissions();
+export default function QRScan({ navigation, route }: Props) {
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
 
   useEffect(() => {
-    if (!permission) requestPermission();
-  }, [permission]);
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
 
-  if (!permission) {
-    return <View style={styles.center}><Text style={styles.text}>Solicitando permiso de cámara…</Text></View>;
-  }
-  if (!permission.granted) {
+  const extractPatientId = useCallback((payload: string): string | null => {
+    try {
+      const obj = JSON.parse(payload);
+      if (obj?.resourceType === 'Patient' && obj.id) return String(obj.id);
+      const ref = obj?.patient?.reference ?? obj?.subject?.reference;
+      const matchedRef = typeof ref === 'string' ? ref.match(/Patient\/([\w\-.]+)/) : null;
+      if (matchedRef) return matchedRef[1];
+    } catch (error) {
+      // Ignored: payload is not JSON or parsing failed.
+    }
+
+    const match = payload.match(/Patient\/([\w\-.]+)/);
+    if (match) return match[1];
+
+    if (/^[A-Za-z0-9.\-]+$/.test(payload)) return payload;
+    return null;
+  }, []);
+
+  const onScan = ({ data }: { data: string }) => {
+    if (scanned) return;
+    setScanned(true);
+    const patientId = extractPatientId(data);
+    if (!patientId) {
+      Alert.alert('QR no válido', 'No se pudo obtener un Patient.id');
+      setScanned(false);
+      return;
+    }
+    const target = route.params?.returnTo ?? 'HandoverForm';
+    navigation.navigate(target, { patientId });
+  };
+
+  if (hasPermission === null) {
     return (
       <View style={styles.center}>
-        <Text style={styles.text}>Sin permiso de cámara.</Text>
-        <Pressable onPress={requestPermission} style={styles.btn}>
-          <Text style={{ color:'#fff', fontWeight:'700' }}>Conceder permiso</Text>
-        </Pressable>
+        <Text>Solicitando permiso…</Text>
       </View>
     );
   }
 
-  const onBarCodeScanned = (result: any) => {
-    if (scanned) return;
-    setScanned(true);
-    const data: string = result?.data ?? '';
-    const pid = parsePatientIdFromQR(data);
-    if (!pid) {
-      Alert.alert('Código no reconocido', 'Asegúrate de que el QR contenga Patient/{id} o un id válido.');
-      setScanned(false);
-      return;
-    }
-    navigation.replace('HandoverForm', { patientId: pid });
-  };
+  if (hasPermission === false) {
+    return (
+      <View style={styles.center}>
+        <Text>Permiso de cámara denegado</Text>
+      </View>
+    );
+  }
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#000' }}>
-      <CameraView
-        style={{ flex: 1 }}
-        facing="back"
-        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
-        onBarcodeScanned={onBarCodeScanned}
-      />
-      <View style={styles.overlay}>
-        <Text style={styles.text}>Enfoca la pulsera QR del paciente</Text>
-        <Pressable onPress={()=>navigation.goBack()} style={styles.btn}>
-          <Text style={{ color:'#fff', fontWeight:'700' }}>Cancelar</Text>
-        </Pressable>
-      </View>
+    <View style={styles.container}>
+      <BarCodeScanner style={styles.scanner} onBarCodeScanned={scanned ? undefined : onScan} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  center: { flex:1, alignItems:'center', justifyContent:'center', backgroundColor:'#0b1220', gap:10 },
-  text: { color:'#eaf2ff', fontSize:16 },
-  overlay: { position:'absolute', bottom:20, left:0, right:0, alignItems:'center', gap:10 },
-  btn: { paddingVertical:10, paddingHorizontal:16, backgroundColor:'#2e4473', borderRadius:12 }
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  scanner: { flex: 1 },
 });


### PR DESCRIPTION
## Summary
- add the QRScan screen using expo-barcode-scanner to derive Patient IDs from QR payloads and return to the form
- extend the root navigator types to include the QRScan route and optional return target parameter
- surface a patient input section in HandoverForm with a Scan button and sync route params back into the form state

## Testing
- pnpm -s tsc --noEmit *(fails: existing type errors in unrelated modules)*
- pnpm -s vitest run --reporter=verbose


------
https://chatgpt.com/codex/tasks/task_e_68fdfc68703c83219a6f1697b2034f2e