### PR TITLE
docs(store): fichas y políticas

### DIFF
--- a/public/privacy-policy.md
+++ b/public/privacy-policy.md
@@ -1,0 +1,3 @@
+<!-- BEGIN HANDOVER: PRIVACY -->
+No almacenamos PHI en servidores propios; se sincroniza con el FHIR del hospital. Cifrado en tránsito y en reposo local.
+<!-- END HANDOVER: PRIVACY -->

--- a/public/support.md
+++ b/public/support.md
@@ -1,0 +1,3 @@
+<!-- BEGIN HANDOVER: SUPPORT -->
+Soporte: soporte@PLACEHOLDER_DOMINIO  | SLA: 48h hábiles
+<!-- END HANDOVER: SUPPORT -->

--- a/store/listings/appstore/es-ES.md
+++ b/store/listings/appstore/es-ES.md
@@ -1,0 +1,4 @@
+<!-- BEGIN HANDOVER: APPSTORE_LISTING -->
+Subtítulo: Handover clínico seguro y rápido.
+Texto marketing + capturas sugeridas.
+<!-- END HANDOVER: APPSTORE_LISTING -->

--- a/store/listings/play/es-ES.md
+++ b/store/listings/play/es-ES.md
@@ -1,0 +1,5 @@
+<!-- BEGIN HANDOVER: PLAY_LISTING -->
+Nombre: Handover
+Descripción breve: Entrega de turno interoperable para enfermería.
+Puntos clave: Vitals con gráficos, QR paciente, NEWS2, offline seguro.
+<!-- END HANDOVER: PLAY_LISTING -->

--- a/store/screenshots/shot-plan.md
+++ b/store/screenshots/shot-plan.md
@@ -1,0 +1,3 @@
+<!-- BEGIN HANDOVER: SHOT_PLAN -->
+1) Dashboard pacientes  2) Vitals con gráfico  3) QR  4) Resumen/NEWS2  5) Offline sync
+<!-- END HANDOVER: SHOT_PLAN -->


### PR DESCRIPTION
## Summary
- add Spanish Play Store listing details for Handover
- add App Store listing copy and screenshot plan guidance
- document privacy policy and support contact information blocks

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162f53c2ac832194ab86c617c1b750)