### PR TITLE
fix(start): Expo Go estable en Expo 54 (Metro CJS, Babel nativo, entrada clásica)

### DIFF
--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -1,9 +1,9 @@
 /** metro.config.cjs — Expo 54 + pnpm (symlinks/exports) */
 const { getDefaultConfig } = require('expo/metro-config');
-const { withNativeWind } = require('nativewind/metro');
 
-const config = getDefaultConfig(__dirname);
-config.resolver.unstable_enableSymlinks = true;
-config.resolver.unstable_enablePackageExports = true;
-
-module.exports = withNativeWind(config);
+module.exports = (() => {
+  const config = getDefaultConfig(__dirname);
+  config.resolver.unstable_enableSymlinks = true;
+  config.resolver.unstable_enablePackageExports = true;
+  return config;
+})();

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@testing-library/react": "^16.0.1",
     "@testing-library/react-native": "^12.8.1",
     "@types/react-test-renderer": "^19.1.0",
-    "@expo/metro-config": "^0.17.5",
     "babel-plugin-module-resolver": "^5.0.2",
     "babel-preset-expo": "^54.0.4",
     "jest": "29.7.0",


### PR DESCRIPTION
## Summary
- Reemplazar metro.config.cjs por el CJS mínimo basado en expo/metro-config con symlinks y package exports habilitados
- Reemplazar babel.config.js para usar nativewind/babel más module-resolver y reanimated al final
- Restaurar index.ts clásico con registerRootComponent(App)
- Eliminar configuraciones duplicadas (.babelrc, metro.config.js) y limpiar cachés
- Ajustar package.json para mantener nativewind@4.2.1 y dejar solo dependencias necesarias

## Testing
- `node -e "require('./metro.config.cjs'); console.log('OK')"`
- `pnpm vitest run --reporter=verbose` *(falla: Command "vitest" not found)*
- Expo Go: pendiente de verificación manual (no disponible en este entorno)


------
https://chatgpt.com/codex/tasks/task_e_690a026579ac83218fca5080a2c4073a