### PR TITLE
feat: enforce auth token usage in FHIR client and offline sync

### DIFF
--- a/jest-tests/fhir-client.test.ts
+++ b/jest-tests/fhir-client.test.ts
@@ -71,6 +71,13 @@ describe('fhir-client', () => {
     expect(logout).toHaveBeenCalled();
   });
 
+  test('fetchFHIR throws when no access token is available', async () => {
+    ensureFreshToken.mockResolvedValueOnce(null);
+    await expect(fetchFHIR({ path: '/Condition' })).rejects.toThrow('NOT_AUTHENTICATED');
+    expect(fetchWithRetry).not.toHaveBeenCalled();
+    expect(logout).not.toHaveBeenCalled();
+  });
+
   test('fetchFHIR allows custom token and headers', async () => {
     (fetchWithRetry as jest.Mock).mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- wire the FHIR client to AuthService so every request requires a bearer token, logs missing credentials, and logs/logs out when the server returns 401/403
- guard the secure/offline sync drains so they pause without an authenticated user, mark unauthorized items to avoid loops, and add lightweight diagnostics
- update sync helpers and fhir-client tests to cover missing-token behaviour

## Testing
- `pnpm vitest run --reporter=verbose` *(fails: pnpm is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918812dad8c83219d43cc8d6a6ec190)