### PR TITLE
feat: clinical alerts, SBAR summary, and prioritization

### DIFF
--- a/src/lib/alerts.spec.ts
+++ b/src/lib/alerts.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { ALERT_CODES } from "./codes";
+import { alertsFromData, ClinicalInput } from "./alerts";
+
+const FIXED_NOW = "2024-02-15T12:00:00.000Z";
+const nowProvider = () => FIXED_NOW;
+
+describe("alertsFromData", () => {
+  it("incluye alerta NEWS2 con severidad según banda", () => {
+    const input: ClinicalInput = {
+      vitals: { rr: 30, spo2: 90, temp: 39, sbp: 85, hr: 130, o2: true, avpu: "V" },
+    };
+
+    const alerts = alertsFromData(input, { now: nowProvider });
+    const news2 = alerts.find(a => a.code === ALERT_CODES.news2);
+
+    expect(news2).toBeTruthy();
+    expect(news2?.severity).toBe("critical");
+    expect(news2?.data).toMatchObject({ total: expect.any(Number), band: "CRÍTICA" });
+  });
+
+  it("genera alerta por catéter con más de 7 días", () => {
+    const input: ClinicalInput = {
+      vitals: { rr: 18 },
+      lines: [
+        { id: "cvc", kind: "catheter", insertedAt: "2024-02-01T10:00:00.000Z", label: "CVC" },
+        { id: "piv", kind: "catheter", insertedAt: "2024-02-10T10:00:00.000Z", label: "PIV" },
+      ],
+    };
+
+    const alerts = alertsFromData(input, { now: nowProvider });
+    const catheterAlert = alerts.find(a => a.code === ALERT_CODES.catheterOverdue);
+
+    expect(catheterAlert).toBeTruthy();
+    expect(catheterAlert?.severity).toBe("high");
+    expect(catheterAlert?.message).toContain("Catéter CVC");
+    expect(alerts.filter(a => a.code === ALERT_CODES.catheterOverdue).length).toBe(1);
+  });
+
+  it("detecta conflicto alergia-medicación", () => {
+    const input: ClinicalInput = {
+      vitals: { rr: 16 },
+      allergies: [
+        { id: "alg1", substance: "Penicilina" },
+      ],
+      medications: [
+        { id: "med1", name: "Piperacilina", ingredients: ["penicilina"] },
+      ],
+    };
+
+    const alerts = alertsFromData(input, { now: nowProvider });
+    const conflict = alerts.find(a => a.code === ALERT_CODES.allergyConflict);
+
+    expect(conflict).toBeTruthy();
+    expect(conflict?.severity).toBe("critical");
+    expect(conflict?.message).toContain("Piperacilina");
+  });
+
+  it("alerta curación o drenaje vencidos", () => {
+    const input: ClinicalInput = {
+      vitals: { rr: 18 },
+      woundCare: [
+        { id: "d1", kind: "dressing", dueAt: "2024-02-10T10:00:00.000Z", description: "Curación abdominal" },
+        { id: "dr1", kind: "drain", dueAt: "2024-02-20T10:00:00.000Z" },
+      ],
+    };
+
+    const alerts = alertsFromData(input, { now: nowProvider });
+    const dressing = alerts.find(a => a.code === ALERT_CODES.dressingOverdue);
+    const drain = alerts.find(a => a.code === ALERT_CODES.drainOverdue);
+
+    expect(dressing).toBeTruthy();
+    expect(dressing?.severity).toBe("moderate");
+    expect(drain).toBeUndefined();
+  });
+
+  it("escala oxigenoterapia prolongada", () => {
+    const input: ClinicalInput = {
+      vitals: { rr: 20 },
+      oxygenTherapy: {
+        active: true,
+        start: "2024-02-10T10:00:00.000Z",
+        fio2: 0.65,
+      },
+    };
+
+    const alerts = alertsFromData(input, { now: nowProvider });
+    const oxygen = alerts.find(a => a.code === ALERT_CODES.oxygenProlonged);
+
+    expect(oxygen).toBeTruthy();
+    expect(oxygen?.severity).toBe("critical");
+    expect(oxygen?.message).toContain("Oxigenoterapia prolongada");
+  });
+});

--- a/src/lib/alerts.ts
+++ b/src/lib/alerts.ts
@@ -1,31 +1,271 @@
-// src/lib/alerts.ts
-import { VitalsInput } from "./priority";
+import { ALERT_CODES } from "./codes";
+import { computeNEWS2, NEWS2Breakdown, NEWS2Input } from "./news2";
 
-export type Alert = { kind: "warning" | "danger"; message: string };
+export type AlertSeverity = "low" | "moderate" | "high" | "critical";
 
-export function alertsFrom(values: {
-  vitals?: VitalsInput;
-  checklist?: { idWristband?: boolean; linesChecked?: boolean; bedrails?: boolean; devicesOk?: boolean };
-  census?: { total?: number; occupied?: number };
-}) : Alert[] {
-  const out: Alert[] = [];
-  const v = values.vitals ?? {};
+export type Alert = {
+  id: string;
+  code: string;
+  severity: AlertSeverity;
+  message: string;
+  data?: unknown;
+};
 
-  // saturación muy baja con O2 -> alerta grave
-  if (typeof v.spo2 === "number" && v.spo2 < 92 && v.o2) {
-    out.push({ kind: "danger", message: "SpO₂ < 92% aún con O₂ suplementario" });
-  }
+export type ClinicalAllergy = {
+  id: string;
+  substance: string;
+  code?: string;
+};
 
-  // censo inconsistente
-  if ((values.census?.total ?? 0) < (values.census?.occupied ?? 0)) {
-    out.push({ kind: "warning", message: "Censo inconsistente: ocupadas > total" });
-  }
+export type ClinicalMedication = {
+  id: string;
+  name: string;
+  code?: string;
+  ingredients?: string[];
+  critical?: boolean;
+  startedAt?: string;
+};
 
-  // checklist cama
-  const chk = values.checklist ?? {};
-  for (const [k, ok] of Object.entries(chk)) {
-    if (ok === false) out.push({ kind: "warning", message: `Checklist: revisar ${k}` });
-  }
+export type ClinicalLine = {
+  id: string;
+  kind: "catheter" | "other";
+  insertedAt?: string;
+  label?: string;
+};
 
-  return out;
+export type ClinicalWoundCare = {
+  id: string;
+  kind: "dressing" | "drain";
+  dueAt: string;
+  description?: string;
+};
+
+export type ClinicalOxygenTherapy = {
+  active: boolean;
+  start: string;
+  fio2?: number;
+  flowLpm?: number;
+  device?: string;
+};
+
+export type ClinicalGlucoseReading = {
+  value: number;
+  unit: "mg/dL" | "mmol/L";
+  takenAt: string;
+};
+
+export type ClinicalInput = {
+  patient?: {
+    id: string;
+    name: string;
+    diagnosis?: string;
+    location?: string;
+  };
+  vitals?: NEWS2Input & { recordedAt?: string };
+  lines?: ClinicalLine[];
+  allergies?: ClinicalAllergy[];
+  medications?: ClinicalMedication[];
+  woundCare?: ClinicalWoundCare[];
+  oxygenTherapy?: ClinicalOxygenTherapy | null;
+  glucoseReadings?: ClinicalGlucoseReading[];
+  medsCritical?: string[];
+  lastUpdated?: string;
+};
+
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+const MILLISECONDS_IN_HOUR = 60 * 60 * 1000;
+const CATHETER_THRESHOLD_DAYS = 7;
+const OXYGEN_PROLONGED_HOURS = 24;
+const OXYGEN_ESCALATE_HOURS = 96;
+const HIGH_FIO2_THRESHOLD = 0.6;
+
+const NEWS2_BAND_SEVERITY: Record<NEWS2Breakdown["band"], AlertSeverity> = {
+  BAJA: "low",
+  MEDIA: "moderate",
+  ALTA: "high",
+  CRÍTICA: "critical",
+};
+
+function toDate(value?: string) {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
 }
+
+function daysBetween(start: Date, end: Date) {
+  return (end.getTime() - start.getTime()) / MILLISECONDS_IN_DAY;
+}
+
+function hoursBetween(start: Date, end: Date) {
+  return (end.getTime() - start.getTime()) / MILLISECONDS_IN_HOUR;
+}
+
+function normalise(value?: string) {
+  return value?.trim().toLowerCase();
+}
+
+function hasAllergyConflict(
+  medication: ClinicalMedication,
+  allergies: ClinicalAllergy[] | undefined,
+): ClinicalAllergy | undefined {
+  if (!allergies?.length) return undefined;
+  const identifiers = new Set(
+    [medication.code, ...(medication.ingredients ?? [])]
+      .map(normalise)
+      .filter((v): v is string => Boolean(v)),
+  );
+  if (!identifiers.size) return undefined;
+  return allergies.find(allergy => {
+    const allergyIds = [allergy.code, allergy.substance]
+      .map(normalise)
+      .filter((v): v is string => Boolean(v));
+    return allergyIds.some(id => identifiers.has(id));
+  });
+}
+
+function buildNews2Alert(breakdown: NEWS2Breakdown): Alert {
+  const severity = NEWS2_BAND_SEVERITY[breakdown.band];
+  const message = `NEWS2 ${breakdown.total} (${breakdown.band})`;
+  return {
+    id: `${ALERT_CODES.news2}:${breakdown.total}`,
+    code: ALERT_CODES.news2,
+    severity,
+    message,
+    data: breakdown,
+  };
+}
+
+function catheterAlerts(
+  lines: ClinicalLine[] | undefined,
+  now: Date,
+): Alert[] {
+  if (!lines?.length) return [];
+  const alerts: Alert[] = [];
+  for (const line of lines) {
+    if (line.kind !== "catheter") continue;
+    const inserted = toDate(line.insertedAt);
+    if (!inserted) continue;
+    const ageDays = daysBetween(inserted, now);
+    if (ageDays <= CATHETER_THRESHOLD_DAYS) continue;
+    const rounded = Math.floor(ageDays);
+    const label = line.label ?? line.id;
+    alerts.push({
+      id: `${ALERT_CODES.catheterOverdue}:${line.id}`,
+      code: ALERT_CODES.catheterOverdue,
+      severity: "high",
+      message: `Catéter ${label} con ${rounded} días desde inserción`,
+      data: { line, ageDays },
+    });
+  }
+  return alerts;
+}
+
+function woundCareAlerts(
+  entries: ClinicalWoundCare[] | undefined,
+  now: Date,
+): Alert[] {
+  if (!entries?.length) return [];
+  const alerts: Alert[] = [];
+  for (const entry of entries) {
+    const due = toDate(entry.dueAt);
+    if (!due) continue;
+    if (due.getTime() > now.getTime()) continue;
+    const description = entry.description ?? entry.id;
+    const base = entry.kind === "drain" ? ALERT_CODES.drainOverdue : ALERT_CODES.dressingOverdue;
+    const kindLabel = entry.kind === "drain" ? "drenaje" : "curación";
+    alerts.push({
+      id: `${base}:${entry.id}`,
+      code: base,
+      severity: "moderate",
+      message: `${kindLabel} ${description} vencido`,
+      data: entry,
+    });
+  }
+  return alerts;
+}
+
+function oxygenAlert(
+  therapy: ClinicalOxygenTherapy | null | undefined,
+  now: Date,
+): Alert[] {
+  if (!therapy?.active) return [];
+  const started = toDate(therapy.start);
+  if (!started) return [];
+  const durationHours = hoursBetween(started, now);
+  if (durationHours < OXYGEN_PROLONGED_HOURS) return [];
+  const severity: AlertSeverity =
+    durationHours >= OXYGEN_ESCALATE_HOURS || (therapy.fio2 ?? 0) >= HIGH_FIO2_THRESHOLD
+      ? "critical"
+      : "high";
+  const rounded = Math.round(durationHours);
+  const fio2Part = therapy.fio2 != null ? `, FiO₂ ${therapy.fio2.toFixed(2)}` : "";
+  return [
+    {
+      id: `${ALERT_CODES.oxygenProlonged}:${therapy.start}`,
+      code: ALERT_CODES.oxygenProlonged,
+      severity,
+      message: `Oxigenoterapia prolongada (${rounded}h${fio2Part})`,
+      data: { therapy, durationHours },
+    },
+  ];
+}
+
+export function alertsFromData(
+  input: ClinicalInput,
+  opts?: { now?: () => string },
+): Alert[] {
+  const nowIso = opts?.now?.() ?? new Date().toISOString();
+  const now = toDate(nowIso) ?? new Date();
+
+  const alerts: Alert[] = [];
+
+  if (input.vitals) {
+    const breakdown = computeNEWS2({
+      rr: input.vitals.rr,
+      spo2: input.vitals.spo2,
+      temp: input.vitals.temp,
+      sbp: input.vitals.sbp,
+      hr: input.vitals.hr,
+      o2: input.vitals.o2,
+      avpu: input.vitals.avpu,
+      scale2: input.vitals.scale2,
+    });
+    alerts.push(buildNews2Alert(breakdown));
+  }
+
+  alerts.push(
+    ...catheterAlerts(input.lines, now),
+    ...woundCareAlerts(input.woundCare, now),
+    ...oxygenAlert(input.oxygenTherapy, now),
+  );
+
+  if (input.medications?.length && input.allergies?.length) {
+    for (const med of input.medications) {
+      const conflictingAllergy = hasAllergyConflict(med, input.allergies);
+      if (!conflictingAllergy) continue;
+      alerts.push({
+        id: `${ALERT_CODES.allergyConflict}:${med.id}:${conflictingAllergy.id}`,
+        code: ALERT_CODES.allergyConflict,
+        severity: "critical",
+        message: `Alergia a ${conflictingAllergy.substance} en medicación ${med.name}`,
+        data: { medication: med, allergy: conflictingAllergy },
+      });
+    }
+  }
+
+  alerts.sort((a, b) => {
+    const severityRank: Record<AlertSeverity, number> = {
+      critical: 3,
+      high: 2,
+      moderate: 1,
+      low: 0,
+    };
+    const diff = severityRank[b.severity] - severityRank[a.severity];
+    if (diff !== 0) return diff;
+    return a.id.localeCompare(b.id);
+  });
+
+  return alerts;
+}
+
+export const alertsFrom = alertsFromData;

--- a/src/lib/codes.ts
+++ b/src/lib/codes.ts
@@ -20,3 +20,12 @@ export const CATEGORY = {
     code: 'vital-signs',
   },
 } as const;
+
+export const ALERT_CODES = {
+  news2: 'alert.news2',
+  catheterOverdue: 'alert.catheter.overdue',
+  allergyConflict: 'alert.allergy.medication',
+  dressingOverdue: 'alert.dressing.overdue',
+  drainOverdue: 'alert.drain.overdue',
+  oxygenProlonged: 'alert.oxygen.prolonged',
+} as const;

--- a/src/lib/priority.spec.ts
+++ b/src/lib/priority.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { ALERT_CODES } from "./codes";
+import { Alert } from "./alerts";
+import {
+  computePriorityList,
+  news2Score,
+  priorityFromNews2,
+  sortByPriority,
+  ClinicalPatientSummary,
+} from "./priority";
+
+describe("priority utilities", () => {
+  it("news2Score reutiliza computeNEWS2", () => {
+    const score = news2Score({ rr: 28, spo2: 90, temp: 39.2, sbp: 88, hr: 135, o2: true, acvpu: "V" });
+    expect(score).toBeGreaterThan(18);
+  });
+
+  it("priorityFromNews2 mantiene umbrales", () => {
+    expect(priorityFromNews2(4)).toBe("low");
+    expect(priorityFromNews2(5)).toBe("medium");
+    expect(priorityFromNews2(7)).toBe("high");
+  });
+
+  it("sortByPriority se mantiene estable", () => {
+    const data = [
+      { id: "a", news2: 5 },
+      { id: "b", news2: 7 },
+      { id: "c", news2: 5 },
+    ];
+
+    const sorted = sortByPriority(data);
+    expect(sorted.map(x => x.id)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("computePriorityList", () => {
+  const baseAlerts = (code: string, severity: Alert["severity"], message: string): Alert => ({
+    id: `${code}:1`,
+    code,
+    severity,
+    message,
+  });
+
+  it("ordena por NEWS2, alertas y factores clínicos", () => {
+    const patients: ClinicalPatientSummary[] = [
+      {
+        id: "p1",
+        name: "Paciente Uno",
+        news2: 8,
+        alerts: [baseAlerts(ALERT_CODES.news2, "critical", "NEWS2 8 (CRÍTICA)")],
+        glucoseFlag: "hypo",
+        oxygen: { active: true, prolonged: true, start: "2024-02-10T10:00:00.000Z" },
+        lastUpdated: "2024-02-15T11:00:00.000Z",
+        recentChangeAt: "2024-02-15T10:30:00.000Z",
+      },
+      {
+        id: "p2",
+        name: "Paciente Dos",
+        news2: 6,
+        alerts: [baseAlerts(ALERT_CODES.oxygenProlonged, "high", "Oxigenoterapia prolongada")],
+        glucoseFlag: null,
+        oxygen: { active: true, prolonged: false, start: "2024-02-14T08:00:00.000Z" },
+        lastUpdated: "2024-02-15T10:50:00.000Z",
+      },
+      {
+        id: "p3",
+        name: "Paciente Tres",
+        news2: 6,
+        alerts: [baseAlerts(ALERT_CODES.allergyConflict, "critical", "Alergia y medicación")],
+        glucoseFlag: "hyper",
+        oxygen: { active: false },
+        lastUpdated: "2024-02-15T09:00:00.000Z",
+      },
+    ];
+
+    const prioritized = computePriorityList(patients);
+
+    expect(prioritized.map(p => p.id)).toEqual(["p1", "p3", "p2"]);
+    const p1 = prioritized[0];
+    expect(p1.reason).toContain("NEWS2 8 (CRÍTICA)");
+    expect(p1.reason).toContain("Hipoglucemia reciente");
+    expect(p1.reason).toContain("Oxígeno prolongado");
+    expect(p1.priority).toBeGreaterThan(prioritized[1].priority);
+  });
+
+  it("utiliza lastUpdated como desempate final", () => {
+    const patients: ClinicalPatientSummary[] = [
+      {
+        id: "p4",
+        name: "Paciente Cuatro",
+        news2: 3,
+        alerts: [],
+        glucoseFlag: null,
+        oxygen: { active: false },
+        lastUpdated: "2024-02-15T08:00:00.000Z",
+      },
+      {
+        id: "p5",
+        name: "Paciente Cinco",
+        news2: 3,
+        alerts: [],
+        glucoseFlag: null,
+        oxygen: { active: false },
+        lastUpdated: "2024-02-15T10:00:00.000Z",
+      },
+    ];
+
+    const prioritized = computePriorityList(patients);
+    expect(prioritized.map(p => p.id)).toEqual(["p5", "p4"]);
+  });
+});

--- a/src/lib/priority.ts
+++ b/src/lib/priority.ts
@@ -1,103 +1,63 @@
-// src/lib/priority.ts
+import { Alert, AlertSeverity } from "./alerts";
+import { computeNEWS2, ACVPU as NEWS2ACVPU } from "./news2";
 
 /** Escala de consciencia (NEWS2). */
-export type ACVPU = "A" | "C" | "V" | "P" | "U";
+export type ACVPU = NEWS2ACVPU;
 
-/** Vitals de entrada para calcular NEWS2 (escala 1 para SpO₂). */
+/** Vitals de entrada para calcular NEWS2 (escala 1 por defecto). */
 export type VitalsInput = {
-  rr?: number;   // frecuencia respiratoria /min
-  hr?: number;   // frecuencia cardiaca /min
-  sbp?: number;  // TAS mmHg
-  dbp?: number;  // TAD mmHg (no puntúa pero se propaga)
-  temp?: number; // °C
-  spo2?: number; // %
-  o2?: boolean;  // en O₂ suplementario
-  o2Device?: string; // dispositivo O₂
-  o2FlowLpm?: number; // flujo L/min
-  fio2?: number; // fracción inspirada
-  acvpu?: ACVPU; // nivel de consciencia
+  rr?: number;
+  hr?: number;
+  sbp?: number;
+  dbp?: number;
+  temp?: number;
+  spo2?: number;
+  o2?: boolean;
+  o2Device?: string;
+  o2FlowLpm?: number;
+  fio2?: number;
+  acvpu?: ACVPU;
+  scale2?: boolean;
 };
 
-/** Calcula el puntaje NEWS2 (escala 1 para SpO₂). */
+/** Calcula el puntaje NEWS2 reutilizando computeNEWS2. */
 export function news2Score(v: VitalsInput): number {
-  const rr  = v.rr   ?? NaN;
-  const hr  = v.hr   ?? NaN;
-  const sbp = v.sbp  ?? NaN;
-  const t   = v.temp ?? NaN;
-  const sp  = v.spo2 ?? NaN;
-
-  let s = 0;
-
-  // FR (respiratory rate)
-  if (!Number.isNaN(rr)) {
-    if (rr <= 8) s += 3;
-    else if (rr <= 11) s += 1;
-    else if (rr <= 20) s += 0;
-    else if (rr <= 24) s += 2;
-    else s += 3;
-  }
-
-  // SpO2 (escala 1)
-  if (!Number.isNaN(sp)) {
-    if (sp <= 91) s += 3;
-    else if (sp <= 93) s += 2;
-    else if (sp <= 95) s += 1;
-    else s += 0;
-  }
-  if (v.o2) s += 2;
-
-  // Temperatura
-  if (!Number.isNaN(t)) {
-    if (t <= 35.0) s += 3;
-    else if (t <= 36.0) s += 1;
-    else if (t <= 38.0) s += 0;
-    else if (t <= 39.0) s += 1;
-    else s += 2;
-  }
-
-  // TAS (systolic BP)
-  if (!Number.isNaN(sbp)) {
-    if (sbp <= 90) s += 3;
-    else if (sbp <= 100) s += 2;
-    else if (sbp <= 110) s += 1;
-    else if (sbp <= 219) s += 0;
-    else s += 3;
-  }
-
-  // FC (heart rate)
-  if (!Number.isNaN(hr)) {
-    if (hr <= 40) s += 3;
-    else if (hr <= 50) s += 1;
-    else if (hr <= 90) s += 0;
-    else if (hr <= 110) s += 1;
-    else if (hr <= 130) s += 2;
-    else s += 3;
-  }
-
-  // ACVPU (no-Alert suma 3)
-  if (v.acvpu && v.acvpu !== "A") s += 3;
-
-  return s;
+  const breakdown = computeNEWS2({
+    rr: v.rr,
+    spo2: v.spo2,
+    temp: v.temp,
+    sbp: v.sbp,
+    hr: v.hr,
+    o2: v.o2,
+    avpu: v.acvpu,
+    scale2: v.scale2,
+  });
+  return breakdown.total;
 }
 
 /** Mapea NEWS2 a etiqueta/coloress (ES) para UI existente. */
-export function news2PriorityTag(score: number): { level: "Crítico"|"Alto"|"Moderado"|"Bajo"; color: string } {
-  if (score >= 7) return { level: "Crítico",  color: "#b91c1c" };  // rojo
-  if (score >= 5) return { level: "Alto",     color: "#ea580c" };  // naranja
-  if (score >= 3) return { level: "Moderado", color: "#ca8a04" };  // ámbar
-  return               { level: "Bajo",      color: "#15803d" };   // verde
+export function news2PriorityTag(score: number): {
+  level: "Crítico" | "Alto" | "Moderado" | "Bajo";
+  color: string;
+} {
+  if (score >= 7) return { level: "Crítico", color: "#b91c1c" };
+  if (score >= 5) return { level: "Alto", color: "#ea580c" };
+  if (score >= 3) return { level: "Moderado", color: "#ca8a04" };
+  return { level: "Bajo", color: "#15803d" };
 }
 
 /** Compatibilidad con código previo (no romper). */
-export function priorityLabel(score: number): "Crítico"|"Alto"|"Moderado"|"Bajo" {
+export function priorityLabel(score: number): "Crítico" | "Alto" | "Moderado" | "Bajo" {
   return news2PriorityTag(score).level;
 }
+
 export function priorityColor(score: number): string {
   return news2PriorityTag(score).color;
 }
 
 /** 🔹 Lo que pediste: nivel simple en inglés para listados (low/medium/high). */
 export type PrioritySimple = "low" | "medium" | "high";
+
 export function priorityFromNews2(score: number): PrioritySimple {
   if (score >= 7) return "high";
   if (score >= 5) return "medium";
@@ -115,6 +75,115 @@ export function sortByPriority<T extends { id: string; news2: number }>(patients
     .map(x => x.p);
 }
 
+export type ClinicalPatientSummary = {
+  id: string;
+  name: string;
+  news2: number;
+  band?: "BAJA" | "MEDIA" | "ALTA" | "CRÍTICA";
+  alerts?: Alert[];
+  glucoseFlag?: "hypo" | "hyper" | null;
+  oxygen?: {
+    active: boolean;
+    start?: string;
+    prolonged?: boolean;
+  } | null;
+  lastUpdated?: string;
+  recentChangeAt?: string;
+};
+
+export function computePriorityList(
+  patients: ClinicalPatientSummary[],
+): Array<ClinicalPatientSummary & { priority: number; reason: string[] }> {
+  const severityRank: Record<AlertSeverity, number> = {
+    critical: 3,
+    high: 2,
+    moderate: 1,
+    low: 0,
+  };
+  const glucoseRank: Record<NonNullable<ClinicalPatientSummary["glucoseFlag"]>, number> = {
+    hypo: 2,
+    hyper: 1,
+  };
+  const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+
+  const enriched = patients.map(patient => {
+    const band = patient.band ?? (patient.news2 >= 7 ? "CRÍTICA" : patient.news2 >= 5 ? "ALTA" : patient.news2 >= 1 ? "MEDIA" : "BAJA");
+    const maxAlert = (patient.alerts ?? []).reduce<{ alert: Alert | null; rank: number }>(
+      (acc, alert) => {
+        const rank = severityRank[alert.severity];
+        if (rank > acc.rank) return { alert, rank };
+        return acc;
+      },
+      { alert: null, rank: -1 },
+    );
+    const glucoseRankValue = patient.glucoseFlag ? glucoseRank[patient.glucoseFlag] : 0;
+    const oxygenRank = patient.oxygen?.active ? (patient.oxygen.prolonged ? 2 : 1) : 0;
+    const oxygenReason = patient.oxygen?.active
+      ? patient.oxygen.prolonged
+        ? `Oxígeno prolongado desde ${patient.oxygen.start ?? "fecha desconocida"}`
+        : `Oxígeno activo${patient.oxygen.start ? ` desde ${patient.oxygen.start}` : ""}`
+      : undefined;
+    const recentChange = patient.recentChangeAt
+      ? (() => {
+          const ts = new Date(patient.recentChangeAt);
+          if (Number.isNaN(ts.getTime())) return false;
+          const now = new Date();
+          return now.getTime() - ts.getTime() <= SIX_HOURS_MS;
+        })()
+      : false;
+    const lastUpdatedMs = patient.lastUpdated ? new Date(patient.lastUpdated).getTime() : 0;
+
+    const priority =
+      patient.news2 * 10 +
+      maxAlert.rank * 5 +
+      glucoseRankValue * 2 +
+      oxygenRank * 3 +
+      (recentChange ? 1 : 0);
+
+    const reason: string[] = [`NEWS2 ${patient.news2} (${band})`];
+    if (maxAlert.alert) {
+      reason.push(`Alerta ${maxAlert.alert.severity}: ${maxAlert.alert.message}`);
+    }
+    if (patient.glucoseFlag === "hypo") {
+      reason.push("Hipoglucemia reciente");
+    } else if (patient.glucoseFlag === "hyper") {
+      reason.push("Hiperglucemia reciente");
+    }
+    if (oxygenReason) {
+      reason.push(oxygenReason);
+    }
+    if (recentChange) {
+      reason.push("Cambio clínico <6h");
+    }
+
+    return {
+      ...patient,
+      band,
+      priority,
+      reason,
+      _meta: {
+        maxAlertSeverity: maxAlert.rank,
+        glucoseRank: glucoseRankValue,
+        oxygenRank,
+        recentChange,
+        lastUpdatedMs,
+      },
+    };
+  });
+
+  enriched.sort((a, b) => {
+    if (b.news2 !== a.news2) return b.news2 - a.news2;
+    if (b._meta.maxAlertSeverity !== a._meta.maxAlertSeverity) return b._meta.maxAlertSeverity - a._meta.maxAlertSeverity;
+    if (b._meta.glucoseRank !== a._meta.glucoseRank) return b._meta.glucoseRank - a._meta.glucoseRank;
+    if (b._meta.oxygenRank !== a._meta.oxygenRank) return b._meta.oxygenRank - a._meta.oxygenRank;
+    if (Number(b._meta.recentChange) !== Number(a._meta.recentChange)) return Number(b._meta.recentChange) - Number(a._meta.recentChange);
+    if (b._meta.lastUpdatedMs !== a._meta.lastUpdatedMs) return b._meta.lastUpdatedMs - a._meta.lastUpdatedMs;
+    return a.id.localeCompare(b.id);
+  });
+
+  return enriched.map(({ _meta: _meta, ...rest }) => rest);
+}
+
 /** Export por defecto (sigue funcionando con import default). */
 const Priority = {
   news2Score,
@@ -123,5 +192,7 @@ const Priority = {
   priorityColor,
   priorityFromNews2,
   sortByPriority,
+  computePriorityList,
 };
+
 export default Priority;

--- a/src/lib/summary.spec.ts
+++ b/src/lib/summary.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { ALERT_CODES } from "./codes";
+import { ClinicalInput } from "./alerts";
+import { generateTurnSummary } from "./summary";
+
+const FIXED_NOW = "2024-02-15T12:00:00.000Z";
+
+describe("generateTurnSummary", () => {
+  it("produce resumen SBAR con alertas y oxígeno", () => {
+    const data: ClinicalInput = {
+      patient: { id: "p1", name: "Juana Pérez", diagnosis: "Neumonía adquirida en la comunidad" },
+      vitals: { rr: 30, spo2: 90, temp: 38.5, sbp: 95, hr: 120, o2: true, avpu: "C" },
+      lines: [{ id: "cvc", kind: "catheter", insertedAt: "2024-02-05T10:00:00.000Z", label: "CVC" }],
+      oxygenTherapy: { active: true, start: "2024-02-10T10:00:00.000Z", fio2: 0.4, flowLpm: 4 },
+      glucoseReadings: [
+        { value: 55, unit: "mg/dL", takenAt: "2024-02-15T09:00:00.000Z" },
+      ],
+      medications: [
+        { id: "med1", name: "Noradrenalina", critical: true },
+      ],
+    };
+
+    const summary = generateTurnSummary(data, { now: () => FIXED_NOW });
+
+    expect(summary.highlights.news2).toBeGreaterThan(0);
+    expect(summary.highlights.band).toBe("CRÍTICA");
+    expect(summary.highlights.alertsTop.length).toBeGreaterThan(0);
+    expect(summary.highlights.oxygen).toContain("Oxígeno");
+    expect(summary.highlights.glucoseFlag).toBe("hypo");
+    expect(summary.highlights.medsCritical).toContain("Noradrenalina");
+
+    const lines = summary.text.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(lines[0]).toContain("S: Juana Pérez");
+    expect(lines[1]).toContain("B: Neumonía");
+    expect(lines[2]).toContain("Alertas principales");
+    expect(summary.text).toContain("Hipoglucemia");
+  });
+
+  it("maneja casos sin alertas ni diagnóstico", () => {
+    const data: ClinicalInput = {
+      patient: { id: "p2", name: "Carlos Díaz" },
+      vitals: { rr: 16, spo2: 97, temp: 36.5, sbp: 120, hr: 85, o2: false, avpu: "A" },
+    };
+
+    const summary = generateTurnSummary(data, { now: () => FIXED_NOW });
+
+    expect(summary.highlights.alertsTop[0].code).toBe(ALERT_CODES.news2);
+    expect(summary.highlights.glucoseFlag).toBeNull();
+    expect(summary.highlights.medsCritical).toEqual([]);
+    expect(summary.text).toContain("B: Sin diagnóstico documentado.");
+    expect(summary.text).toContain("Sin alertas activas");
+  });
+});

--- a/src/lib/summary.ts
+++ b/src/lib/summary.ts
@@ -1,20 +1,128 @@
-type SummaryInputs = {
-  patientName: string;
-  diagnosis?: string;
-  news2Score?: number;
-  keyFindings?: string[];
-  pending?: string[];
-  sttText?: string;
+import { alertsFromData, Alert, ClinicalInput } from "./alerts";
+import { computeNEWS2 } from "./news2";
+
+const SEVERITY_ORDER: Record<Alert["severity"], number> = {
+  critical: 3,
+  high: 2,
+  moderate: 1,
+  low: 0,
 };
 
-export function buildHandoverSummary(i: SummaryInputs) {
-  const lines: string[] = [];
-  lines.push(`Paciente: ${i.patientName}`);
-  if (i.diagnosis) lines.push(`Dx: ${i.diagnosis}`);
-  if (typeof i.news2Score === "number") lines.push(`NEWS2: ${i.news2Score}`);
-  if (i.keyFindings?.length) lines.push(`Hallazgos: ${i.keyFindings.join("; ")}`);
-  if (i.pending?.length) lines.push(`Pendientes: ${i.pending.join("; ")}`);
-  if (i.sttText) lines.push(`(Dictado) ${i.sttText}`);
+function getNow(opts?: { now?: () => string }) {
+  const iso = opts?.now?.() ?? new Date().toISOString();
+  const date = new Date(iso);
+  return { iso: date.toISOString(), date };
+}
 
-  return lines.join("\n");
+function formatOxygen(oxygen: ClinicalInput["oxygenTherapy"], now: Date) {
+  if (!oxygen?.active) return undefined;
+  const started = oxygen.start ? new Date(oxygen.start) : undefined;
+  if (!started || Number.isNaN(started.getTime())) return undefined;
+  const hours = Math.round((now.getTime() - started.getTime()) / (60 * 60 * 1000));
+  const fio2 = oxygen.fio2 != null ? `FiO₂ ${oxygen.fio2.toFixed(2)}` : undefined;
+  const flow = oxygen.flowLpm != null ? `${oxygen.flowLpm} L/min` : undefined;
+  const descriptor = [fio2, flow].filter(Boolean).join(", ");
+  const details = descriptor ? `${descriptor} desde ${started.toISOString()} (${hours}h)` : `desde ${started.toISOString()} (${hours}h)`;
+  return `Oxígeno ${details}`;
+}
+
+function normaliseGlucose(value: number, unit: "mg/dL" | "mmol/L") {
+  if (unit === "mg/dL") return value;
+  return Math.round(value * 18); // conversión aproximada
+}
+
+function extractGlucoseFlag(data: ClinicalInput) {
+  const readings = data.glucoseReadings;
+  if (!readings?.length) return { flag: null, detail: undefined as string | undefined };
+  const sorted = [...readings].sort((a, b) => b.takenAt.localeCompare(a.takenAt));
+  const latest = sorted[0];
+  const value = normaliseGlucose(latest.value, latest.unit);
+  if (value < 70) {
+    return { flag: "hypo" as const, detail: `Hipoglucemia ${value} mg/dL a ${latest.takenAt}` };
+  }
+  if (value >= 180) {
+    return { flag: "hyper" as const, detail: `Hiperglucemia ${value} mg/dL a ${latest.takenAt}` };
+  }
+  return { flag: null, detail: undefined };
+}
+
+function collectCriticalMeds(data: ClinicalInput): string[] | undefined {
+  const meds = data.medications?.filter(med => med.critical).map(med => med.name);
+  const manual = data.medsCritical ?? [];
+  const merged = [...(meds ?? []), ...manual];
+  return merged.length ? Array.from(new Set(merged)) : undefined;
+}
+
+function pickTopAlerts(alerts: Alert[]): Alert[] {
+  const sorted = [...alerts].sort((a, b) => {
+    const diff = SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity];
+    if (diff !== 0) return diff;
+    return a.id.localeCompare(b.id);
+  });
+  return sorted.slice(0, 3);
+}
+
+export function generateTurnSummary(
+  data: ClinicalInput,
+  opts?: { now?: () => string },
+) {
+  const { iso: nowIso, date: now } = getNow(opts);
+  const alerts = alertsFromData(data, { now: () => nowIso });
+  const vitals = data.vitals
+    ? computeNEWS2({
+        rr: data.vitals.rr,
+        spo2: data.vitals.spo2,
+        temp: data.vitals.temp,
+        sbp: data.vitals.sbp,
+        hr: data.vitals.hr,
+        o2: data.vitals.o2,
+        avpu: data.vitals.avpu,
+        scale2: data.vitals.scale2,
+      })
+    : undefined;
+
+  const news2Score = vitals?.total ?? 0;
+  const news2Band = vitals?.band ?? "BAJA";
+  const topAlerts = pickTopAlerts(alerts);
+  const oxygenSummary = formatOxygen(data.oxygenTherapy, now);
+  const { flag: glucoseFlag, detail: glucoseDetail } = extractGlucoseFlag(data);
+  const medsCritical = collectCriticalMeds(data);
+
+  const patientName = data.patient?.name ?? "Paciente sin identificar";
+  const diagnosis = data.patient?.diagnosis;
+
+  const lines: string[] = [];
+  lines.push(`S: ${patientName} con NEWS2 ${news2Score} (${news2Band}).`);
+  if (diagnosis) {
+    lines.push(`B: ${diagnosis}.`);
+  } else {
+    lines.push("B: Sin diagnóstico documentado.");
+  }
+
+  if (topAlerts.length) {
+    lines.push(`A: Alertas principales - ${topAlerts.map(a => a.message).join("; ")}.`);
+  } else {
+    lines.push("A: Sin alertas activas.");
+  }
+
+  const recommendations: string[] = [];
+  if (oxygenSummary) recommendations.push(oxygenSummary);
+  if (glucoseDetail) recommendations.push(glucoseDetail);
+  if (medsCritical?.length) recommendations.push(`Medicación crítica: ${medsCritical.join(", ")}`);
+  if (!recommendations.length) recommendations.push("Vigilar y continuar plan vigente.");
+  lines.push(`R: ${recommendations.join(" | ")}`);
+
+  const text = lines.join("\n");
+
+  return {
+    text,
+    highlights: {
+      news2: news2Score,
+      band: news2Band,
+      alertsTop: topAlerts,
+      oxygen: oxygenSummary,
+      glucoseFlag,
+      medsCritical: medsCritical ?? [],
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- implement structured clinical alerts covering NEWS2 and high-risk bedside rules
- generate SBAR handover summaries with oxygen, glucose, and critical medication highlights
- compute auditable patient priority lists driven by NEWS2, alerts, glucose, oxygen, and recency signals

## Testing
- `pnpm -w tsc --noEmit`
- `pnpm -w vitest run --reporter=verbose`

## Checklist de aceptación

fhir-map.ts: Bundle incluye Observation, MedicationStatement, DeviceUse/Procedure, DocumentReference(audio), Composition; IDs estables; codificaciones correctas; sin duplicados de optionsMerged.

fhir-client.ts: POST con Authorization: Bearer y application/fhir+json; maneja 2xx/4xx (OperationOutcome); configurable por env.ts; tests OK.

sync.ts: SecureStore, backoff, deduplicación por fullUrl, agrupación por paciente; pasa pruebas de red intermitente.

alerts.ts: Reglas NEWS2 + clínicas con unit tests.

summary.ts / priority.ts: SBAR y orden de pacientes con tests.

Validadores FHIR pasan; cobertura mínima OK.

tsc --noEmit sin errores; sin any nuevos.

------
https://chatgpt.com/codex/tasks/task_e_690272b4f6d48321868c28a68274d096