### PR TITLE
feat(sync): cola cifrada, bundles, backoff, no duplicación

### DIFF
--- a/__tests__/sync.spec.ts
+++ b/__tests__/sync.spec.ts
@@ -1,0 +1,8 @@
+// BEGIN HANDOVER: TEST_SYNC
+import { queue } from "../src/lib/sync/offlineQueue";
+it("enqueue/dequeue", async()=>{
+  await queue.push({id:"1",type:"obs",payload:{},createdAt:Date.now()});
+  const j=await queue.shift();
+  expect(j?.id).toBe("1");
+});
+// END HANDOVER: TEST_SYNC

--- a/src/lib/fhir/bundleBuilder.ts
+++ b/src/lib/fhir/bundleBuilder.ts
@@ -1,0 +1,7 @@
+// BEGIN HANDOVER: FHIR_BUNDLE
+type FhirResource={ resourceType:string; id?:string; [k:string]:any };
+export function bundleTx(resources:FhirResource[]){
+  return { resourceType:"Bundle", type:"transaction",
+    entry: resources.map(r=>({ resource:r, request:{ method: r.id?"PUT":"POST", url: r.id?`${r.resourceType}/${r.id}`:r.resourceType } })) };
+}
+// END HANDOVER: FHIR_BUNDLE

--- a/src/lib/fhir/idempotency.ts
+++ b/src/lib/fhir/idempotency.ts
@@ -1,0 +1,9 @@
+// BEGIN HANDOVER: IDEMPOTENCY
+export const stableId=(patientId:string, kind:string, fingerprint:string)=>{
+  const s=`${patientId}:${kind}:${fingerprint}`;
+  let h=0;
+  for (let i=0;i<s.length;i++){ h=(h*31 + s.charCodeAt(i))>>>0; }
+  const hex=h.toString(16).padStart(8,"0");
+  return (hex+hex+hex).slice(0,24);
+};
+// END HANDOVER: IDEMPOTENCY

--- a/src/lib/sync/backoff.ts
+++ b/src/lib/sync/backoff.ts
@@ -27,3 +27,6 @@ export async function retryWithBackoff<T>(
   }
   throw lastErr;
 }
+// BEGIN HANDOVER: BACKOFF
+export const backoff=(attempt:number,baseMs=500,capMs=15000)=>Math.min(capMs, baseMs*Math.pow(2,attempt)) + Math.floor(Math.random()*250);
+// END HANDOVER: BACKOFF

--- a/src/lib/sync/offlineQueue.ts
+++ b/src/lib/sync/offlineQueue.ts
@@ -1,0 +1,10 @@
+// BEGIN HANDOVER: OFFLINE_QUEUE
+import { secure } from "../secure-store";
+type Job={ id:string; type:string; payload:any; createdAt:number };
+const KEY="offlineQueue";
+export const queue={
+  all: async():Promise<Job[]>=>JSON.parse((await secure.get(KEY))||"[]"),
+  push: async(j:Job)=>{ const q=await queue.all(); q.push(j); await secure.set(KEY,JSON.stringify(q)); },
+  shift: async()=>{ const q=await queue.all(); const j=q.shift(); await secure.set(KEY,JSON.stringify(q)); return j; }
+};
+// END HANDOVER: OFFLINE_QUEUE


### PR DESCRIPTION
## Summary
- add encrypted offline queue helper around secure store with enqueue/dequeue helpers
- provide deterministic idempotency hash and FHIR bundle transaction builder utilities
- expose jittered backoff constant and add basic queue test coverage

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691614d871b48321883ced1aaee1fd93)