### PR TITLE
feat(sync): secure offline queue + idempotent bundles

### DIFF
--- a/src/lib/__tests__/sync.offline.spec.ts
+++ b/src/lib/__tests__/sync.offline.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import {
+  clearQueue,
+  enqueueTxFromValues,
+  flushQueue,
+  readQueueState,
+} from '@/src/lib/sync';
+
+describe('sync.ts offline queue retries', () => {
+  beforeEach(async () => {
+    (globalThis as any).__secureStoreMem = {};
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    await clearQueue();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('reintenta con backoff y trata 409 como entregado sin duplicar', async () => {
+    await enqueueTxFromValues({ patientId: 'pat-001' } as any);
+
+    const onSent = vi.fn();
+    const sender = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        throw new Error('offline');
+      })
+      .mockImplementationOnce(async () => ({ ok: false, status: 409 }));
+
+    await flushQueue({ sender, onSent });
+
+    let state = await readQueueState();
+    expect(state.size).toBe(1);
+    expect(state.items[0].attempts).toBe(1);
+
+    const readyTs = new Date(state.items[0].nextAttemptAt).getTime() + 1;
+    vi.setSystemTime(new Date(readyTs));
+
+    await flushQueue({ sender, onSent });
+
+    state = await readQueueState();
+    expect(state.size).toBe(0);
+    expect(onSent).toHaveBeenCalledTimes(1);
+    expect(onSent).toHaveBeenCalledWith({ patientId: 'pat-001' });
+    expect(sender).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/__tests__/sync.queue.spec.ts
+++ b/src/lib/__tests__/sync.queue.spec.ts
@@ -36,7 +36,7 @@ describe('cola offline + flush(sender)', () => {
     expect(clearDraft).toHaveBeenCalledWith('pat-001');
   });
 
-  it('duplicado 412 → skip y clearDraft llamado', async () => {
+  it('conflicto 409 → tratado como entregado y clearDraft llamado', async () => {
     const bundle = buildTransactionBundleForQueue(input, { now: NOW });
     await enqueueBundle(bundle);
 
@@ -44,7 +44,7 @@ describe('cola offline + flush(sender)', () => {
 
     const sender = async () => ({
       ok: false,
-      status: 412,
+      status: 409,
       body: {},
     });
 


### PR DESCRIPTION
## Summary
- consolidate the offline queue per patient with SecureStore persistence, exponential backoff with jitter, and delivery handling for 409/412 conflicts
- ensure enqueue operations store a single transaction bundle per patient with idempotent identifiers and reset retry metadata
- add Vitest coverage for offline retry flows and update existing queue expectations for 409 responses

## Testing
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_69010675046c8321a828e7c1ad2ce1c0