### PR TITLE
fix: improve QR re-scan handling in handover form

### DIFF
--- a/src/screens/HandoverForm.tsx
+++ b/src/screens/HandoverForm.tsx
@@ -60,30 +60,32 @@ export default function HandoverForm({ navigation, route }: Props) {
     evolution: "",
   });
 
-  // Sincroniza params -> form SOLO si no está dirty (evita pisar cambios del usuario)
+  // Sincroniza params -> campos desde QR sin ensuciar el formulario
   useEffect(() => {
-    const isDirty = Boolean((form.formState as { isDirty?: boolean })?.isDirty);
-
     if (patientIdParam) {
-      const currentPid = form.getValues("patientId");
-      if (!isDirty && currentPid !== patientIdParam) {
+      const fieldState = form.getFieldState?.("patientId");
+      const current = form.getValues("patientId");
+      if (!fieldState?.isDirty && current !== patientIdParam) {
         form.setValue("patientId", patientIdParam, {
           shouldValidate: true,
-          shouldDirty: true,
+          shouldDirty: false,
         });
       }
     }
+  }, [patientIdParam, form]);
 
+  useEffect(() => {
     if (unitIdParam) {
-      const currentUnit = form.getValues("unitId");
-      if (!isDirty && currentUnit !== unitIdParam) {
+      const fieldState = form.getFieldState?.("unitId");
+      const current = form.getValues("unitId");
+      if (!fieldState?.isDirty && current !== unitIdParam) {
         form.setValue("unitId", unitIdParam, {
           shouldValidate: true,
-          shouldDirty: true,
+          shouldDirty: false,
         });
       }
     }
-  }, [form, patientIdParam, unitIdParam]);
+  }, [unitIdParam, form]);
 
   const { control, formState } = form;
   const errors = (formState as any)?.errors ?? {};

--- a/tests/handover-form.qr-rescan.test.ts
+++ b/tests/handover-form.qr-rescan.test.ts
@@ -1,0 +1,167 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import HandoverForm from '@/src/screens/HandoverForm';
+
+vi.mock('react-hook-form', async () => {
+  const actual = await vi.importActual<typeof import('react-hook-form')>('react-hook-form');
+  return {
+    ...actual,
+    Controller: () => null,
+  };
+});
+
+const mockUseZodForm = vi.fn();
+vi.mock('@/src/validation/form-hooks', () => ({
+  useZodForm: (...args: unknown[]) => mockUseZodForm(...args),
+}));
+
+describe('HandoverForm QR re-scan', () => {
+  const navigation: any = {
+    navigate: vi.fn(),
+    getState: vi.fn(() => ({ routeNames: [] })),
+  };
+
+  beforeEach(() => {
+    mockUseZodForm.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('actualiza patientId y unitId en re-scans cuando no están dirty', async () => {
+    const values: Record<string, string> = { patientId: '', unitId: '' };
+    const dirtiness: Record<string, boolean> = { patientId: false, unitId: false };
+    const setValueSpy = vi.fn((field: string, value: string, _options: unknown) => {
+      values[field] = value;
+    });
+
+    mockUseZodForm.mockReturnValue({
+      control: {},
+      formState: {},
+      handleSubmit: (fn: any) => fn,
+      getValues: (field: string) => values[field],
+      getFieldState: (field: string) => ({ isDirty: dirtiness[field] }),
+      setValue: (field: string, value: string, options: unknown) => {
+        setValueSpy(field, value, options);
+      },
+    });
+
+    let renderer: ReturnType<typeof create> | undefined;
+    await act(async () => {
+      renderer = create(
+        <HandoverForm
+          navigation={navigation}
+          route={{ key: 'test', name: 'HandoverForm', params: { patientId: 'A', unitId: 'U1' } } as any}
+        />
+      );
+    });
+
+    expect(setValueSpy).toHaveBeenCalledWith(
+      'patientId',
+      'A',
+      expect.objectContaining({ shouldDirty: false, shouldValidate: true })
+    );
+    expect(setValueSpy).toHaveBeenCalledWith(
+      'unitId',
+      'U1',
+      expect.objectContaining({ shouldDirty: false, shouldValidate: true })
+    );
+
+    setValueSpy.mockClear();
+
+    await act(async () => {
+      renderer!.update(
+        <HandoverForm
+          navigation={navigation}
+          route={{ key: 'test', name: 'HandoverForm', params: { patientId: 'B', unitId: 'U2' } } as any}
+        />
+      );
+    });
+
+    expect(setValueSpy).toHaveBeenCalledWith(
+      'patientId',
+      'B',
+      expect.objectContaining({ shouldDirty: false })
+    );
+    expect(setValueSpy).toHaveBeenCalledWith(
+      'unitId',
+      'U2',
+      expect.objectContaining({ shouldDirty: false })
+    );
+
+    setValueSpy.mockClear();
+
+    await act(async () => {
+      renderer!.update(
+        <HandoverForm
+          navigation={navigation}
+          route={{ key: 'test', name: 'HandoverForm', params: { patientId: 'C', unitId: 'U3' } } as any}
+        />
+      );
+    });
+
+    expect(setValueSpy).toHaveBeenCalledWith('patientId', 'C', expect.any(Object));
+    expect(setValueSpy).toHaveBeenCalledWith('unitId', 'U3', expect.any(Object));
+  });
+
+  it('no sobreescribe campos dirty en re-scan', async () => {
+    const values: Record<string, string> = { patientId: 'A', unitId: 'U1' };
+    const dirtiness: Record<string, boolean> = { patientId: true, unitId: false };
+    const setValueSpy = vi.fn();
+
+    mockUseZodForm.mockReturnValue({
+      control: {},
+      formState: {},
+      handleSubmit: (fn: any) => fn,
+      getValues: (field: string) => values[field],
+      getFieldState: (field: string) => ({ isDirty: dirtiness[field] }),
+      setValue: (field: string, value: string, options: unknown) => {
+        values[field] = value;
+        setValueSpy(field, value, options);
+      },
+    });
+
+    let renderer: ReturnType<typeof create> | undefined;
+    await act(async () => {
+      renderer = create(
+        <HandoverForm
+          navigation={navigation}
+          route={{
+            key: 'test',
+            name: 'HandoverForm',
+            params: { patientId: 'A', unitId: 'U1' },
+          } as any}
+        />
+      );
+    });
+
+    setValueSpy.mockClear();
+
+    await act(async () => {
+      renderer!.update(
+        <HandoverForm
+          navigation={navigation}
+          route={{
+            key: 'test',
+            name: 'HandoverForm',
+            params: { patientId: 'B', unitId: 'U2' },
+          } as any}
+        />
+      );
+    });
+
+    expect(setValueSpy).not.toHaveBeenCalledWith(
+      'patientId',
+      'B',
+      expect.objectContaining({ shouldDirty: false })
+    );
+    expect(setValueSpy).toHaveBeenCalledWith(
+      'unitId',
+      'U2',
+      expect.objectContaining({ shouldDirty: false })
+    );
+  });
+});

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -204,6 +204,7 @@ declare module 'react-hook-form' {
     setValue: (...args: any[]) => any;
     watch: (...args: any[]) => any;
     getValues: (...args: any[]) => any;
+    getFieldState?: (...args: any[]) => any;
     reset: (...args: any[]) => any;
     formState: { errors: Record<string, unknown>; isSubmitting: boolean };
   };


### PR DESCRIPTION
## Summary
- sync QR-derived `patientId` and `unitId` individually without marking the form dirty
- skip overwriting user-edited fields during subsequent scans
- add regression tests that mock the form API to cover A→B→C rescans and dirty-field protection
- extend the local react-hook-form type shim with the `getFieldState` helper

## Testing
- `pnpm -w tsc --noEmit` *(fails: pre-existing type issues in RootNavigator, QRScan, and ACL modules)*
- `pnpm vitest run --reporter=verbose`
- `pnpm -w expo start -c` *(fails: Expo CLI cannot fetch native module versions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902183c744883219a12fddd0d24175d