### PR TITLE
feat(telemetry): sentry + perf, logs sin PII

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,21 @@
+import type { ExpoConfig } from "expo/config";
+
+const appJson = require("./app.json");
+
+const config: ExpoConfig = {
+  ...appJson,
+  expo: {
+    ...appJson.expo,
+    plugins: [
+      ...(appJson.expo?.plugins ?? []),
+      // BEGIN HANDOVER: SENTRY_PLUGIN
+      [
+        "sentry-expo",
+        { organization: "PLACEHOLDER_ORG", project: "handover" }
+      ]
+      // END HANDOVER: SENTRY_PLUGIN
+    ]
+  }
+};
+
+export default config;

--- a/docs/observability/events-policy.md
+++ b/docs/observability/events-policy.md
@@ -1,0 +1,3 @@
+<!-- BEGIN HANDOVER: EVENTS_POLICY -->
+No registrar nombres de paciente, HC, cama, diagnósticos en claro. Usar IDs seudónimos.
+<!-- END HANDOVER: EVENTS_POLICY -->

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,14 @@
+// BEGIN HANDOVER: LOGGER
+type Level = "debug" | "info" | "warn" | "error";
+const PHI_KEYS = ["name", "fullName", "document", "bed", "mrn", "hc", "history", "dni"];
+const redactPII = (obj: any) =>
+  JSON.parse(
+    JSON.stringify(obj, (k, v) => (PHI_KEYS.includes(k) ? "***" : v))
+  );
+export const logger = {
+  log: (lvl: Level, msg: string, meta?: any) => {
+    const safe = meta ? redactPII(meta) : undefined;
+    console[lvl](`[${lvl.toUpperCase()}] ${msg}`, safe ?? "");
+  }
+};
+// END HANDOVER: LOGGER

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,9 @@
+// BEGIN HANDOVER: SENTRY_INIT
+import * as Sentry from "@sentry/react-native";
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 0.2,
+  enableAutoPerformanceTracking: true
+});
+export { Sentry };
+// END HANDOVER: SENTRY_INIT


### PR DESCRIPTION
## Summary
- initialize Sentry with performance tracking via a dedicated entry point
- register the sentry-expo plugin alongside the Expo configuration
- add a logger that redacts PII and document the observability event policy

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f309e4148321a2121f4cddbacd8c)