### PR TITLE
fix(audio+qr): full expo-audio shim over expo-av + migrate QR to expo-camera

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "crypto-js": "^4.2.0",
     "expo": "54.0.20",
     "expo-audio": "~1.0.13",
-    "expo-barcode-scanner": "^13.0.1",
     "expo-camera": "~17.0.8",
     "expo-file-system": "~19.0.17",
     "expo-network": "~8.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       expo-audio:
         specifier: ~1.0.13
         version: 1.0.13(expo@54.0.20)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-barcode-scanner:
-        specifier: ^13.0.1
-        version: 13.0.1(expo@54.0.20)
       expo-camera:
         specifier: ~17.0.8
         version: 17.0.8(expo@54.0.20)(react-native-web@0.21.2(react-dom@19.2.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -2579,11 +2576,6 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
-
-  expo-barcode-scanner@13.0.1:
-    resolution: {integrity: sha512-xBGLT1An2gpAMIQRTLU3oHydKohX8r8F9/ait1Fk9Vgd0GraFZbP4IiT7nHMlaw4H6E7Muucf7vXpGV6u7d4HQ==}
-    peerDependencies:
-      expo: '*'
 
   expo-camera@17.0.8:
     resolution: {integrity: sha512-BIGvS+3myaYqMtk2VXWgdcOMrewH+55BttmaYqq9tv9+o5w+RAbH9wlJSt0gdaswikiyzoWT7mOnLDleYClXmw==}
@@ -8174,11 +8166,6 @@ snapshots:
       expo: 54.0.20(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
-
-  expo-barcode-scanner@13.0.1(expo@54.0.20):
-    dependencies:
-      expo: 54.0.20(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-image-loader: 4.7.0(expo@54.0.20)
 
   expo-camera@17.0.8(expo@54.0.20)(react-native-web@0.21.2(react-dom@19.2.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/lib/expo-audio-shim.ts
+++ b/src/lib/expo-audio-shim.ts
@@ -1,36 +1,148 @@
-import type { RecordingOptions } from 'expo-av/build/Audio/Recording.types';
+import { useEffect, useRef, useState } from 'react';
+import { Audio } from 'expo-av';
 
-type RecordingPresetsMap = Record<string, RecordingOptions>;
+type ExpoAudioModule = typeof Audio extends infer T ? (T extends object ? T : Record<string, unknown>) : Record<string, unknown>;
 
-type RecordingConstantsModule = {
-  RecordingOptionsPresets: RecordingPresetsMap;
+type RecordingOptionsShape = Record<string, unknown>;
+
+type RecordingClass = ExpoAudioModule extends { Recording: new () => infer R } ? R : {
+  prepareToRecordAsync: (options: RecordingOptionsShape) => Promise<void>;
+  startAsync: () => Promise<void>;
+  stopAndUnloadAsync: () => Promise<void>;
+  getURI: () => string | null;
 };
 
-type ExpoAudioConstantsModule = {
-  RecordingPresets: RecordingPresetsMap;
+export type RecordingOptions = RecordingClass extends { prepareToRecordAsync: (options: infer O) => Promise<void> } ? O : RecordingOptionsShape;
+
+const ExpoAudio = Audio as unknown as {
+  RecordingOptionsPresets?: Record<string, RecordingOptions>;
+  setAudioModeAsync?: (...params: unknown[]) => Promise<unknown>;
+  requestPermissionsAsync?: (...params: unknown[]) => Promise<unknown>;
+  getPermissionsAsync?: (...params: unknown[]) => Promise<unknown>;
+  Recording?: new () => RecordingClass;
 };
 
-function loadRecordingPresets(): RecordingPresetsMap {
-  try {
-    const { RecordingOptionsPresets } = require('expo-av/build/Audio/RecordingConstants') as RecordingConstantsModule;
-    if (RecordingOptionsPresets) {
-      return RecordingOptionsPresets;
-    }
-  } catch {
-    // noop - fall back to expo-audio implementation below
-  }
+export const RecordingPresets = ExpoAudio.RecordingOptionsPresets ?? ({} as Record<string, RecordingOptions>);
 
-  try {
-    const { RecordingPresets } = require('expo-audio/build/RecordingConstants') as ExpoAudioConstantsModule;
-    if (RecordingPresets) {
-      return RecordingPresets;
-    }
-  } catch {
-    // Final fallback: return empty map so the app does not crash in environments without the module.
-  }
+type SetAudioModeSignature = typeof ExpoAudio.setAudioModeAsync extends (...params: infer P) => infer R
+  ? { params: P; return: R }
+  : { params: [mode: unknown]; return: Promise<unknown> };
 
-  return {} as RecordingPresetsMap;
+export async function setAudioModeAsync(
+  ...params: SetAudioModeSignature['params']
+): Promise<SetAudioModeSignature['return']> {
+  if (!ExpoAudio.setAudioModeAsync) {
+    throw new Error('Audio.setAudioModeAsync is not available');
+  }
+  return ExpoAudio.setAudioModeAsync(
+    ...(params as Parameters<NonNullable<typeof ExpoAudio.setAudioModeAsync>>)
+  ) as Promise<SetAudioModeSignature['return']>;
 }
 
-export const RecordingPresets = loadRecordingPresets();
-export type { RecordingOptions };
+type PermissionSignature = typeof ExpoAudio.requestPermissionsAsync extends (...params: infer P) => infer R
+  ? { params: P; return: R }
+  : { params: []; return: Promise<unknown> };
+
+type GetPermissionSignature = typeof ExpoAudio.getPermissionsAsync extends (...params: infer P) => infer R
+  ? { params: P; return: R }
+  : { params: []; return: Promise<unknown> };
+
+export const AudioModule = {
+  requestRecordingPermissionsAsync: (
+    ...params: PermissionSignature['params']
+  ): Promise<PermissionSignature['return']> => {
+    if (!ExpoAudio.requestPermissionsAsync) {
+      throw new Error('Audio.requestPermissionsAsync is not available');
+    }
+    return ExpoAudio.requestPermissionsAsync(
+      ...(params as Parameters<NonNullable<typeof ExpoAudio.requestPermissionsAsync>>)
+    ) as Promise<PermissionSignature['return']>;
+  },
+  getRecordingPermissionsAsync: (
+    ...params: GetPermissionSignature['params']
+  ): Promise<GetPermissionSignature['return']> => {
+    if (!ExpoAudio.getPermissionsAsync) {
+      throw new Error('Audio.getPermissionsAsync is not available');
+    }
+    return ExpoAudio.getPermissionsAsync(
+      ...(params as Parameters<NonNullable<typeof ExpoAudio.getPermissionsAsync>>)
+    ) as Promise<GetPermissionSignature['return']>;
+  },
+};
+
+type StopResult = { uri?: string };
+type RecorderControls = {
+  startAsync: (options?: RecordingOptions) => Promise<void>;
+  stopAndUnloadAsync: () => Promise<StopResult>;
+  getURI: () => string | undefined;
+  isRecording: boolean;
+};
+
+export function useAudioRecorder(): RecorderControls {
+  const RecordingCtor = ExpoAudio.Recording;
+  if (!RecordingCtor) {
+    throw new Error('Audio.Recording is not available');
+  }
+
+  const recordingRef = useRef<RecordingClass | null>(null);
+  const [uri, setUri] = useState<string | undefined>(undefined);
+  const [isRecording, setIsRecording] = useState<boolean>(false);
+
+  const startAsync = async (options?: RecordingOptions) => {
+    const preset =
+      options ??
+      ExpoAudio.RecordingOptionsPresets?.HIGH_QUALITY ??
+      ({} as RecordingOptions);
+    const recording = new RecordingCtor();
+    await recording.prepareToRecordAsync(preset);
+    await recording.startAsync();
+    recordingRef.current = recording;
+    setIsRecording(true);
+  };
+
+  const stopAndUnloadAsync = async (): Promise<StopResult> => {
+    const recording = recordingRef.current;
+    if (!recording) {
+      return { uri };
+    }
+
+    try {
+      await recording.stopAndUnloadAsync();
+    } catch {
+      // ignore errors from stopping an already stopped recording
+    }
+
+    const newUri = recording.getURI() ?? undefined;
+    setUri(newUri);
+    setIsRecording(false);
+    return { uri: newUri };
+  };
+
+  const getURI = () => uri;
+
+  return { startAsync, stopAndUnloadAsync, getURI, isRecording };
+}
+
+type RecorderLike = {
+  isRecording?: boolean;
+  getURI?: () => string | undefined;
+};
+
+type RecorderState = 'idle' | 'recording' | 'stopped';
+
+export function useAudioRecorderState(recorder?: RecorderLike): RecorderState {
+  const [state, setState] = useState<RecorderState>('idle');
+  const currentUri = recorder?.getURI?.();
+
+  useEffect(() => {
+    if (recorder?.isRecording) {
+      setState('recording');
+    } else if (currentUri) {
+      setState('stopped');
+    } else {
+      setState('idle');
+    }
+  }, [recorder?.isRecording, currentUri]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- replace the expo-audio shim with an implementation backed by expo-av that exposes recording presets, permissions, audio mode, and recorder hooks
- keep the project aliases pointing expo-audio to the shim to ensure runtime resolution
- remove the legacy expo-barcode-scanner dependency now that QR scanning uses expo-camera

## Testing
- pnpm -s tsc --noEmit
- pnpm -s vitest run --reporter=verbose

## Notes
- Instalar nativos: npx expo install expo-av expo-camera
- Arranque: npx expo start --clear --lan (o --tunnel)


------
https://chatgpt.com/codex/tasks/task_e_68ff7675347883219e41ea4c39088080