### PR TITLE
Align Expo configuration with NativeWind plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,17 +2,18 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: [
-      ['babel-preset-expo', { jsxImportSource: 'nativewind' }],
-      'nativewind/babel',
-    ],
+    presets: ['babel-preset-expo'],
     plugins: [
-      ['module-resolver', {
-        root: ['./'],
-        alias: { '@': './src', '@src': './src' },
-        extensions: ['.tsx', '.ts', '.jsx', '.js', '.json'],
-      }],
-      'react-native-reanimated/plugin', // siempre al final
+      [
+        'module-resolver',
+        {
+          root: ['./'],
+          alias: { '@': './src', '@src': './src' },
+          extensions: ['.tsx', '.ts', '.jsx', '.js', '.json'],
+        },
+      ],
+      'nativewind/babel',
+      'react-native-reanimated/plugin',
     ],
   };
 };

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,4 @@
-import 'expo-router/entry';
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -1,0 +1,9 @@
+/** metro.config.cjs — Expo 54 + pnpm (symlinks/exports) */
+const { getDefaultConfig } = require('expo/metro-config');
+const { withNativeWind } = require('nativewind/metro');
+
+const config = getDefaultConfig(__dirname);
+config.resolver.unstable_enableSymlinks = true;
+config.resolver.unstable_enablePackageExports = true;
+
+module.exports = withNativeWind(config);

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,0 @@
-// metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
-const { withNativeWind } = require('nativewind/metro');
-const config = getDefaultConfig(__dirname);
-// Si no usas global.css, igual funciona; deja la línea siguiente tal cual:
-module.exports = withNativeWind(config /*, { input: './global.css' }*/);


### PR DESCRIPTION
## Summary
- replace the Metro configuration with a .cjs variant compatible with pnpm and NativeWind
- update the Babel configuration to use the NativeWind plugin alongside module resolver aliases
- restore the classic Expo entry point so App.tsx registers correctly

## Testing
- `pnpm vitest run --reporter=verbose` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6909abe82bd08321b83c25df8ff5e09d