### PR TITLE
fix: shim expo-audio and refresh sync focus

### DIFF
--- a/src/components/AudioAttach.tsx
+++ b/src/components/AudioAttach.tsx
@@ -22,13 +22,15 @@ if (!FALLBACK_PRESET) {
 const DEFAULT_RECORDING_OPTIONS = FALLBACK_PRESET as RecordingOptions;
 
 type Props = {
-  onRecorded: (uri: string) => void;
+  onRecorded?: (uri: string) => void;
+  onAttach?: (uri: string) => void;
   startLabel?: string;        // "Adjuntar audio de incidencias", etc.
   stopLabel?: string;         // "Detener y adjuntar"
 };
 
 export default function AudioAttach({
   onRecorded,
+  onAttach,
   startLabel = 'Grabar audio',
   stopLabel = 'Detener y adjuntar',
 }: Props) {
@@ -49,7 +51,10 @@ export default function AudioAttach({
   const onPress = async () => {
     if (state.isRecording) {
       await recorder.stop();
-      if (recorder.uri) onRecorded(recorder.uri);
+      if (recorder.uri) {
+        onRecorded?.(recorder.uri);
+        onAttach?.(recorder.uri);
+      }
       return;
     }
     await recorder.prepareToRecordAsync();

--- a/src/lib/expo-audio-shim.ts
+++ b/src/lib/expo-audio-shim.ts
@@ -1,0 +1,10 @@
+import { Audio } from 'expo-av';
+
+export type RecordingOptions = Audio.RecordingOptions;
+
+export const RecordingPresets = {
+  HIGH_QUALITY: Audio.RecordingOptionsPresets.HIGH_QUALITY,
+  LOW_QUALITY: Audio.RecordingOptionsPresets.LOW_QUALITY,
+} as const;
+
+export { Audio };

--- a/src/screens/SyncCenter.tsx
+++ b/src/screens/SyncCenter.tsx
@@ -4,7 +4,7 @@ import {
   View, Text, FlatList, RefreshControl,
   Pressable, StyleSheet, Alert, useColorScheme, Switch
 } from 'react-native';
-import { useFocusEffect } from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 import { readQueue } from '@/src/lib/offlineQueue';
 import { flushQueueNow, type SyncOpts } from '@/src/lib/sync/index';
 
@@ -33,6 +33,7 @@ export default function SyncCenter() {
   const scheme = useColorScheme();
   const C = scheme === 'dark' ? D_COLORS : L_COLORS;
 
+  const isFocused = useIsFocused();
   const [items, setItems] = React.useState<QueueItemMeta[]>([]);
   const [refreshing, setRefreshing] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
@@ -60,6 +61,11 @@ export default function SyncCenter() {
   }, []);
 
   React.useEffect(() => { load(); }, [load]);
+  React.useEffect(() => {
+    if (isFocused) {
+      void load();
+    }
+  }, [isFocused, load]);
 
   const doFlush = React.useCallback(async () => {
     const opts = resolveSyncOpts();
@@ -82,20 +88,27 @@ export default function SyncCenter() {
   }, [load]);
 
   // Inicia/detiene interval cuando la pantalla está enfocada
-  useFocusEffect(
-    React.useCallback(() => {
-      if (autoRetry) {
-        intervalRef.current = setInterval(() => {
-          // flush coalescente en sync/index.ts; es seguro llamarlo seguido
-          void doFlush();
-        }, Math.max(5, Math.min(60, intervalSec)) * 1000);
-      }
-      return () => {
-        if (intervalRef.current) clearInterval(intervalRef.current);
+  React.useEffect(() => {
+    if (!isFocused || !autoRetry) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
         intervalRef.current = null;
-      };
-    }, [autoRetry, intervalSec, doFlush])
-  );
+      }
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      // flush coalescente en sync/index.ts; es seguro llamarlo seguido
+      void doFlush();
+    }, Math.max(5, Math.min(60, intervalSec)) * 1000);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [autoRetry, intervalSec, doFlush, isFocused]);
 
   const decInterval = () => setIntervalSec((s) => Math.max(5, s - 5));
   const incInterval = () => setIntervalSec((s) => Math.min(60, s + 5));

--- a/src/validation/form-hooks.ts
+++ b/src/validation/form-hooks.ts
@@ -1,10 +1,10 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { ZodSchema } from "zod";
+import type { ZodType } from "zod";
 
-export function useZodForm<TSchema extends ZodSchema<any>>(schema: TSchema, defaultValues?: any) {
-  return useForm<unknown & ReturnType<TSchema["parse"]>>({
+export function useZodForm<TSchema extends ZodType<any, any, any>>(schema: TSchema, defaultValues?: any) {
+  return useForm<any>({
     resolver: zodResolver(schema as any),
-    defaultValues
+    defaultValues,
   }) as any;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@/src/*": ["src/*"]
+      "@/src/*": ["src/*"],
+      "expo-audio": ["src/lib/expo-audio-shim"]
     },
     "jsx": "react-jsx",
     "lib": ["es2021", "dom"],

--- a/types/external.d.ts
+++ b/types/external.d.ts
@@ -46,6 +46,7 @@ declare module 'react-native' {
   export const ActivityIndicator: any;
   export const RefreshControl: any;
   export const Alert: any;
+  export const Modal: any;
   export const Switch: any;
   export const StyleSheet: any;
   export const SafeAreaView: any;
@@ -75,6 +76,7 @@ declare module '@react-navigation/native' {
   export const NavigationContainer: React.FC<{ ref?: any; children?: React.ReactNode }>;
   export function useNavigation<T = any>(): T;
   export function useFocusEffect(effect: () => void): void;
+  export function useIsFocused(): boolean;
 }
 
 declare module '@react-navigation/native-stack' {
@@ -163,12 +165,34 @@ declare module 'expo-file-system' {
   export function readAsStringAsync(uri: string, options?: { encoding?: string }): Promise<string>;
 }
 
+declare module 'expo-av' {
+  export namespace Audio {
+    type RecordingOptions = any;
+    const RecordingOptionsPresets: Record<string, RecordingOptions> & {
+      HIGH_QUALITY?: RecordingOptions;
+      LOW_QUALITY?: RecordingOptions;
+    };
+  }
+  export const Audio: {
+    RecordingOptions: Audio.RecordingOptions;
+    RecordingOptionsPresets: typeof Audio.RecordingOptionsPresets;
+  };
+}
+
 declare module 'expo-audio' {
   export type RecordingOptions = any;
-  export const AudioModule: { requestRecordingPermissionsAsync(): Promise<{ granted: boolean }> };
+  export const RecordingPresets: Record<string, RecordingOptions> & {
+    HIGH_QUALITY?: RecordingOptions;
+    LOW_QUALITY?: RecordingOptions;
+  };
+  export const AudioModule: {
+    AudioRecorder: new (...args: any[]) => any;
+    requestRecordingPermissionsAsync(): Promise<{ granted: boolean }>;
+  };
   export function useAudioRecorder(options: RecordingOptions): any;
   export function useAudioRecorderState(recorder: any): any;
   export function setAudioModeAsync(config: any): Promise<void>;
+  export const Audio: any;
 }
 
 declare module 'expo-camera' {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -132,6 +132,7 @@ declare module 'react-native' {
   export const TextInput: ComponentType<any>;
   export const ActivityIndicator: ComponentType<any>;
   export const RefreshControl: ComponentType<any>;
+  export const Modal: ComponentType<any>;
   export const StatusBar: ComponentType<any>;
   export const Button: ComponentType<any>;
   export const Switch: ComponentType<any>;
@@ -178,6 +179,7 @@ declare module '@react-navigation/native' {
   export const NavigationContainer: ComponentType<{ children?: any; ref?: any }>;
   export function useNavigation<T = any>(): T;
   export function useRoute<T = any>(): T;
+  export function useIsFocused(): boolean;
   export type RouteProp<P, K extends keyof P> = { key: string; name: K; params: P[K] };
 }
 
@@ -216,6 +218,7 @@ declare module '@hookform/resolvers/zod' {
 declare module 'zod' {
   export const z: any;
   export type ZodTypeAny = any;
+  export type ZodType<TOutput = any, TDef = any, TInput = any> = any;
   export namespace z {
     type infer<T> = any;
     type output<T> = any;
@@ -246,11 +249,31 @@ declare module '@react-native-community/*' {
   export = Module;
 }
 
+declare module 'expo-av' {
+  export namespace Audio {
+    type RecordingOptions = any;
+    const RecordingOptionsPresets: Record<string, RecordingOptions> & {
+      HIGH_QUALITY?: RecordingOptions;
+      LOW_QUALITY?: RecordingOptions;
+    };
+  }
+  export const Audio: {
+    RecordingOptions: Audio.RecordingOptions;
+    RecordingOptionsPresets: typeof Audio.RecordingOptionsPresets;
+  };
+}
+
 declare module 'expo-audio' {
+  export type RecordingOptions = any;
+  export const RecordingPresets: Record<string, RecordingOptions> & {
+    HIGH_QUALITY?: RecordingOptions;
+    LOW_QUALITY?: RecordingOptions;
+  };
   export const AudioModule: any;
   export const setAudioModeAsync: (...args: any[]) => Promise<void>;
-  export function useAudioRecorder(options: any): any;
+  export function useAudioRecorder(options: RecordingOptions): any;
   export function useAudioRecorderState(recorder: any): any;
+  export const Audio: any;
 }
 
 declare module 'expo-camera' {

--- a/types/zod/index.d.ts
+++ b/types/zod/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'zod' {
   export type ZodTypeAny = any;
+  export type ZodType<TOutput = any, TDef = any, TInput = any> = any;
   export type RefinementCtx = { addIssue(issue: { code: string; message?: string }): void };
   export type infer<T> = any;
   export type output<T> = any;


### PR DESCRIPTION
## Summary
- add a shim that re-exports expo-audio recording presets/options from expo-av and wire it through the tsconfig path alias
- update SyncCenter to refresh via useIsFocused and make AudioAttach/form hooks compatible with the shim
- extend our custom type stubs to cover the new audio bindings and zod type usage

## Testing
- pnpm -s tsc --noEmit
- pnpm -s vitest run --reporter=verbose
- npx expo start -c *(fails: TypeError: fetch failed while Expo CLI tried to fetch native module versions)*

------
https://chatgpt.com/codex/tasks/task_e_68ff4a1c8d308321b79a1ef0b1603b33