### PR TITLE
Add FHIR bundle validation test and CLI

### DIFF
--- a/__tests__/fhir/bundle-validation.spec.ts
+++ b/__tests__/fhir/bundle-validation.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHandoverBundle } from '@/src/lib/fhir-map';
+import { validateBundle } from '@/src/lib/fhir/validators';
+
+describe('FHIR bundle validation', () => {
+  const NOW = '2025-04-05T10:15:00.000Z';
+  const values = {
+    patientId: 'patient-12345',
+    encounterId: 'enc-67890',
+    author: { id: 'nurse-007', display: 'Nurse Example' },
+    vitals: {
+      recordedAt: '2025-04-05T09:45:00.000Z',
+      issuedAt: '2025-04-05T09:47:00.000Z',
+      hr: 82,
+      rr: 18,
+      sbp: 118,
+      dbp: 74,
+      tempC: 37.1,
+      spo2: 95,
+      glucoseMgDl: 110,
+    },
+    medications: [
+      {
+        status: 'active',
+        code: {
+          system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+          code: '161',
+          display: 'Paracetamol 500mg tablet',
+        },
+        start: '2025-04-05T08:00:00.000Z',
+        note: 'Administered during morning rounds',
+      },
+    ],
+    oxygenTherapy: {
+      status: 'in-progress',
+      start: '2025-04-05T09:00:00.000Z',
+      deviceDisplay: 'Nasal cannula',
+      flowLMin: 4,
+      fio2: 32,
+      note: 'Patient tolerating well',
+    },
+    audioAttachment: {
+      url: 'https://example.org/fhir/handover/audio.m4a',
+      contentType: 'audio/m4a',
+      title: 'Shift summary',
+    },
+    composition: {
+      status: 'final',
+      title: 'Clinical handover summary',
+    },
+    sbar: {
+      situation: 'Post-operative monitoring',
+      background: 'Appendectomy performed yesterday',
+      assessment: 'Stable vitals, mild pain controlled with medication',
+      recommendation: 'Continue oxygen therapy, monitor vitals hourly',
+    },
+  } as const;
+
+  it('generates a structurally valid FHIR transaction bundle with coherent references', () => {
+    const bundle = buildHandoverBundle(values, { now: () => NOW });
+    const {
+      bundle: parsedBundle,
+      observations,
+      medicationStatements,
+      deviceUseStatements,
+      documentReferences,
+      compositions,
+    } = validateBundle(bundle);
+
+    expect(parsedBundle.resourceType).toBe('Bundle');
+    expect(parsedBundle.type).toBe('transaction');
+
+    expect(observations.length).toBeGreaterThan(0);
+    expect(medicationStatements.length).toBe(1);
+    expect(deviceUseStatements.length).toBe(1);
+    expect(documentReferences.length).toBe(1);
+    expect(compositions.length).toBe(1);
+
+    const [composition] = compositions;
+    const [documentReference] = documentReferences;
+
+    const entries = parsedBundle.entry ?? [];
+    const resourcesByFullUrl = new Map<string, any>();
+    for (const entry of entries) {
+      if (entry.fullUrl && entry.resource) {
+        resourcesByFullUrl.set(entry.fullUrl, entry.resource);
+      }
+    }
+
+    const patientReference = `Patient/${values.patientId}`;
+    const encounterReference = `Encounter/${values.encounterId}`;
+
+    for (const observation of observations) {
+      expect(observation.subject.reference).toBe(patientReference);
+      expect(observation.encounter?.reference).toBe(encounterReference);
+    }
+
+    for (const medication of medicationStatements) {
+      expect(medication.subject.reference).toBe(patientReference);
+      expect(medication.encounter?.reference).toBe(encounterReference);
+    }
+
+    for (const deviceUse of deviceUseStatements) {
+      expect(deviceUse.subject.reference).toBe(patientReference);
+      expect(deviceUse.encounter?.reference).toBe(encounterReference);
+    }
+
+    expect(documentReference.subject.reference).toBe(patientReference);
+    expect(documentReference.encounter?.reference).toBe(encounterReference);
+
+    expect(composition.subject.reference).toBe(patientReference);
+    expect(composition.encounter?.reference).toBe(encounterReference);
+
+    const collectSectionRefs = (title: string) =>
+      (composition.section ?? [])
+        .filter((section) => section.title === title)
+        .flatMap((section) => section.entry?.map((ref) => ref.reference) ?? []);
+
+    const vitalsRefs = collectSectionRefs('Vital signs');
+    expect(vitalsRefs.length).toBeGreaterThan(0);
+    for (const ref of vitalsRefs) {
+      const resource = resourcesByFullUrl.get(ref);
+      expect(resource?.resourceType).toBe('Observation');
+    }
+
+    const medicationsRefs = collectSectionRefs('Medications');
+    expect(medicationsRefs).toHaveLength(1);
+    expect(resourcesByFullUrl.get(medicationsRefs[0])?.resourceType).toBe('MedicationStatement');
+
+    const oxygenRefs = collectSectionRefs('Oxygen therapy');
+    expect(oxygenRefs.length).toBeGreaterThan(0);
+    const oxygenTypes = oxygenRefs.map((ref) => resourcesByFullUrl.get(ref)?.resourceType);
+    expect(oxygenTypes).toContain('DeviceUseStatement');
+    expect(oxygenTypes).toContain('Observation');
+
+    const attachmentRefs = collectSectionRefs('Attachments');
+    expect(attachmentRefs).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^urn:uuid:/),
+      ]),
+    );
+    for (const ref of attachmentRefs) {
+      expect(resourcesByFullUrl.get(ref)?.resourceType).toBe('DocumentReference');
+    }
+
+    const allCompositionRefs = new Set(
+      (composition.section ?? []).flatMap((section) => section.entry?.map((ref) => ref.reference) ?? []),
+    );
+    for (const ref of allCompositionRefs) {
+      expect(resourcesByFullUrl.has(ref)).toBe(true);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "precommit": "pnpm typecheck && pnpm lint && pnpm test"
+    "precommit": "pnpm typecheck && pnpm lint && pnpm test",
+    "validate:fhir": "node --loader ./tools/ts-esm-loader.mjs scripts/validate-fhir.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/validate-fhir.ts
+++ b/scripts/validate-fhir.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { stdin as input } from 'node:process';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+import { ZodError } from 'zod';
+
+import { validateBundle } from '../src/lib/fhir/validators';
+
+async function readFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  return new Promise((resolveStdin, reject) => {
+    input.resume();
+    input.on('data', (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    input.on('error', (error) => reject(error));
+    input.on('end', () => {
+      resolveStdin(Buffer.concat(chunks).toString('utf8'));
+    });
+  });
+}
+
+async function readJson(source: string): Promise<unknown> {
+  if (source === '-' || source === '/dev/stdin') {
+    const raw = await readFromStdin();
+    return JSON.parse(raw);
+  }
+
+  const filePath = resolve(source);
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function printSuccess(label: string, summary: {
+  entries: number;
+  observations: number;
+  medications: number;
+  deviceUses: number;
+  documents: number;
+  compositions: number;
+}) {
+  const stats = [
+    `${summary.entries} entries`,
+    `${summary.observations} observations`,
+    `${summary.medications} medication statements`,
+    `${summary.deviceUses} device use statements`,
+    `${summary.documents} document references`,
+    `${summary.compositions} compositions`,
+  ].join(', ');
+  console.log(`✔ ${label}: ${stats}`);
+}
+
+function printFailure(label: string, error: unknown) {
+  console.error(`✖ ${label}`);
+  if (error instanceof ZodError) {
+    for (const issue of error.issues) {
+      const path = issue.path.join('.') || '<root>';
+      console.error(`  • [${path}] ${issue.message}`);
+    }
+  } else if (error instanceof Error) {
+    console.error(`  • ${error.message}`);
+  } else {
+    console.error('  • Unknown error');
+  }
+}
+
+async function main() {
+  const [, , ...args] = process.argv;
+
+  if (args.length === 0) {
+    console.error('Usage: pnpm validate:fhir <bundle.json> [more.json | -]');
+    process.exitCode = 1;
+    return;
+  }
+
+  let hasErrors = false;
+
+  for (const source of args) {
+    const label = source === '-' ? 'stdin' : resolve(source);
+    try {
+      const data = await readJson(source);
+      const result = validateBundle(data);
+      printSuccess(label, {
+        entries: result.bundle.entry?.length ?? 0,
+        observations: result.observations.length,
+        medications: result.medicationStatements.length,
+        deviceUses: result.deviceUseStatements.length,
+        documents: result.documentReferences.length,
+        compositions: result.compositions.length,
+      });
+    } catch (error) {
+      hasErrors = true;
+      printFailure(label, error);
+    }
+  }
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('Unexpected error while validating FHIR bundle');
+  printFailure('runtime', error);
+  process.exit(1);
+});

--- a/src/lib/fhir/validators.ts
+++ b/src/lib/fhir/validators.ts
@@ -1,0 +1,295 @@
+import { z } from 'zod';
+
+import type {
+  Bundle,
+  Composition,
+  DeviceUseStatement,
+  DocumentReference,
+  MedicationStatement,
+  Observation,
+} from '../fhir-map';
+
+const isoDateTime = z
+  .string()
+  .refine((value) => {
+    if (typeof value !== 'string') return false;
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp);
+  }, { message: 'Value must be a valid ISO-8601 date-time string' });
+
+const referenceSchema = z
+  .object({
+    reference: z.string().min(1),
+    type: z.string().optional(),
+    display: z.string().optional(),
+  })
+  .passthrough();
+
+const codingSchema = z
+  .object({
+    system: z.string().optional(),
+    code: z.union([z.string(), z.number()]).optional(),
+    display: z.string().optional(),
+  })
+  .passthrough();
+
+const codeableConceptSchema = z
+  .object({
+    coding: z.array(codingSchema).min(1).optional(),
+    text: z.string().optional(),
+  })
+  .refine((value) => value.coding !== undefined || value.text !== undefined, {
+    message: 'CodeableConcept requires coding or text',
+  })
+  .passthrough();
+
+const quantitySchema = z
+  .object({
+    value: z.number(),
+    unit: z.string().optional(),
+    system: z.string().optional(),
+    code: z.union([z.string(), z.number()]).optional(),
+  })
+  .passthrough();
+
+const periodSchema = z
+  .object({
+    start: isoDateTime,
+    end: isoDateTime.optional(),
+  })
+  .passthrough();
+
+const attachmentSchema = z
+  .object({
+    contentType: z.string().min(1),
+    url: z.string().url().optional(),
+    title: z.string().optional(),
+    data: z.string().optional(),
+    size: z.number().optional(),
+    hash: z.string().optional(),
+  })
+  .refine((value) => value.url !== undefined || value.data !== undefined, {
+    message: 'Attachment requires either an URL or inline data',
+  })
+  .passthrough();
+
+const observationSchema = z
+  .object({
+    resourceType: z.literal('Observation'),
+    status: z.string().min(1),
+    meta: z
+      .object({
+        profile: z.array(z.string()).min(1),
+      })
+      .optional(),
+    category: z
+      .array(
+        z
+          .object({
+            coding: z.array(codingSchema).min(1),
+            text: z.string().optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    code: codeableConceptSchema,
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    effectiveDateTime: isoDateTime,
+    issued: isoDateTime.optional(),
+    valueQuantity: quantitySchema.optional(),
+    valueCodeableConcept: codeableConceptSchema.optional(),
+    valueString: z.string().optional(),
+    component: z
+      .array(
+        z
+          .object({
+            code: codeableConceptSchema,
+            valueQuantity: quantitySchema.optional(),
+            valueCodeableConcept: codeableConceptSchema.optional(),
+            valueString: z.string().optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    hasMember: z.array(referenceSchema).optional(),
+  })
+  .superRefine((value, ctx) => {
+    const hasValue =
+      value.valueQuantity !== undefined ||
+      value.valueCodeableConcept !== undefined ||
+      value.valueString !== undefined ||
+      (value.component !== undefined && value.component.length > 0) ||
+      (value.hasMember !== undefined && value.hasMember.length > 0);
+    if (!hasValue) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Observation requires a value, component, or hasMember reference',
+        path: ['valueQuantity'],
+      });
+    }
+  })
+  .passthrough();
+
+const medicationStatementSchema = z
+  .object({
+    resourceType: z.literal('MedicationStatement'),
+    status: z.enum(['active', 'completed', 'entered-in-error', 'intended']).or(z.string().min(1)),
+    medicationCodeableConcept: codeableConceptSchema,
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    effectiveDateTime: isoDateTime.optional(),
+    effectivePeriod: periodSchema.optional(),
+    dateAsserted: isoDateTime.optional(),
+    dosage: z.any().optional(),
+    note: z.array(z.object({ text: z.string() }).passthrough()).optional(),
+  })
+  .passthrough();
+
+const deviceUseStatementSchema = z
+  .object({
+    resourceType: z.literal('DeviceUseStatement'),
+    status: z.enum(['active', 'completed', 'entered-in-error']).or(z.string().min(1)),
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    device: z
+      .object({
+        reference: z.string().min(1),
+        display: z.string().optional(),
+      })
+      .passthrough(),
+    timingPeriod: periodSchema,
+  })
+  .passthrough();
+
+const documentReferenceSchema = z
+  .object({
+    resourceType: z.literal('DocumentReference'),
+    status: z.string().min(1),
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    author: z.array(referenceSchema).min(1),
+    date: isoDateTime,
+    content: z.array(z.object({ attachment: attachmentSchema }).passthrough()).min(1),
+    category: z.array(codeableConceptSchema).min(1),
+  })
+  .passthrough();
+
+const compositionSectionSchema = z
+  .object({
+    title: z.string().optional(),
+    code: codeableConceptSchema.optional(),
+    text: z
+      .object({
+        status: z.string().optional(),
+        div: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    entry: z.array(referenceSchema).optional(),
+  })
+  .passthrough();
+
+const compositionSchema = z
+  .object({
+    resourceType: z.literal('Composition'),
+    status: z.string().min(1),
+    type: codeableConceptSchema,
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    date: isoDateTime,
+    author: z.array(referenceSchema).min(1),
+    title: z.string().min(1),
+    section: z.array(compositionSectionSchema).optional(),
+  })
+  .passthrough();
+
+const bundleEntrySchema = z
+  .object({
+    fullUrl: z.string().min(1),
+    resource: z.record(z.any()).optional(),
+    request: z
+      .object({
+        method: z.string().min(1),
+        url: z.string().min(1),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+const bundleSchema = z
+  .object({
+    resourceType: z.literal('Bundle'),
+    type: z.literal('transaction'),
+    entry: z.array(bundleEntrySchema).min(1),
+  })
+  .passthrough();
+
+type ValidatedBundle = {
+  bundle: Bundle;
+  observations: Observation[];
+  medicationStatements: MedicationStatement[];
+  deviceUseStatements: DeviceUseStatement[];
+  documentReferences: DocumentReference[];
+  compositions: Composition[];
+};
+
+export function validateBundle(input: unknown): ValidatedBundle {
+  const parsedBundle = bundleSchema.parse(input) as Bundle & { entry: Array<{ resource?: any }> };
+
+  const observations: Observation[] = [];
+  const medicationStatements: MedicationStatement[] = [];
+  const deviceUseStatements: DeviceUseStatement[] = [];
+  const documentReferences: DocumentReference[] = [];
+  const compositions: Composition[] = [];
+
+  for (const entry of parsedBundle.entry ?? []) {
+    const resource = entry.resource;
+    if (!resource || typeof resource !== 'object') continue;
+
+    switch ((resource as { resourceType?: string }).resourceType) {
+      case 'Observation':
+        observations.push(observationSchema.parse(resource) as Observation);
+        break;
+      case 'MedicationStatement':
+        medicationStatements.push(medicationStatementSchema.parse(resource) as MedicationStatement);
+        break;
+      case 'DeviceUseStatement':
+        deviceUseStatements.push(deviceUseStatementSchema.parse(resource) as DeviceUseStatement);
+        break;
+      case 'DocumentReference':
+        documentReferences.push(documentReferenceSchema.parse(resource) as DocumentReference);
+        break;
+      case 'Composition':
+        compositions.push(compositionSchema.parse(resource) as Composition);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {
+    bundle: parsedBundle,
+    observations,
+    medicationStatements,
+    deviceUseStatements,
+    documentReferences,
+    compositions,
+  };
+}
+
+export const schemas = {
+  isoDateTime,
+  reference: referenceSchema,
+  codeableConcept: codeableConceptSchema,
+  quantity: quantitySchema,
+  observation: observationSchema,
+  medicationStatement: medicationStatementSchema,
+  deviceUseStatement: deviceUseStatementSchema,
+  documentReference: documentReferenceSchema,
+  composition: compositionSchema,
+  bundle: bundleSchema,
+};
+
+export type { ValidatedBundle };

--- a/tools/ts-esm-loader.mjs
+++ b/tools/ts-esm-loader.mjs
@@ -1,0 +1,58 @@
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx'];
+
+async function fileExists(url) {
+  try {
+    await access(url, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolve(specifier, context, defaultResolve) {
+  const hasExtension = /\.[a-zA-Z0-9]+$/.test(specifier);
+
+  if (!hasExtension && !specifier.startsWith('node:') && context.parentURL) {
+    for (const ext of TS_EXTENSIONS) {
+      const candidate = new URL(`${specifier}${ext}`, context.parentURL);
+      const path = fileURLToPath(candidate);
+      if (await fileExists(path)) {
+        return {
+          url: candidate.href,
+          format: 'module',
+        };
+      }
+    }
+  }
+
+  const resolved = await defaultResolve(specifier, context, defaultResolve);
+  return resolved;
+}
+
+export async function load(url, context, defaultLoad) {
+  if (TS_EXTENSIONS.some((ext) => url.endsWith(ext))) {
+    const source = await readFile(fileURLToPath(url), 'utf8');
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2020,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        esModuleInterop: true,
+        resolveJsonModule: true,
+        allowSyntheticDefaultImports: true,
+      },
+      fileName: fileURLToPath(url),
+    });
+    return {
+      format: 'module',
+      source: outputText,
+    };
+  }
+
+  return defaultLoad(url, context, defaultLoad);
+}


### PR DESCRIPTION
## Summary
- add reusable FHIR bundle validation schemas for observations, medications, oxygen therapy, documents, and compositions
- add a vitest suite that builds a synthetic handover bundle and checks structural integrity and reference coherence
- provide a CLI command and loader wiring to validate exported bundle JSON outside of the test suite

## Testing
- `pnpm vitest run --reporter=verbose` *(fails: vitest binary missing because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690610b39e1083218f743ca7c216c79d