### PR TITLE
feat: add mock auth provider

### DIFF
--- a/docs/mock-auth-login.md
+++ b/docs/mock-auth-login.md
@@ -1,0 +1,29 @@
+# Mock Auth Login (F1-01 / F1-02)
+
+El provider mock implementado en `src/lib/auth/AuthService.ts` expone helpers para iniciar/cerrar sesión y leer el usuario/token actual.
+
+## Credenciales fijas
+
+```
+usuario: nurse@example.com
+password: password123
+```
+
+Estas credenciales están disponibles como `MOCK_CREDENTIALS` si necesitas reusarlas en código.
+
+## Ejemplo rápido (sin UI)
+
+```ts
+import { login, getCurrentUser, getAccessToken } from '@/src/lib/auth/AuthService';
+
+async function debugMockLogin() {
+  await login({ username: 'nurse@example.com', password: 'password123' });
+  const user = await getCurrentUser();
+  const token = await getAccessToken();
+
+  console.log('usuario mock', user);
+  console.log('access token', token);
+}
+```
+
+El estado y los tokens se persisten usando `expo-secure-store`, por lo que puedes instanciar `AuthService` en otra parte del código y se hidratará automáticamente desde almacenamiento seguro.

--- a/src/lib/auth/AuthService.ts
+++ b/src/lib/auth/AuthService.ts
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+
+import { secure } from '../secure-store';
+import type {
+  AuthCredentials,
+  AuthProvider,
+  AuthState,
+  AuthToken,
+  AuthUser,
+} from './types';
+
+export type SecureStoreAdapter = {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  del(key: string): Promise<void>;
+};
+
+const AUTH_TOKEN_KEY = 'auth/token';
+const AUTH_USER_KEY = 'auth/user';
+
+export const MOCK_CREDENTIALS: AuthCredentials = {
+  username: 'nurse@example.com',
+  password: 'password123',
+};
+
+export const MOCK_USER: AuthUser = {
+  id: 'nurse-1',
+  name: 'Jane Doe',
+  email: 'nurse@example.com',
+  role: 'nurse',
+  unitIds: ['icu-adulto', 'urgencias'],
+};
+
+export const MOCK_TOKEN: AuthToken = {
+  accessToken: 'mock-access-token',
+  refreshToken: 'mock-refresh-token',
+  expiresAt: Date.now() + 60 * 60 * 1000,
+  tokenType: 'Bearer',
+  scope: 'openid profile offline_access',
+};
+
+type Listener = (state: AuthState) => void;
+
+function createDefaultSecureStoreAdapter(): SecureStoreAdapter {
+  return {
+    get: (key) => secure.get(key),
+    set: (key, value) => secure.set(key, value),
+    del: (key) => secure.del(key),
+  };
+}
+
+function cloneState(state: AuthState): AuthState {
+  return {
+    user: state.user
+      ? {
+          ...state.user,
+          unitIds: [...state.user.unitIds],
+        }
+      : null,
+    token: state.token
+      ? {
+          ...state.token,
+        }
+      : null,
+  };
+}
+
+function safeParse<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn('AuthService: failed to parse stored value', error);
+    return null;
+  }
+}
+
+export class AuthService implements AuthProvider {
+  private state: AuthState = { user: null, token: null };
+  private readonly listeners = new Set<Listener>();
+  private hydrated = false;
+  private hydrationPromise: Promise<void> | null = null;
+
+  constructor(private readonly storage: SecureStoreAdapter = createDefaultSecureStoreAdapter()) {}
+
+  private emit(): void {
+    if (!this.listeners.size) return;
+    const snapshot = cloneState(this.state);
+    for (const listener of this.listeners) {
+      try {
+        listener(snapshot);
+      } catch (error) {
+        console.error('AuthService listener error', error);
+      }
+    }
+  }
+
+  private async persistState(): Promise<void> {
+    const tasks: Promise<void>[] = [];
+    if (this.state.token) {
+      tasks.push(this.storage.set(AUTH_TOKEN_KEY, JSON.stringify(this.state.token)));
+    } else {
+      tasks.push(this.storage.del(AUTH_TOKEN_KEY));
+    }
+
+    if (this.state.user) {
+      tasks.push(this.storage.set(AUTH_USER_KEY, JSON.stringify(this.state.user)));
+    } else {
+      tasks.push(this.storage.del(AUTH_USER_KEY));
+    }
+
+    await Promise.all(tasks);
+  }
+
+  private async ensureHydrated(): Promise<void> {
+    if (this.hydrated) return;
+    if (!this.hydrationPromise) {
+      this.hydrationPromise = (async () => {
+        try {
+          const [tokenRaw, userRaw] = await Promise.all([
+            this.storage.get(AUTH_TOKEN_KEY),
+            this.storage.get(AUTH_USER_KEY),
+          ]);
+          const token = safeParse<AuthToken>(tokenRaw);
+          const user = safeParse<AuthUser>(userRaw);
+          this.state = { token, user };
+        } catch (error) {
+          console.warn('AuthService hydration failed', error);
+          this.state = { token: null, user: null };
+        } finally {
+          this.hydrated = true;
+          this.emit();
+        }
+      })().finally(() => {
+        this.hydrationPromise = null;
+      });
+    }
+    await this.hydrationPromise;
+  }
+
+  private updateState(next: AuthState): AuthState {
+    this.state = cloneState(next);
+    this.emit();
+    return cloneState(this.state);
+  }
+
+  public subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(cloneState(this.state));
+    void this.ensureHydrated();
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public getSnapshot(): AuthState {
+    return cloneState(this.state);
+  }
+
+  async login(credentials: AuthCredentials): Promise<AuthState> {
+    await this.ensureHydrated();
+    if (
+      credentials.username !== MOCK_CREDENTIALS.username ||
+      credentials.password !== MOCK_CREDENTIALS.password
+    ) {
+      throw new Error('INVALID_CREDENTIALS');
+    }
+
+    const token: AuthToken = {
+      ...MOCK_TOKEN,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    const state: AuthState = { user: { ...MOCK_USER }, token };
+    this.updateState(state);
+    await this.persistState();
+    return cloneState(this.state);
+  }
+
+  async logout(): Promise<void> {
+    await this.ensureHydrated();
+    this.updateState({ user: null, token: null });
+    await this.persistState();
+  }
+
+  async getCurrentUser(): Promise<AuthUser | null> {
+    await this.ensureHydrated();
+    return cloneState(this.state).user;
+  }
+
+  async getAccessToken(): Promise<string | null> {
+    await this.ensureHydrated();
+    return this.state.token?.accessToken ?? null;
+  }
+
+  async getAuthState(): Promise<AuthState> {
+    await this.ensureHydrated();
+    return cloneState(this.state);
+  }
+}
+
+export const authService = new AuthService();
+
+export async function login(credentials: AuthCredentials): Promise<AuthState> {
+  return authService.login(credentials);
+}
+
+export async function logout(): Promise<void> {
+  return authService.logout();
+}
+
+export async function getCurrentUser(): Promise<AuthUser | null> {
+  return authService.getCurrentUser();
+}
+
+export async function getAccessToken(): Promise<string | null> {
+  return authService.getAccessToken();
+}
+
+export function useAuthState(): AuthState {
+  useEffect(() => {
+    void authService.getAuthState();
+  }, []);
+
+  return useSyncExternalStore(
+    (listener) => authService.subscribe(listener),
+    () => authService.getSnapshot(),
+    () => authService.getSnapshot()
+  );
+}
+
+export function useLogin() {
+  return useCallback((credentials: AuthCredentials) => authService.login(credentials), []);
+}
+
+export function useLogout() {
+  return useCallback(() => authService.logout(), []);
+}
+
+export function useCurrentUser() {
+  const state = useAuthState();
+  return state.user;
+}
+
+export function useAccessToken() {
+  const state = useAuthState();
+  return state.token?.accessToken ?? null;
+}

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,0 +1,52 @@
+export type AuthToken = {
+  /** Access token (e.g. JWT) to authorize API calls. */
+  accessToken: string;
+  /** Optional refresh token to renew the access token when it expires. */
+  refreshToken: string | null;
+  /** Expiration timestamp in milliseconds since epoch. */
+  expiresAt: number;
+  /** Optional ID token issued by the identity provider. */
+  idToken?: string;
+  /** Optional scope attached to the token. */
+  scope?: string | null;
+  /** Optional token type (e.g. "Bearer"). */
+  tokenType?: string;
+};
+
+export type AuthUser = {
+  /** Unique identifier for the authenticated user. */
+  id: string;
+  /** Display name for UI purposes. */
+  name: string;
+  /** Primary email associated with the user. */
+  email: string;
+  /** Main role of the user within the app. */
+  role: 'nurse' | 'admin' | 'viewer';
+  /** Units/wards the user can access. */
+  unitIds: string[];
+};
+
+export type AuthState = {
+  /** Currently authenticated user (null if logged out). */
+  user: AuthUser | null;
+  /** Active auth token bundle (null if logged out). */
+  token: AuthToken | null;
+};
+
+export type AuthCredentials = {
+  username: string;
+  password: string;
+};
+
+export interface AuthProvider {
+  /** Perform login with the provided credentials. */
+  login(credentials: AuthCredentials): Promise<AuthState>;
+  /** Clear all auth state and revoke access. */
+  logout(): Promise<void>;
+  /** Retrieve the current authenticated user (after hydration). */
+  getCurrentUser(): Promise<AuthUser | null>;
+  /** Retrieve the active access token (after hydration). */
+  getAccessToken(): Promise<string | null>;
+  /** Snapshot the full auth state (after hydration). */
+  getAuthState(): Promise<AuthState>;
+}

--- a/tests/auth/AuthService.test.ts
+++ b/tests/auth/AuthService.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AuthService,
+  MOCK_CREDENTIALS,
+  MOCK_TOKEN,
+  MOCK_USER,
+  type SecureStoreAdapter,
+} from '@/src/lib/auth/AuthService';
+import type { AuthState } from '@/src/lib/auth/types';
+
+function createMemorySecureStore() {
+  const store = new Map<string, string>();
+  const adapter: SecureStoreAdapter = {
+    get: async (key) => store.get(key) ?? null,
+    set: async (key, value) => {
+      store.set(key, value);
+    },
+    del: async (key) => {
+      store.delete(key);
+    },
+  };
+  return { adapter, store };
+}
+
+describe('AuthService (mock provider)', () => {
+  let adapter: SecureStoreAdapter;
+  let service: AuthService;
+
+  beforeEach(() => {
+    ({ adapter } = createMemorySecureStore());
+    service = new AuthService(adapter);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs in with fixed credentials and persists state', async () => {
+    const state = await service.login(MOCK_CREDENTIALS);
+
+    expect(state.user).toEqual(MOCK_USER);
+    expect(state.token?.accessToken).toBe(MOCK_TOKEN.accessToken);
+
+    const rehydrated = new AuthService(adapter);
+    const restored = await rehydrated.getAuthState();
+
+    expect(restored.user).toEqual(MOCK_USER);
+    expect(restored.token?.accessToken).toBe(MOCK_TOKEN.accessToken);
+  });
+
+  it('rejects invalid credentials', async () => {
+    await expect(
+      service.login({ username: 'bad@example.com', password: 'nope' })
+    ).rejects.toThrow('INVALID_CREDENTIALS');
+  });
+
+  it('clears state on logout', async () => {
+    await service.login(MOCK_CREDENTIALS);
+    await service.logout();
+
+    const next = new AuthService(adapter);
+    expect(await next.getCurrentUser()).toBeNull();
+    expect(await next.getAccessToken()).toBeNull();
+  });
+
+  it('notifies subscribers on auth changes', async () => {
+    const updates: AuthState[] = [];
+    const unsubscribe = service.subscribe((state) => {
+      updates.push(state);
+    });
+
+    await service.login(MOCK_CREDENTIALS);
+    await service.logout();
+    unsubscribe();
+
+    expect(updates.length).toBeGreaterThanOrEqual(3);
+    expect(updates[0]).toEqual({ user: null, token: null });
+    expect(updates.at(-1)).toEqual({ user: null, token: null });
+  });
+});


### PR DESCRIPTION
## Summary
- define shared auth types and provider interface for Phase 1 work
- add mock AuthService with secure-store persistence plus helpers/hooks
- document mock login usage and cover behaviour with vitest specs

## Testing
- pnpm vitest run --reporter=verbose *(fails: Command "vitest" not found in workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691854627cb48321b1b4074170f32869)