### PR TITLE
ops(store): canales internos Play + TestFlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,11 @@ __pycache__/
 .env
 .env.*
 
-android/
+android/*
+!android/gradle.properties
+!android/app/
+android/app/*
+!android/app/build.gradle
 src/security/*.bak
 src/security/*.bak
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,3 @@
+// BEGIN HANDOVER: ANDROID_APPID
+android { defaultConfig { applicationId "com.handover.app" } }
+// END HANDOVER: ANDROID_APPID

--- a/docs/distribution/android-internal.md
+++ b/docs/distribution/android-internal.md
@@ -1,0 +1,5 @@
+<!-- BEGIN HANDOVER: ANDROID_INTERNAL -->
+1) EAS build preview (aab) → subir a Play Console (Internal testing).
+2) Añadir testers (emails / grupos).
+3) Instalar y verificar en dispositivo real.
+<!-- END HANDOVER: ANDROID_INTERNAL -->

--- a/docs/distribution/ios-testflight.md
+++ b/docs/distribution/ios-testflight.md
@@ -1,0 +1,5 @@
+<!-- BEGIN HANDOVER: IOS_TESTFLIGHT -->
+1) EAS build preview iOS → enviar a App Store Connect.
+2) Crear grupo TestFlight y añadir testers.
+3) Validar instalación y notas de versión.
+<!-- END HANDOVER: IOS_TESTFLIGHT -->

--- a/docs/distribution/tester-invite-email.md
+++ b/docs/distribution/tester-invite-email.md
@@ -1,0 +1,4 @@
+<!-- BEGIN HANDOVER: TESTER_INVITE -->
+Asunto: Acceso interno a Handover (Android/iOS)
+Cuerpo: Hola, te invitamos a probar Handover. Instrucciones adjuntas.
+<!-- END HANDOVER: TESTER_INVITE -->


### PR DESCRIPTION
## Summary
- add internal distribution doc steps for Android, iOS TestFlight, and tester invites
- ensure the Android applicationId is set via a dedicated build.gradle snippet and adjust ignore rules accordingly

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ed277de083219ff12ccfb4c67592)