### PR TITLE
feat(auth): add login screen and protected navigation (F1-03)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,14 +5,17 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import RootNavigator from '@/src/navigation/RootNavigator';
 import { AppThemeProvider } from '@/src/theme';
 import { navigationRef } from '@/src/navigation/navigation';
+import { AuthProvider } from '@/src/lib/auth/AuthContext';
 
 export default function App() {
   return (
     <SafeAreaProvider>
       <AppThemeProvider>
-        <NavigationContainer ref={navigationRef}>
-          <RootNavigator />
-        </NavigationContainer>
+        <AuthProvider>
+          <NavigationContainer ref={navigationRef}>
+            <RootNavigator />
+          </NavigationContainer>
+        </AuthProvider>
       </AppThemeProvider>
     </SafeAreaProvider>
   );

--- a/src/lib/auth/AuthContext.tsx
+++ b/src/lib/auth/AuthContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+import type { AuthCredentials, AuthState, AuthToken, AuthUser } from './types';
+import { authService, useAuthState, useLogin, useLogout } from './AuthService';
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  token: AuthToken | null;
+  state: AuthState;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (credentials: AuthCredentials) => Promise<AuthState>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+type AuthProviderProps = {
+  children: React.ReactNode;
+};
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const state = useAuthState();
+  const login = useLogin();
+  const logout = useLogout();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    authService
+      .getAuthState()
+      .catch(() => {
+        // noop - state will remain unauthenticated if hydration fails
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user: state.user,
+    token: state.token,
+    state,
+    isAuthenticated: Boolean(state.user && state.token),
+    isLoading,
+    login,
+    logout,
+  }), [state, isLoading, login, logout]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,10 +1,11 @@
 // src/navigation/RootNavigator.tsx 
 import * as React from 'react';
 import { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 // Pantallas existentes en tu proyecto
-import LoginMock from '@/src/screens/LoginMock';
+import LoginScreen from '@/src/screens/LoginScreen';
 import PatientList from '@/src/screens/PatientList';
 import AudioNote from '@/src/screens/AudioNote';
 import HandoverMain from '@/src/screens/HandoverMain'; // <- versión nueva con pestañas
@@ -12,6 +13,7 @@ import QRScan from '@/src/screens/QRScan';
 
 // Asegúrate de tener este archivo:
 import PatientDashboard from '@/src/screens/PatientDashboard';
+import { useAuth } from '@/src/lib/auth/AuthContext';
 
 export type RootStackParamList = {
   Login: undefined;
@@ -75,43 +77,60 @@ function HandoverRedirect({ route, navigation }: any) {
 }
 
 export default function RootNavigator() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
   return (
-    <Navigator initialRouteName="Login" screenOptions={{ headerShown: false }}>
-      <Screen name="Login" component={LoginMock} options={{ headerShown: false }} />
+    <Navigator
+      initialRouteName={isAuthenticated ? 'PatientList' : 'Login'}
+      screenOptions={{ headerShown: false }}
+    >
+      {isAuthenticated ? (
+        <>
+          <Screen
+            name="PatientList"
+            component={PatientList}
+            options={{ title: 'Pacientes', headerShown: true }}
+          />
 
-      <Screen
-        name="PatientList"
-        component={PatientList}
-        options={{ title: 'Pacientes', headerShown: true }}
-      />
+          {/* ÚNICA entrega de turno (versión nueva con pestañas) */}
+          <Screen
+            name="Handover"
+            component={HandoverMain}
+            options={{ title: 'Entrega de turno', headerShown: true }}
+          />
 
-      {/* ÚNICA entrega de turno (versión nueva con pestañas) */}
-      <Screen
-        name="Handover"
-        component={HandoverMain}
-        options={{ title: 'Entrega de turno', headerShown: true }}
-      />
+          <Screen
+            name="PatientDashboard"
+            component={PatientDashboard}
+            options={{ title: 'Dashboard clínico', headerShown: true }}
+          />
 
-      <Screen
-        name="PatientDashboard"
-        component={PatientDashboard}
-        options={{ title: 'Dashboard clínico', headerShown: true }}
-      />
+          <Screen
+            name="AudioNote"
+            component={AudioNote}
+            options={{ title: 'Notas de audio', headerShown: true }}
+          />
 
-      <Screen
-        name="AudioNote"
-        component={AudioNote}
-        options={{ title: 'Notas de audio', headerShown: true }}
-      />
+          <Screen
+            name="QRScan"
+            component={QRScan}
+            options={{ title: 'Escanear', headerShown: true }}
+          />
 
-      <Screen
-        name="QRScan"
-        component={QRScan}
-        options={{ title: 'Escanear', headerShown: true }}
-      />
-
-      {/* Compat temporal: rutas viejas a HandoverForm */}
-      <Screen name="HandoverForm" component={HandoverRedirect} options={{ headerShown: false }} />
+          {/* Compat temporal: rutas viejas a HandoverForm */}
+          <Screen name="HandoverForm" component={HandoverRedirect} options={{ headerShown: false }} />
+        </>
+      ) : (
+        <Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
+      )}
     </Navigator>
   );
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,40 +1,223 @@
-// src/screens/LoginScreen.tsx
-import React from 'react';
-import { View, Text, Pressable } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import { login, getSession } from '@/src/security/auth';
-import { UNITS_BY_ID } from '@/src/config/units';
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Controller, useForm } from 'react-hook-form';
+
+import { useAuth } from '@/src/lib/auth/AuthContext';
+import { MOCK_CREDENTIALS } from '@/src/lib/auth/AuthService';
+
+type LoginFormValues = {
+  username: string;
+  password: string;
+};
 
 export default function LoginScreen() {
-  const navigation = useNavigation<any>();
+  const { login } = useAuth();
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+    setValue,
+  } = useForm<LoginFormValues>({
+    defaultValues: {
+      username: '',
+      password: '',
+    },
+  });
+  const [error, setError] = useState<string | null>(null);
 
-  const onPress = async () => {
-    const allowedUnits = ["icu-a", "icu-b"];
-    await login({
-      user: { id: 'nurse-1', name: 'Demo Nurse', allowedUnits },
-      units: allowedUnits, // acceso demo restringido a unidades base
-      token: 'mock-token',
-    });
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      setError(null);
+      await login({ username: values.username.trim(), password: values.password });
+    } catch (err) {
+      const message = err instanceof Error && err.message === 'INVALID_CREDENTIALS'
+        ? 'Credenciales incorrectas. Revisa tu usuario y contraseña.'
+        : 'No se pudo iniciar sesión. Inténtalo nuevamente.';
+      setError(message);
+    }
+  });
 
-    const s = await getSession();
-    console.log('[dev] session', s?.units, s?.user?.allowedUnits);
-    (globalThis as any).__NURSEOS_SESSION_CACHE = s;
-
-    navigation.reset({
-      index: 0,
-      routes: [{ name: 'PatientList' }],
-    });
+  const handleFillMock = () => {
+    setValue('username', MOCK_CREDENTIALS.username);
+    setValue('password', MOCK_CREDENTIALS.password);
+    setError(null);
   };
 
   return (
-    <View style={{ flex: 1, padding: 16, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ fontSize: 20, fontWeight: '600', marginBottom: 12 }}>Handover Pro</Text>
-      <Pressable
-        onPress={onPress}
-        style={{ backgroundColor: '#1677ff', paddingHorizontal: 24, paddingVertical: 12, borderRadius: 8 }}
-      >
-        <Text style={{ color: 'white', fontWeight: '600' }}>Entrar (demo)</Text>
-      </Pressable>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <View style={styles.card}>
+        <Text style={styles.title}>Inicio de sesión</Text>
+        <Text style={styles.subtitle}>Usa tus credenciales de enfermería para continuar.</Text>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Usuario o email</Text>
+          <Controller
+            control={control}
+            name="username"
+            rules={{ required: 'Ingresa tu usuario o email' }}
+            render={({ field: { onChange, onBlur, value }, fieldState: { error: fieldError } }) => (
+              <>
+                <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="email-address"
+                  placeholder="nurse@example.com"
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  value={value}
+                  style={[styles.input, fieldError && styles.inputError]}
+                  accessibilityLabel="Usuario"
+                />
+                {fieldError ? <Text style={styles.errorText}>{fieldError.message}</Text> : null}
+              </>
+            )}
+          />
+        </View>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Contraseña</Text>
+          <Controller
+            control={control}
+            name="password"
+            rules={{ required: 'Ingresa tu contraseña' }}
+            render={({ field: { onChange, onBlur, value }, fieldState: { error: fieldError } }) => (
+              <>
+                <TextInput
+                  placeholder="••••••••"
+                  secureTextEntry
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  value={value}
+                  style={[styles.input, fieldError && styles.inputError]}
+                  accessibilityLabel="Contraseña"
+                />
+                {fieldError ? <Text style={styles.errorText}>{fieldError.message}</Text> : null}
+              </>
+            )}
+          />
+        </View>
+
+        {error ? <Text style={styles.formError}>{error}</Text> : null}
+
+        <Pressable
+          onPress={onSubmit}
+          style={({ pressed }) => [
+            styles.submitButton,
+            (isSubmitting || pressed) && styles.submitButtonPressed,
+          ]}
+          accessibilityRole="button"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.submitText}>Iniciar sesión</Text>
+          )}
+        </Pressable>
+
+        <Pressable onPress={handleFillMock} style={styles.mockButton} accessibilityRole="button">
+          <Text style={styles.mockButtonText}>Rellenar credenciales demo</Text>
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f2f4f7',
+    paddingHorizontal: 24,
+    justifyContent: 'center',
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 24,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 4,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#555',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#333',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d0d5dd',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    backgroundColor: '#fff',
+  },
+  inputError: {
+    borderColor: '#ff5a5f',
+  },
+  errorText: {
+    color: '#ff5a5f',
+    fontSize: 12,
+    marginTop: 6,
+  },
+  formError: {
+    color: '#ff5a5f',
+    textAlign: 'center',
+    marginBottom: 12,
+    fontSize: 14,
+  },
+  submitButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  submitButtonPressed: {
+    opacity: 0.8,
+  },
+  submitText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  mockButton: {
+    marginTop: 16,
+    alignItems: 'center',
+  },
+  mockButtonText: {
+    color: '#2563eb',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/src/screens/PatientList.tsx
+++ b/src/screens/PatientList.tsx
@@ -23,7 +23,7 @@ import { UNITS, UNITS_BY_ID, type Unit } from "@/src/config/units";
 import type { RootStackParamList } from "@/src/navigation/types";
 import { currentUser, hasUnitAccess } from "@/src/security/acl";
 import { mark } from "@/src/lib/otel";
-import { logout } from "@/src/lib/auth";
+import { useAuth } from "@/src/lib/auth/AuthContext";
 import {
   ALL_UNITS_OPTION,
   setSelectedUnitId,
@@ -147,12 +147,12 @@ function PickerSelect({ label, value, options, onValueChange, disabled }: Picker
 }
 
 export default function PatientList({ navigation }: Props) {
+  const { logout } = useAuth();
   const [selectedSpecialtyId, setSelectedSpecialtyId] = useState<string>(DEFAULT_SPECIALTY_ID);
   const selectedUnitId = useSelectedUnitId();
   const handleLogout = useCallback(async () => {
     await logout();
-    navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
-  }, [navigation]);
+  }, [logout]);
 
   useLayoutEffect(() => {
     navigation.setOptions({


### PR DESCRIPTION
## Summary
- add an AuthProvider that wraps the mock AuthService and exposes authentication state to the app tree
- replace the mock login entry with a react-hook-form based LoginScreen tied to the mock credentials
- protect the root navigator, wire logout from the patient list header, and gate the app on authentication

## Testing
- pnpm exec expo start

## Issue
- Closes F1-03

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918777a79908321acea070d4c656515)