### PR TITLE
fix: enable mock login entry flow

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,23 +1,15 @@
 module.exports = function (api) {
   api.cache(true);
-
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      [
-        'module-resolver',
-        {
-          root: ['./'],
-          alias: { '@': './src' },
-          extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
-        },
-      ],
-      // Necesario para NativeWind v3/v4
+      ['module-resolver', {
+        root: ['./'],
+        alias: { '@': './src' },
+        extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
+      }],
       'nativewind/babel',
-      // SIEMPRE el último
-      'react-native-reanimated/plugin',
+      'react-native-reanimated/plugin', // <- SIEMPRE último
     ],
   };
 };
-
-

--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -1,5 +1,0 @@
-const { getDefaultConfig } = require('expo/metro-config');
-
-const config = getDefaultConfig(__dirname);
-
-module.exports = config;

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,4 @@
-// Metro config — Expo 54 (RN 0.81) sin transformadores custom
-const { getDefaultConfig } = require('@expo/metro-config');
-
-module.exports = getDefaultConfig(__dirname);
-
+// metro.config.js
+const { getDefaultConfig } = require('expo/metro-config');
+const config = getDefaultConfig(__dirname);
+module.exports = config;

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,6 +1,7 @@
 // src/navigation/RootNavigator.tsx
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import LoginMock from '@/src/screens/LoginMock';
 import PatientList from '@/src/screens/PatientList';
 import AudioNote from '@/src/screens/AudioNote';
 import HandoverForm from '@/src/screens/HandoverForm';
@@ -8,6 +9,7 @@ import HandoverMain from '@/src/screens/HandoverMain';
 import QRScan from '@/src/screens/QRScan';
 
 export type RootStackParamList = {
+  Login: undefined;
   PatientList: undefined;
   AudioNote: { onDoneRoute?: string } | undefined;
   HandoverMain: { patientId: string };
@@ -26,16 +28,29 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function RootNavigator() {
   return (
-    <Stack.Navigator initialRouteName="PatientList">
-      <Stack.Screen name="PatientList" component={PatientList} options={{ title: 'Pacientes' }} />
-      <Stack.Screen name="HandoverForm" component={HandoverForm} options={{ title: 'Entrega de turno' }} />
+    <Stack.Navigator initialRouteName="Login" screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Login" component={LoginMock} options={{ headerShown: false }} />
+      <Stack.Screen
+        name="PatientList"
+        component={PatientList}
+        options={{ title: 'Pacientes', headerShown: true }}
+      />
+      <Stack.Screen
+        name="HandoverForm"
+        component={HandoverForm}
+        options={{ title: 'Entrega de turno', headerShown: true }}
+      />
       <Stack.Screen
         name="HandoverMain"
         component={HandoverMain}
-        options={{ title: 'Entrega de turno' }}
+        options={{ title: 'Entrega de turno', headerShown: true }}
       />
-      <Stack.Screen name="AudioNote" component={AudioNote} options={{ title: 'Notas de audio' }} />
-      <Stack.Screen name="QRScan" component={QRScan} options={{ title: 'Escanear' }} />
+      <Stack.Screen
+        name="AudioNote"
+        component={AudioNote}
+        options={{ title: 'Notas de audio', headerShown: true }}
+      />
+      <Stack.Screen name="QRScan" component={QRScan} options={{ title: 'Escanear', headerShown: true }} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/LoginMock.tsx
+++ b/src/screens/LoginMock.tsx
@@ -11,7 +11,7 @@ export default function LoginMock() {
     await loginWithMockUser();
     // tras login: a la lista de pacientes
     // @ts-ignore
-    nav.replace("Patients");
+    nav.replace("PatientList");
   };
 
   return (


### PR DESCRIPTION
## Summary
- restore Expo default Metro configuration and align Babel plugins
- remove the legacy Metro CJS config to avoid conflicts
- route mock login into the stack and land on the patient list after signing in

## Testing
- pnpm vitest run --reporter=verbose *(fails: Command "vitest" not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f34be71dc8321a134d2fe9f302a5f)