### PR TITLE
fix: keep metro custom resolver and add expo-audio shim stub

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,14 +1,18 @@
-const path = require("path");
-const { getDefaultConfig } = require("expo/metro-config");
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
 
-const config = getDefaultConfig(__dirname);
+const projectRoot = __dirname;
+const config = getDefaultConfig(projectRoot);
+
+// Soporte monorepo / pnpm
 config.resolver.unstable_enableSymlinks = true;
 config.resolver.unstable_enablePackageExports = true;
 
+// Shim opcional para expo-audio (si lo usamos)
+const expoAudioShim = path.resolve(projectRoot, 'src/shims/expo-audio');
 config.resolver.extraNodeModules = {
-  ...(config.resolver.extraNodeModules ?? {}),
-  "expo-audio": path.resolve(__dirname, "src/lib/expo-audio-shim"),
+  ...(config.resolver.extraNodeModules || {}),
+  'expo-audio': expoAudioShim,
 };
 
 module.exports = config;
-module.exports = getDefaultConfig(__dirname);

--- a/src/shims/expo-audio.ts
+++ b/src/shims/expo-audio.ts
@@ -1,0 +1,3 @@
+export default {};
+export const Audio = {};
+export const Recording = {};


### PR DESCRIPTION
## Summary
- remove the duplicate module export in metro.config.js so the customized resolver is preserved
- keep symlink support and point the expo-audio alias to a shim under src/shims
- add a minimal expo-audio shim stub to satisfy the alias during bundling

## Testing
- pnpm -w tsc --noEmit
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_6902259915b48321babeefc4ec86e284