### PR TITLE
fix(network+fhir+acl): fetchWithRetry + FHIR client + quitar ACL en chips

### DIFF
--- a/jest-tests/fhir-client.test.ts
+++ b/jest-tests/fhir-client.test.ts
@@ -67,8 +67,7 @@ describe('fhir-client', () => {
       text: jest.fn().mockResolvedValue(''),
       headers: { get: jest.fn() },
     });
-    const result = await fetchFHIR({ path: '/Encounter' });
-    expect(result.ok).toBe(false);
+    await expect(fetchFHIR({ path: '/Encounter' })).rejects.toThrow('unauthorized');
     expect(logout).toHaveBeenCalled();
   });
 

--- a/src/lib/net.ts
+++ b/src/lib/net.ts
@@ -1,49 +1,106 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // src/lib/net.ts
+
+/** Opciones de reintento para fetchWithRetry */
 export type RetryOptions = {
-  retries?: number;           // intentos adicionales (default 3)
-  backoffMs?: number;         // base del backoff (default 500 ms)
-  retryOn?: number[];         // HTTP que reintentan (default 408,429,5xx)
+  /** Intentos adicionales (default 3) */
+  retries?: number;
+  /** Base del backoff exponencial en ms (default 500) */
+  backoffMs?: number;
+  /** Códigos HTTP que disparan reintento (default 408,429,5xx) */
+  retryOn?: number[];
+  /** AbortSignal externo */
   signal?: AbortSignal;
 };
 
-const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
+/** Extiende RequestInit para permitir un fetch alternativo y flags usados en tests */
+export interface ExtendedRequestInit extends RequestInit {
+  /** Implementación custom de fetch (usado por jest/vitest) */
+  fetchImpl?: typeof fetch;
+  /** Puede ser número (p.ej., 0) o objeto con overrides (usado por tests) */
+  retry?: number | {
+    retries?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+  };
+  /** Timeout duro en ms (se cancela la petición) */
+  timeoutMs?: number;
+}
+
+const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 /**
- * fetchWithRetry: wrapper con backoff exponencial + jitter.
- * Exportado porque los tests lo piden explícitamente.
+ * fetchWithRetry: wrapper de fetch con backoff exponencial + jitter.
+ * - Acepta `init.fetchImpl` para inyectar un fetch simulado en tests.
+ * - Acepta `init.retry` (number | object) y `init.timeoutMs`.
+ * - Reintenta en 408, 429 y 5xx por defecto.
  */
 export async function fetchWithRetry(
   input: RequestInfo | URL,
-  init: RequestInit = {},
+  init: ExtendedRequestInit = {},
   opts: RetryOptions = {},
 ): Promise<Response> {
   const {
-    retries = 3,
-    backoffMs = 500,
+    retries: optRetries = 3,
+    backoffMs: optBackoff = 500,
     retryOn = [408, 429, 500, 502, 503, 504],
-    signal,
+    signal: optSignal,
   } = opts;
+
+  // Separa extensiones de init y decide qué fetch usar
+  const { fetchImpl, retry, timeoutMs, ...initRest } = init;
+  const doFetch = fetchImpl ?? fetch;
+
+  // Overrides provenientes de init.retry
+  const retries =
+    typeof retry === 'number' ? retry :
+    (retry?.retries ?? optRetries);
+
+  const baseDelayMs =
+    typeof retry === 'number' ? optBackoff :
+    (retry?.baseDelayMs ?? optBackoff);
+
+  const maxDelayMs =
+    typeof retry === 'number' ? Number.POSITIVE_INFINITY :
+    (retry?.maxDelayMs ?? Number.POSITIVE_INFINITY);
+
+  // Timeout opcional
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const controller = new AbortController();
+  const finalSignal = optSignal ?? (timeoutMs ? controller.signal : undefined);
+  if (timeoutMs) {
+    // Sin argumento para compatibilidad con DOM libs antiguas
+    timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  }
 
   let attempt = 0;
   let lastErr: any;
 
   while (attempt <= retries) {
     try {
-      const res = await fetch(input, { ...init, signal });
-      // Si no es reintitable o ya es el último intento, devolvemos:
-      if (!retryOn.includes(res.status) || attempt === retries) return res;
+      const res = await doFetch(input, { ...initRest, signal: finalSignal });
+      // Si no es reintitable o ya es el último intento, devolvemos la respuesta
+      if (!retryOn.includes(res.status) || attempt === retries) {
+        if (timeoutId) clearTimeout(timeoutId);
+        return res;
+      }
     } catch (err) {
       lastErr = err;
-      if (attempt === retries) throw err;
+      if (attempt === retries) {
+        if (timeoutId) clearTimeout(timeoutId);
+        throw err; // último intento: propaga error
+      }
     }
-    // Backoff exponencial con un poquito de jitter:
-    const delay = backoffMs * Math.pow(2, attempt) + Math.floor(Math.random() * 100);
+
+    // Backoff exponencial + jitter (0..99 ms), acotado por maxDelayMs
+    const backoff = baseDelayMs * Math.pow(2, attempt) + Math.floor(Math.random() * 100);
+    const delay = Math.min(backoff, maxDelayMs);
     await sleep(delay);
     attempt += 1;
   }
-  // TS guard
-  if (lastErr) throw lastErr;
+
+  if (timeoutId) clearTimeout(timeoutId);
+  if (lastErr) throw lastErr; // TS guard
   throw new Error('fetchWithRetry: fallthrough inesperado');
 }
 

--- a/src/types/expo-auth-session-compat.d.ts
+++ b/src/types/expo-auth-session-compat.d.ts
@@ -1,0 +1,17 @@
+// Tipos de compatibilidad para expo-auth-session (alivian TS sin tocar lógica)
+declare module 'expo-auth-session' {
+  export function parse(url: string): any;
+  export function fetchDiscoveryAsync(issuer: string): Promise<any>;
+  export function revokeAsync(params: any, discovery?: any): Promise<void>;
+  export function refreshAsync(config: any, body: any, discovery?: any): Promise<any>;
+  export function exchangeCodeAsync(config: any, body: any, discovery?: any): Promise<any>;
+  export function makeRedirectUri(opts?: any): string;
+
+  export class AuthRequest {
+    constructor(config: any);
+    codeVerifier?: string;
+    redirectUri?: string;
+  }
+
+  export const ResponseType: { Code: string; Token?: string };
+}


### PR DESCRIPTION
## Summary
- replace the networking helper with the new fetchWithRetry supporting retry overrides, timeout and custom fetch implementations
- overhaul the FHIR client to add overloads, ensureFreshToken integration, sync compatibility helpers and mock-friendly response handling
- add Expo Auth Session compatibility types and update fhir-client tests for the new unauthorized flow

## Testing
- pnpm -w typecheck
- pnpm -w test
- pnpm vitest run --reporter=verbose *(fails: Command "vitest" not found)*
- pnpm -w start -c *(fails: Expo CLI network fetch error)*

------
https://chatgpt.com/codex/tasks/task_e_6907d749c0ec83219014a9ff27e540d2