### PR TITLE
feature/week4-security-tests-deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,19 @@
+# API endpoints
 EXPO_PUBLIC_API_BASE_URL=http://192.168.0.16:8000
+EXPO_PUBLIC_FHIR_BASE_URL=http://192.168.0.16:8080/fhir
+FHIR_BASE_URL=http://192.168.0.16:8080/fhir
 
+# OpenID Connect configuration used by the Expo app
+# Redirect URI must match the Expo scheme configured as `handoverpro`
+EXPO_PUBLIC_OIDC_CLIENT_ID=
+EXPO_PUBLIC_OIDC_CLIENT_SECRET=
+EXPO_PUBLIC_OIDC_ISSUER=
+EXPO_PUBLIC_OIDC_REDIRECT_URI=handoverpro://redirect
+EXPO_PUBLIC_OIDC_SCOPES=openid profile email offline_access
+
+# Backend/SDK variables without the Expo prefix (if required by other tooling)
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_ISSUER=
+OIDC_REDIRECT_URI=handoverpro://redirect
+OIDC_SCOPES=openid profile email offline_access

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "handover-pro",
     "slug": "handover-pro",
+    "scheme": "handoverpro",
     "version": "1.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "light",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "1.0.0",
   "main": "index.ts",
   "scripts": {
-    "start": "expo start",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
-    "web": "expo start --web",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:cov": "vitest run --coverage"
+    "start": "pnpm exec expo start",
+    "android": "pnpm exec expo run:android",
+    "ios": "pnpm exec expo run:ios",
+    "web": "pnpm exec expo start --web",
+    "typecheck": "pnpm exec tsc --noEmit",
+    "lint": "pnpm exec expo lint",
+    "test": "pnpm exec vitest run --reporter=verbose",
+    "test:watch": "pnpm exec vitest",
+    "test:cov": "pnpm exec vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -21,7 +23,9 @@
     "expo": "54.0.20",
     "expo-audio": "~1.0.13",
     "expo-camera": "~17.0.8",
+    "expo-auth-session": "~7.0.8",
     "expo-file-system": "~19.0.17",
+    "expo-linking": "~8.0.8",
     "expo-network": "~8.0.7",
     "expo-notifications": "^0.32.12",
     "expo-router": "^6.0.12",


### PR DESCRIPTION
## Summary
- update Expo scripts to pnpm exec variants and add typecheck/lint/test adjustments for Vitest
- add expo-auth-session and expo-linking dependencies and document OIDC/FHIR environment variables
- configure the Expo app scheme for handoverpro to support auth redirects

## Testing
- pnpm vitest run --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_6903c15272408321abaf0dbe3a79ad28