### PR TITLE
ci(docs): GH Actions, changelog y guía

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,59 +1,17 @@
+# BEGIN HANDOVER: CI
 name: CI
-
-on:
-  push:
-    branches: ['**']
-  pull_request:
-    branches: ['**']
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
+on: [push, pull_request]
 jobs:
-  node:
-    name: Node CI (non-blocking)
+  build:
     runs-on: ubuntu-latest
-    continue-on-error: true
-    env:
-      CI: "true"
-      NODE_OPTIONS: "--dns-result-order=ipv4first"
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - name: Print tool versions
-        run: |
-          node -v || true
-          pnpm -v || true
-          npm -v || true
-
-      - name: Configure registry and timeouts
-        run: |
-          corepack enable || true
-          pnpm config set registry https://registry.npmjs.org || true
-          pnpm config set fetch-retries 5 || true
-          pnpm config set fetch-retry-maxtimeout 600000 || true
-          pnpm config set network-timeout 600000 || true
-
-      - name: Install
-        run: pnpm -w install --no-frozen-lockfile || true
-
-      - name: Typecheck
-        run: pnpm -w typecheck || true
-
-      - name: Lint
-        run: pnpm -w lint --fix || true
-
-      - name: Vitest
-        run: pnpm -w vitest run --reporter=verbose || true
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'pnpm' }
+      - run: pnpm i
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test -- --ci
+# END HANDOVER: CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,4 @@
+<!-- BEGIN HANDOVER: CHANGELOG -->
 # Changelog
-
-## [v0.4.0-rc.1] - 2024-09-20
-
-### Seguridad y permisos
-- Autenticación OIDC reforzada con almacenamiento seguro y refresco de tokens (`src/lib/auth.ts`).
-- Validaciones de red endurecidas: `safeFetch` impide HTTP en producción y añade reintentos/timeout configurables.
-- Revisiones de permisos móviles con mensajes localizados para cámara, audio y notificaciones (`app.json`).
-- Guardias RBAC centralizadas (`src/security/acl.ts`) documentadas en README para un onboarding consistente.
-
-### Pruebas y calidad
-- Migración a Vitest para unitarias/integración con reporter verboso en CI.
-- Nuevas suites en `tests/security/` y `tests/fhir-client.spec.ts` cubren ACL, tokens y contratos FHIR.
-- Script `scripts/validate-fhir.ts` y pruebas de contrato Python aseguran conformidad con perfiles FHIR.
-- Umbral de cobertura elevado a 80 % (líneas/funciones/estatements) y documentación de reportes HTML/LCOV.
-
-### Offline y FHIR
-- Cola offline endurecida para reintentos con idempotencia al enviar bundles.
-- Prefill de pacientes y validaciones SBAR con nuevas ayudas en `src/lib/fhir-client.ts` y `src/validation/`.
-
-### DevEx y CI/CD
-- Documentación actualizada (`README.md`, `docs/DEPLOY.md`) con flujos de setup, pruebas y builds.
-- Nuevo workflow `ci.yml` con jobs paralelos (typecheck, lint, vitest) utilizando PNPM cacheado en GitHub Actions.
-- Guía de release candidate que detalla generación de artefactos y publicación del tag `v0.4.0-rc.1`.
-- Job Node marcado como no bloqueante para tolerar errores `403` de registry y documentado en README/DEPLOY.
+- Sigue Conventional Commits (feat, fix, chore, docs, ci, refactor).
+<!-- END HANDOVER: CHANGELOG -->

--- a/README.md
+++ b/README.md
@@ -1,94 +1,17 @@
-# Handover Pro
-
-Aplicación móvil para pases de turno clínico construida con React Native (Expo) y TypeScript. Incluye un backend Django opcional para pruebas locales y una cola offline que garantiza la entrega de bundles FHIR incluso con conectividad intermitente.
-
+<!-- BEGIN HANDOVER: README -->
+# Handover
 ## Requisitos
-
-- Node.js 20
-- pnpm 10
-- Expo CLI (`pnpm dlx expo install` instala dependencias nativas cuando se añaden paquetes)
-- (Opcional) Python 3.10+ y PostgreSQL/SQLite si se desea correr el backend incluido en `backend/`
-
-## Configuración de entorno
-
-1. Copia el archivo de ejemplo y ajusta las variables de OpenID Connect y FHIR:
-   ```bash
-   cp .env.example .env
-   ```
-   - `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_AUDIENCE`, `OIDC_SCOPE` y `OIDC_REDIRECT_SCHEME` alimentan el flujo de OAuth/OIDC implementado en `src/lib/auth.ts` y las guardias RBAC de `src/security/acl.ts`.
-   - `FHIR_BASE_URL` o `EXPO_PUBLIC_FHIR_BASE` define la URL consumida por `src/lib/fhir-client.ts` para leer/escribir Bundles.
-   - `EXPO_PUBLIC_ALLOWED_UNITS` y `EXPO_PUBLIC_ALLOW_ALL_UNITS` filtran el acceso a unidades clínicas específicas.
-   - `EXPO_PUBLIC_BYPASS_SCOPE` habilita cuentas de soporte que omiten filtros RBAC en situaciones operativas.
-2. Variables adicionales leídas desde Expo (`app.json > expo.extra`) o el entorno:
-   - `EXPO_PUBLIC_API_BASE_URL` (o `API_BASE_URL`) apunta al backend REST si se usa el servidor Django.
-   - `EXPO_PUBLIC_API_TOKEN` agrega un token para llamadas autenticadas contra APIs complementarias.
-   - `EXPO_PUBLIC_STORAGE_NAMESPACE` personaliza el espacio de almacenamiento seguro y el aislamiento de datos offline.
-   - `EXPO_PUBLIC_OFFLINE_REPLAY_MAX_ATTEMPTS` y `EXPO_PUBLIC_QUEUE_BACKOFF_BASE` afinan la cola offline y el backoff exponencial.
-3. Define `EXPO_TOKEN` o credenciales EAS en CI/CD cuando generes binarios firmados con Expo Application Services.
-
-## Login y permisos
-
-- El login usa OAuth 2.0/OIDC mediante `expo-auth-session`. Define permisos y roles en el backend de identidad para que el claim `role` incluya valores como `nurse`, `admin` o `viewer`.
-- En Android se solicitan permisos para cámara, micrófono y notificaciones (ver `app.json`). El flujo de QR y notas de audio depende de `android.permission.CAMERA` y `android.permission.RECORD_AUDIO` respectivamente.
-- Para pruebas sin un proveedor OIDC real, puedes habilitar la pantalla mock en `src/screens/LoginMock.tsx` ajustando las banderas de características en `app.json`.
-- Las guardias RBAC reutilizables viven en `src/security/acl.ts`; usa `ensureRole` y `ensureUnit` para proteger nuevas pantallas.
-
-## Offline y resiliencia de red
-
-- `safeFetch` en `src/lib/net.ts` fuerza HTTPS en producción, aplica timeouts y reintentos con backoff exponencial frente a errores 502/503/504, y añade cabeceras de idempotencia.
-- La cola offline (`src/lib/queue.ts` + `src/lib/sync.ts`) genera UUID por bundle, persiste en SQLite y reintenta envíos cuando detecta conectividad con `@react-native-community/netinfo`.
-- Puedes inspeccionar y vaciar la cola desde la pantalla `SyncCenter` (`src/screens/SyncCenter.tsx`).
-- Los borradores se guardan en SecureStore; al reconectar se validan mediante esquemas Zod antes de sincronizar.
-
-## Instalación y ejecución
-
-1. Instala dependencias JavaScript:
-   ```bash
-   pnpm -w install
-   ```
-2. Levanta el backend opcional (Django) si necesitas un API REST local:
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate  # Windows: .venv\Scripts\activate
-   pip install -r requirements.txt
-   python manage.py migrate
-   python manage.py runserver 0.0.0.0:8000
-   ```
-3. Arranca el cliente Expo:
-   ```bash
-   pnpm expo start
-   ```
-   Usa la app Expo Go o un emulador (`pnpm expo run:android`, `pnpm expo run:ios`, `pnpm expo start --web`).
-
-## Pruebas
-
-La automatización usa Vitest junto con utilidades específicas para FHIR y seguridad.
-
-- Revisar tipos: `pnpm -w typecheck`
-- Linter: `pnpm -w lint`
-- Unit/integration y validaciones FHIR: `pnpm -w vitest run --reporter=verbose`
-- Cobertura ≥ 80 %: `pnpm -w vitest run --reporter=verbose --coverage`
-- Validación puntual de bundles FHIR: `pnpm validate:fhir`
-
-Los umbrales de cobertura están definidos en `vitest.config.ts` y se enfocan en seguridad (`src/lib/auth.ts`, `src/lib/net.ts`), validaciones (`src/validation/schemas.ts`) y componentes críticos (`src/screens/HandoverForm.tsx`).
-El reporte HTML queda en `coverage/unit/index.html` y el `lcov.info` en `coverage/unit/lcov.info` para integrar con Codecov u otras herramientas.
-
-### CI y resiliencia del registry
-
-El workflow `CI` usa Node 20 y pnpm 10. El job de Node está configurado como “non-blocking” (`continue-on-error: true`) para mitigar errores `403` intermitentes del registry de npm; revisa los logs del paso `Install` para confirmar si ocurrió la incidencia.
-
-## Estructura relevante
-
-- `src/lib/net.ts`: capa de red con timeouts, reintentos y bloqueo de HTTP en producción.
-- `src/lib/fhir-client.ts`: cliente FHIR con manejo de OperationOutcome y cabeceras idempotentes.
-- `src/lib/queue.ts` y `src/lib/sync.ts`: sincronización offline de bundles con SQLite/Expo.
-- `scripts/validate-fhir.ts`: validación de recursos FHIR durante CI o pipelines.
-- `docs/DEPLOY.md`: guía de despliegue multiplataforma.
-
-## Despliegue y release candidate
-
-Consulta `docs/DEPLOY.md` para builds Android/iOS/Web. Las notas de la versión RC actual están en `RELEASE_NOTES.md` y los cambios detallados en `CHANGELOG.md`. Para publicar una RC:
-
-1. Ejecuta los cheques (`pnpm -w typecheck`, `pnpm -w lint`, `pnpm -w vitest run --reporter=verbose`).
-2. Genera los binarios siguiendo la guía de despliegue.
-3. Crea el tag `v0.4.0-rc.1` y sube artefactos + notas al repositorio.
+- Node 20, pnpm 9, Expo CLI, EAS CLI.
+## Cómo correr
+pnpm i && pnpm start -c
+## Build
+npx eas build -p android --profile preview
+## Tests
+pnpm test  |  detox ver /e2e
+## Variables de entorno
+Ver .env.example (usar EAS Secrets para valores reales)
+## Permisos
+Cámara (QR), Micrófono (dictado)
+## Troubleshooting
+- Limpia caché: rm -rf node_modules && pnpm i
+<!-- END HANDOVER: README -->


### PR DESCRIPTION
## Summary
- replace the CI workflow with the required pnpm-based pipeline
- reset the changelog to the standardized handover note
- update the README with the streamlined project guide

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691649c6e98c83219138685d574a023a)