### PR TITLE
chore(expo): purge expo-barcode-scanner from Expo config

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,25 +6,20 @@
     "orientation": "portrait",
     "userInterfaceStyle": "light",
     "icon": "./assets/icon.png",
-
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-
     "plugins": [
       "expo-sqlite",
       "expo-secure-store",
       "expo-notifications",
       [
         "expo-audio",
-        {
-          "microphonePermission": "Permitir a Handover usar el micrófono."
-        }
+        { "microphonePermission": "Permitir a Handover usar el micrófono." }
       ]
     ],
-
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
@@ -38,7 +33,6 @@
       ],
       "useNextNotificationsApi": true
     },
-
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
@@ -47,7 +41,6 @@
         "NSUserTrackingUsageDescription": "Se usa para mejorar la experiencia del turno"
       }
     },
-
     "extra": {
       "eas": {
         "projectId": "00000000-0000-0000-0000-000000000000"

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -8,4 +8,4 @@ pnpm add expo-notifications expo-audio expo-camera expo-file-system expo-secure-
 Write-Host "Asegurando tipos y utilidades" -ForegroundColor Cyan
 pnpm add -D @types/node
 
-Write-Host "Listo. Recuerda ajustar FHIR_BASE_URL y STT_ENDPOINT en app.json -> extra."
+Write-Host "Listo. Recuerda ajustar FHIR_BASE_URL y STT_ENDPOINT en app.json -> expo.extra." 


### PR DESCRIPTION
## Summary
- restore the Expo configuration to `app.json` while keeping only the required plugins and permissions (no `expo-barcode-scanner`)
- update the setup script instructions to point at the JSON config's `expo.extra` section

## Testing
- pnpm -s tsc --noEmit
- pnpm -s vitest run --reporter=verbose
- npx expo config --type public --json | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const j=JSON.parse(s);const p=(j.plugins||[]).some(x=>JSON.stringify(x).includes('expo-barcode-scanner'));if(p){console.error('FOUND scanner plugin');process.exit(1)}console.log('OK: no scanner plugin')})"


------
https://chatgpt.com/codex/tasks/task_e_68ff84200c3c8321b539d8f772bb9e19