### PR TITLE
Fix QR scanner dynamic loading for expo-barcode-scanner

### DIFF
--- a/__mocks__/expo-barcode-scanner.ts
+++ b/__mocks__/expo-barcode-scanner.ts
@@ -1,0 +1,5 @@
+// __mocks__/expo-barcode-scanner.ts
+export const BarCodeScanner = {
+  requestPermissionsAsync: async () => ({ status: 'granted' }),
+};
+export default { BarCodeScanner };

--- a/app.json
+++ b/app.json
@@ -38,7 +38,7 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
-        "NSCameraUsageDescription": "Usamos la cámara para escanear códigos QR de pacientes.",
+        "NSCameraUsageDescription": "Se requiere la cámara para escanear códigos QR en Handover.",
         "NSMicrophoneUsageDescription": "Grabación de notas de audio del turno",
         "NSUserTrackingUsageDescription": "Se usa para mejorar la experiencia del turno"
       }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,7 @@ import { vi } from 'vitest';
  *   (globalThis as any).__secureStoreMem = {}
  */
 (globalThis as any).__secureStoreMem ??= {} as Record<string, string | null>;
+vi.mock('expo-barcode-scanner');
 vi.mock('expo-secure-store', () => ({
   AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY',
   getItemAsync: (k: string) =>
@@ -26,6 +27,13 @@ vi.mock('expo-constants', () => ({
     expoConfig: { extra: {} },
   },
 }));
+
+vi.mock('js-sha256', async () => {
+  const { createHash } = await import('node:crypto');
+  return {
+    sha256: (input: string) => createHash('sha256').update(input).digest('hex'),
+  };
+});
 
 /** Mock global de auth para evitar dependencias RN/Expo en tests */
 vi.mock('@/src/security/auth', async () => {


### PR DESCRIPTION
## Summary
- replace the QRScan screen with a dynamic expo-barcode-scanner loader that shows fallbacks for missing dependency and permissions
- update the iOS camera permission copy in app.json and provide dedicated mocks for expo-barcode-scanner and js-sha256 in tests

## Testing
- pnpm -s tsc --noEmit
- pnpm vitest run --reporter=verbose

## Dev Notes
- npx expo install expo-barcode-scanner
- npx expo start -c


------
https://chatgpt.com/codex/tasks/task_e_690363d4bd4c8321b270938d82502603