### PR TITLE
fix: export allowedUnitsFrom helper and add RBAC tests

### DIFF
--- a/src/security/acl.ts
+++ b/src/security/acl.ts
@@ -1,26 +1,8 @@
-// src/security/acl.ts
 import { allowedUnitsFrom, type Session } from '@/src/security/auth';
-import { toSlug } from '@/src/utils/taxonomy';
 
-const ALLOW_ALL = process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS === '1';
-
-/**
- * Devuelve true si el usuario puede acceder a la unidad.
- * - Si EXPO_PUBLIC_ALLOW_ALL_UNITS=1 -> siempre permite (bypass para DEV).
- * - Si no, usa tu RBAC real vía allowedUnitsFrom(session).
- * Puedes pasar una sesión si ya la tienes; si no, intenta con una cache global opcional.
- */
-export function hasUnitAccess(unitId?: string, session?: Partial<Session> | null): boolean {
-  if (!unitId) return true;
-  if (ALLOW_ALL) return true;
-
-  try {
-    const s = session ?? (globalThis as any).__NURSEOS_SESSION_CACHE ?? null;
-    const allowed = allowedUnitsFrom((s ?? null) as Session | null);
-    return allowed.has(toSlug(unitId));
-  } catch {
-    // En duda, niega acceso (comportamiento conservador). Si quieres no bloquear en dev, retorna true.
-    return false;
-  }
+export function hasUnitAccess(unitId?: string, session?: Session): boolean {
+  if (!unitId) return false;
+  const allowed = allowedUnitsFrom(session ?? null);
+  return allowed.has('*') || allowed.has(unitId);
 }
 

--- a/tests/security/acl.spec.ts
+++ b/tests/security/acl.spec.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { hasUnitAccess } from '@/src/security/acl';
+import type { Session } from '@/src/security/auth';
+
+const ORIGINAL_FLAG = process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS;
+
+afterEach(() => {
+  if (ORIGINAL_FLAG === undefined) {
+    delete process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS;
+  } else {
+    process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS = ORIGINAL_FLAG;
+  }
+});
+
+describe('hasUnitAccess', () => {
+  it('allows access when env flag enables wildcard', () => {
+    process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS = '1';
+    expect(hasUnitAccess('AnyUnit')).toBe(true);
+  });
+
+  it('allows access when unit is included in session', () => {
+    delete process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS;
+    const session = { units: ['UCI'] } as Session;
+    expect(hasUnitAccess('UCI', session)).toBe(true);
+  });
+
+  it('denies access when unit not allowed', () => {
+    delete process.env.EXPO_PUBLIC_ALLOW_ALL_UNITS;
+    const session = { units: ['UCI'] } as Session;
+    expect(hasUnitAccess('XYZ', session)).toBe(false);
+  });
+});

--- a/tests/security/auth.spec.ts
+++ b/tests/security/auth.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { allowedUnitsFrom, type Session } from '@/src/security/auth';
+
+describe('allowedUnitsFrom', () => {
+  it('returns empty set when session is null', () => {
+    const allowed = allowedUnitsFrom(null, {});
+    expect(allowed.size).toBe(0);
+  });
+
+  it('returns wildcard when env flag is enabled', () => {
+    const allowed = allowedUnitsFrom(null, { EXPO_PUBLIC_ALLOW_ALL_UNITS: '1' });
+    expect(allowed.has('*')).toBe(true);
+    expect(allowed.size).toBe(1);
+  });
+
+  it('returns units from session', () => {
+    const session = { units: ['UCI', 'Pab1'] } as Session;
+    const allowed = allowedUnitsFrom(session, {});
+    expect(allowed.has('UCI')).toBe(true);
+    expect(allowed.has('XYZ')).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       '**/__tests__/**/sync.*.(spec|test).ts',
       'tests/patientlist-*.test.ts',
       'tests/qr-scan.test.ts',
+      'tests/security/**/*.spec.ts',
     ],
     exclude: [
       'src/screens/**',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -22,9 +22,15 @@ vi.mock('expo-secure-store', () => ({
 }));
 
 /** Mock global de auth para evitar dependencias RN/Expo en tests */
-vi.mock('@/src/security/auth', () => ({
-  getSession: async () => ({ token: '' }),
-}));
+vi.mock('@/src/security/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/src/security/auth')>(
+    '@/src/security/auth'
+  );
+  return {
+    ...actual,
+    getSession: async () => ({ token: '' }),
+  };
+});
 
 /** (Opcional) Polyfill de fetch si el entorno no lo trae */
 if (!(globalThis as any).fetch) {


### PR DESCRIPTION
## Summary
- return wildcard access from allowedUnitsFrom when the EXPO_PUBLIC_ALLOW_ALL_UNITS flag is enabled and treat it in downstream helpers
- simplify the RBAC unit access check to consume the exported helper and respect wildcard access
- cover RBAC helpers with Vitest and update the shared test setup/configuration to include the new suite

## Testing
- pnpm -w tsc --noEmit
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_69022196b7c08321934bb4b993ad9b70