### PR TITLE
Lote 1C – Vitals + Zod + FHIR

### DIFF
--- a/src/lib/__tests__/fhir-map.edge.spec.ts
+++ b/src/lib/__tests__/fhir-map.edge.spec.ts
@@ -32,7 +32,7 @@ describe('mapVitalsToObservations — edge cases', () => {
     expect(first?.valueQuantity?.code).toBe('Cel');
   });
 
-  it('valores fuera de rango no rompen y preservan UCUM', () => {
+  it('filtra valores fuera de rango y mantiene UCUM en los válidos', () => {
     const obs = mapVitalsToObservations(
       {
         patientId: 'pat-EDG-2',
@@ -42,18 +42,11 @@ describe('mapVitalsToObservations — edge cases', () => {
     ).sort(byCode);
 
     const codes = obs.map(o => o.code?.coding?.[0]?.code).sort();
-    expect(codes).toEqual([LOINC.HR, LOINC.RR, LOINC.TEMP].sort());
+    expect(codes).toEqual([LOINC.TEMP]);
 
     const get = (c: string) => obs.find(o => o.code?.coding?.[0]?.code === c);
-    const rr = get(LOINC.RR);
-    const hr = get(LOINC.HR);
     const temp = get(LOINC.TEMP);
-    expect(rr).toBeDefined();
-    expect(hr).toBeDefined();
     expect(temp).toBeDefined();
-    expect(rr?.valueQuantity?.system).toBe('http://unitsofmeasure.org');
-    expect(rr?.valueQuantity?.code).toBe('/min');
-    expect(hr?.valueQuantity?.code).toBe('/min');
     expect(temp?.valueQuantity?.code).toBe('Cel');
 
     for (const o of obs) expect(o.effectiveDateTime).toBe(ISO_NOW);

--- a/src/lib/fhir-map.ts
+++ b/src/lib/fhir-map.ts
@@ -357,13 +357,13 @@ const normalizeScale = (allowed: readonly string[]) =>
 
 const VitalsSchema = z
   .object({
-    hr: normalizeNumeric(0, 300),
-    rr: normalizeNumeric(0, 100),
-    temp: normalizeNumeric(25, 45),
-    spo2: normalizeNumeric(0, 100),
-    sbp: normalizeNumeric(0, 400),
-    dbp: normalizeNumeric(0, 300),
-    bgMgDl: normalizeNumeric(0, 1500),
+    hr: normalizeNumeric(30, 220),
+    rr: normalizeNumeric(5, 60),
+    temp: normalizeNumeric(30, 45),
+    spo2: normalizeNumeric(50, 100),
+    sbp: normalizeNumeric(50, 260),
+    dbp: normalizeNumeric(30, 160),
+    bgMgDl: normalizeNumeric(20, 600),
     bgMmolL: normalizeNumeric(0, 100),
     o2: normalizeBoolean(),
     o2Device: normalizeString(),

--- a/src/screens/HandoverForm.tsx
+++ b/src/screens/HandoverForm.tsx
@@ -18,6 +18,11 @@ const styles = StyleSheet.create({
   section: {
     marginBottom: 24
   },
+  h2: {
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 12
+  },
   label: {
     fontSize: 16,
     fontWeight: "600",
@@ -29,6 +34,9 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 12,
     marginBottom: 8
+  },
+  inputError: {
+    borderColor: "#DC2626"
   },
   error: {
     color: "#DC2626",
@@ -69,6 +77,15 @@ export default function HandoverForm({ navigation, route }: Props) {
   }, [form, patientIdFromParams]);
 
   const { control, formState: { errors } } = form;
+
+  const parseNumericInput = (value: string) => {
+    if (value === "") {
+      return undefined;
+    }
+    const normalized = value.replace(",", ".");
+    const parsed = Number(normalized);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  };
 
   const onSubmit = form.handleSubmit(async (values) => {
     const bundle = buildHandoverBundle(values as any);
@@ -183,6 +200,144 @@ export default function HandoverForm({ navigation, route }: Props) {
             title="Escanear"
             onPress={() => navigation.navigate('QRScan', { returnTo: 'HandoverForm' })}
           />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.h2}>Signos vitales</Text>
+
+        <Controller
+          control={control}
+          name="vitals.hr"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="Frecuencia cardíaca (/min)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="vitals.rr"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="Frecuencia respiratoria (/min)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="vitals.temp"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="Temperatura (°C)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="vitals.spo2"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="SpO₂ (%)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="vitals.sbp"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="Tensión sistólica (mmHg)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="vitals.dbp"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="Tensión diastólica (mmHg)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="vitals.bgMgDl"
+          render={({ field, fieldState }) => (
+            <>
+              <TextInput
+                placeholder="Glucemia (mg/dL)"
+                keyboardType="numeric"
+                value={field.value?.toString() ?? ""}
+                onChangeText={(t) => field.onChange(parseNumericInput(t))}
+                style={[styles.input, fieldState.error && styles.inputError]}
+              />
+              {!!fieldState.error && <Text style={styles.error}>{fieldState.error.message}</Text>}
+            </>
+          )}
+        />
+
+        <View
+          testID="vitals-trend"
+          style={{
+            height: 140,
+            borderWidth: 1,
+            borderColor: "#E5E7EB",
+            borderRadius: 8,
+            marginTop: 8,
+            alignItems: "center",
+            justifyContent: "center"
+          }}
+        >
+          <Text>Trend chart placeholder</Text>
         </View>
       </View>
 

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+export const zVitals = z.object({
+  hr: z.number().int().min(30).max(220).optional(),
+  rr: z.number().int().min(5).max(60).optional(),
+  temp: z.number().min(30).max(45).optional(),
+  spo2: z.number().int().min(50).max(100).optional(),
+  sbp: z.number().int().min(50).max(260).optional(),
+  dbp: z.number().int().min(30).max(160).optional(),
+  bgMgDl: z.number().int().min(20).max(600).optional(),
+});
+
 export const zHandover = z.object({
   // Admin
   unitId: z.string().min(1, "Unidad requerida"),
@@ -12,15 +22,7 @@ export const zHandover = z.object({
   patientId: z.string().min(1, "ID paciente requerido"),
 
   // Signos (se completa en 1C)
-  vitals: z.object({
-    hr: z.number().int().min(0).max(250).optional(),
-    rr: z.number().int().min(0).max(80).optional(),
-    temp: z.number().min(25).max(45).optional(),
-    spo2: z.number().min(0).max(100).optional(),
-    sbp: z.number().int().min(40).max(300).optional(),
-    dbp: z.number().int().min(20).max(200).optional(),
-    bgMgDl: z.number().min(10).max(1000).optional()
-  }).default({}),
+  vitals: zVitals.optional(),
 
   // Diagnóstico/Evolución (se mejora en 1D)
   dxMedical: z.string().optional(),


### PR DESCRIPTION
## Summary
- add a dedicated Zod schema for vitals with the updated ranges and wire it into the handover form validation
- render the vital-sign inputs (including glucose mg/dL) in the handover form with numeric controllers plus a trend placeholder container
- update the FHIR mapping normalization and edge-case expectations so observations follow the new vital ranges

## Testing
- pnpm -s tsc --noEmit *(fails: expo-audio types and navigation hook exports missing; existing in main branch)*
- pnpm -s vitest run --reporter=verbose


------
https://chatgpt.com/codex/tasks/task_e_68fe74df9eb483218c2d16aa3150cf00