### PR TITLE
Fix Expo Tailwind configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,28 +1,15 @@
-// babel.config.js
 module.exports = function (api) {
   api.cache(true);
-
-  const plugins = [
-    [
-      'module-resolver',
-      {
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      ['module-resolver', {
         root: ['./'],
-        alias: {
-          '@/src': './src',
-        },
+        alias: { '@': './src', '@src': './src' },
         extensions: ['.tsx', '.ts', '.jsx', '.js', '.json'],
-      },
+      }],
+      'nativewind/babel',
+      'react-native-reanimated/plugin', // ← SIEMPRE EL ÚLTIMO
     ],
-  ];
-
-  plugins.push('nativewind/babel'); // INSTALAR: nativewind
-
-  // Debe ir el ÚLTIMO y solo si existe: evita crashear si aún no está instalado
-  try {
-    require.resolve('react-native-reanimated/plugin');
-    plugins.push('react-native-reanimated/plugin');
-  } catch {}
-
-  return { presets: ['babel-preset-expo'], plugins };
+  };
 };
-

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jest-expo": "^50.0.4",
     "jsdom": "^27.0.0",
     "react-test-renderer": "^19.2.0",
+    "tailwindcss": "3.4.13",
     "ts-jest": "^29.4.5",
     "typescript": "5.9.3"
   },

--- a/src/screens/HandoverMain.tsx
+++ b/src/screens/HandoverMain.tsx
@@ -230,7 +230,7 @@ function Cierre({sb,v,meds,disps,ox}:{sb:{s:string;b:string;a:string;r:string}; 
       <Label>Adjuntos</Label>
       <AudioAttach onRecorded={(uri)=>console.log('Audio:', uri)} />
       <View style={{height:12}} />
-      <Button title="Guardar y Enviar (solo UI)" onPress={()=>console.log('Enviar bundle (UI): listo para integrar FHIR)'} />
+      <Button title="Guardar y Enviar (solo UI)" onPress={()=>console.log('Enviar bundle (UI): listo para integrar FHIR')} />
       <Text style={{marginTop:8,color:'#64748b',fontSize:12}}>
         * Esta pantalla no envía aún a FHIR: integraremos con buildHandoverBundle y cola offline en el siguiente paso.
       </Text>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,15 +1,12 @@
-// INSTALAR: nativewind tailwindcss
-/** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{ts,tsx}'],
+  content: ["./App.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
-        'news2-green': '#10B981',
-        'news2-amber': '#F59E0B',
-        'news2-red': '#EF4444',
-      },
-    },
-  },
-  plugins: [],
+        "news2-green":"#10B981",
+        "news2-amber":"#F59E0B",
+        "news2-red":"#EF4444"
+      }
+    }
+  }
 };


### PR DESCRIPTION
## Summary
- replace the Expo Babel configuration with the required module-resolver, NativeWind, and Reanimated plugin ordering
- update Tailwind to version 3.4.13 with the new content sources and color palette
- correct the UI console log message in `HandoverMain`

## Testing
- ⚠️ `pnpm install` *(fails: registry returned 403 when fetching tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_690899f7f90483219279477e20939647