### PR TITLE
Add sensitive field inventory for offline queue

### DIFF
--- a/__tests__/lib/offlineQueue.spec.ts
+++ b/__tests__/lib/offlineQueue.spec.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as SecureStore from 'expo-secure-store';
+
+import { clearAll, enqueueTx, readQueue } from '@/src/lib/offlineQueue';
+
+afterEach(async () => {
+  await clearAll();
+  (SecureStore as any).__reset?.();
+});
+
+describe('offlineQueue sensitiveFields', () => {
+  it('marca campos sensibles cuando el payload contiene datos de paciente', async () => {
+    const payload = {
+      patientId: 'patient-123',
+      summary: 'Paciente estable',
+      vitals: { heartRate: 80 },
+    };
+
+    const item = await enqueueTx({ payload });
+    expect(item.sensitiveFields).toEqual(expect.arrayContaining(['patientId', 'summary', 'vitals']));
+
+    const [stored] = await readQueue();
+    expect(stored.sensitiveFields).toEqual(expect.arrayContaining(['patientId', 'summary', 'vitals']));
+  });
+
+  it('no marca campos sensibles en payloads técnicos sin datos de paciente', async () => {
+    const payload = { type: 'ping', timestamp: Date.now() };
+
+    const item = await enqueueTx({ payload });
+
+    expect(item.sensitiveFields ?? []).toHaveLength(0);
+    const [stored] = await readQueue();
+    expect(stored?.sensitiveFields ?? []).toHaveLength(0);
+  });
+});

--- a/src/security/sensitiveFields.ts
+++ b/src/security/sensitiveFields.ts
@@ -1,0 +1,44 @@
+export type SensitiveFieldPath = string;
+
+/**
+ * Inventario de rutas/campos que contienen datos sensibles de paciente o
+ * credenciales. Sirve para revisar periódicamente qué campos se guardan en
+ * local (cola offline, storage, etc.) y garantizar que todos ellos se
+ * almacenan cifrados.
+ *
+ * Si en el futuro se añaden nuevos datos clínicos o tokens al storage local,
+ * deben añadirse aquí para mantener el inventario actualizado.
+ */
+export const SENSITIVE_FIELDS: SensitiveFieldPath[] = [
+  // Identificación de paciente
+  'patientId',
+  'patient.id',
+  'patient.identifier',
+  'patient.name',
+  'administrativeData.unit',
+  'administrativeData.staffIn',
+  'administrativeData.staffOut',
+  'administrativeData.shiftStart',
+  'administrativeData.shiftEnd',
+  'administrativeData.census',
+
+  // Contenido clínico del handover
+  'diagnosis',
+  'evolution',
+  'vitals',
+  'vitalsHistory',
+  'devices',
+  'medications',
+  'exams',
+  'examsPending',
+  'risks',
+  'incidents',
+  'summary',
+  'audioNotes',
+  'attachments',
+
+  // Autenticación / tokens
+  'auth.accessToken',
+  'auth.refreshToken',
+  'auth.userId',
+];


### PR DESCRIPTION
## Summary
- add documented inventory of sensitive field paths for local storage
- annotate offline queue items with detected sensitive field metadata
- cover sensitiveFields tagging with new offline queue tests

## Testing
- pnpm vitest run --reporter=verbose *(fails: existing suite errors unrelated to change, e.g., missing Expo Secure Store module, zod passthrough usage, auth OIDC config, safeFetch exports)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5e68b9748321abd08b46e04de849)