### PR TITLE
Add administrative handover section UI

### DIFF
--- a/jest-tests/fhir-validation.test.ts
+++ b/jest-tests/fhir-validation.test.ts
@@ -2,9 +2,14 @@ import { zHandover } from '@/src/validation/schemas';
 
 describe('HandoverFormSchema', () => {
   const baseValues = {
-    unitId: 'icu-1',
-    start: '2024-01-01T07:00:00Z',
-    end: '2024-01-01T15:00:00Z',
+    administrativeData: {
+      unit: 'icu-1',
+      census: 12,
+      staffIn: ['Alice'],
+      staffOut: ['Bob'],
+      shiftStart: '2024-01-01T07:00:00Z',
+      shiftEnd: '2024-01-01T15:00:00Z',
+    },
     patientId: 'patient-1',
     vitals: { rr: 18, hr: 80, spo2: 98 },
   } as const;


### PR DESCRIPTION
## Summary
- add dedicated administrative section to handover form with shift details, census, and staff lists
- wire form fields to react-hook-form including dynamic staff add/remove controls and numeric census input
- align schema validation test fixture with administrativeData structure

## Testing
- pnpm vitest run --reporter=verbose
- pnpm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b44966db08321a61fb24f80a9c5f0)