### PR TITLE
docs(audit): reconcile AUDITORIA_09.04.2026 with current main and fix document drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Importante: este paquete queda ahora en estado piloto-grade trazable; no declara
      - `EXPO_PUBLIC_OIDC_SCOPE` (por ejemplo `openid profile email offline_access` para refresh tokens).
      - El flujo se resuelve en `src/security/OAuthService.ts` y se integra en `src/security/auth.tsx`; las guardias RBAC viven en `src/security/acl.ts`.
     - `FHIR_BASE_URL` o `EXPO_PUBLIC_FHIR_BASE` define la URL consumida por `src/lib/fhir-client.ts` para leer/escribir Bundles.
-    - `EXPO_PUBLIC_ALLOWED_UNITS` y `EXPO_PUBLIC_ALLOW_ALL_UNITS` filtran el acceso a unidades clínicas específicas.
-    - `EXPO_PUBLIC_BYPASS_SCOPE` habilita cuentas de soporte que omiten filtros RBAC en situaciones operativas.
+    - `EXPO_PUBLIC_ALLOWED_UNITS` restringe el acceso del cliente a unidades clínicas explícitas.
+    - `EXPO_PUBLIC_ALLOW_ALL_UNITS` y `EXPO_PUBLIC_BYPASS_SCOPE` quedan como flags legacy de compatibilidad/configuración, pero no abren bypass RBAC ni acceso total en el runtime actual; `src/security/acl.ts` y sus tests fallan en cerrado.
     - `HANDOVER_FHIR_VALIDATION_MODE`: controla la validación de Bundles FHIR en el backend Django/DRF.
       - `"off"` (por defecto): el backend reenviará los Bundles sin validarlos.
       - `"remote"`: se invocará `$validate` contra el servidor FHIR (`FHIR_BASE/Bundle/$validate`) antes de reenviar; si se detectan errores `error`/`fatal` se responderá `422` con detalles.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -63,8 +63,8 @@ Ese wrapper ahora replica el gate JS sensible real del repo (`typecheck`, `lint:
 - `EXPO_PUBLIC_API_BASE_URL`
 - `EXPO_PUBLIC_FHIR_BASE_URL`
 - `EXPO_PUBLIC_ALLOWED_UNITS`
-- `EXPO_PUBLIC_ALLOW_ALL_UNITS`
-- `EXPO_PUBLIC_BYPASS_SCOPE`
+- `EXPO_PUBLIC_ALLOW_ALL_UNITS` (legacy no-op en el runtime actual)
+- `EXPO_PUBLIC_BYPASS_SCOPE` (legacy no-op; no habilita bypass RBAC)
 - `EXPO_PUBLIC_STORAGE_NAMESPACE`
 - `EXPO_PUBLIC_OFFLINE_REPLAY_MAX_ATTEMPTS`
 - `EXPO_PUBLIC_QUEUE_BACKOFF_BASE`

--- a/docs/clinical-decision-log-template-nnn-icea.md
+++ b/docs/clinical-decision-log-template-nnn-icea.md
@@ -1,6 +1,6 @@
 # Registro operativo de decisiones clinicas de IA (NNN + ICEA+)
 
-> Estado real del repo: HANDOVER no persiste todavia un log dedicado de `accepted/rejected/modified` para sugerencias NNN o ICEA+. Este documento es una plantilla operativa para el piloto, anclada a IDs tecnicos que el repo si genera.
+> Estado real del repo: HANDOVER ya persiste eventos dedicados de decision clinica para superficies IA cableadas en SBAR/NIC/NOC mediante `ClinicalDecisionEvent` y `/api/ai/clinical-decision`, pero todavia no persiste un feedback clinico dedicado para salidas ICEA+ ni cubre automaticamente cualquier sugerencia futura fuera de esas superficies. Esta plantilla sigue siendo util como complemento operativo del piloto y para correlacion con IDs tecnicos del repo.
 
 ## 1) Que si existe hoy para correlacion
 
@@ -16,15 +16,15 @@
 
 ## 2) Que no existe hoy
 
-- No hay modelo backend dedicado a "decision clinica de sugerencia".
-- La UI NNN no guarda automaticamente si una sugerencia NIC/NOC/NANDA fue aceptada, rechazada o modificada.
-- ICEA+ expone estado y resumen, pero no una entidad de feedback clinico persistente en este repo.
+- No existe todavia una entidad dedicada de feedback clinico persistente para salidas ICEA+.
+- La cobertura automatizada del decision log sigue limitada a superficies IA ya cableadas (SBAR/NIC/NOC), no a cualquier sugerencia futura o flujo operativo externo.
+- Esta plantilla sigue siendo necesaria cuando el piloto requiera conciliacion manual fuera de esas superficies o correlacion transversal con procesos institucionales.
 
 Por tanto, para un piloto:
 
-1. el registro debe mantenerse fuera de banda o en una exportacion controlada;
+1. el registro puede apoyarse en el log dedicado del repo para SBAR/NIC/NOC, pero debe mantenerse fuera de banda o en una exportacion controlada cuando el caso sea ICEA+ o una superficie no cableada;
 2. cada fila debe enlazarse a `request_id` y, si aplica, `bridge_request_id`;
-3. no debe afirmarse que este log ya esta automatizado por HANDOVER.
+3. no debe afirmarse que toda la gobernanza NNN + ICEA+ ya esta automatizada de punta a punta por HANDOVER.
 
 ## 3) Estructura minima recomendada
 


### PR DESCRIPTION
## Resumen

Este PR reconcilia `AUDITORIA_09.04.2026.docx` contra el estado real actual de `main` y corrige drift documental mínimo detectado durante esa revisión.

El hallazgo principal fue documental, no de runtime: la mayoría de los claims críticos del Word estaban desactualizados frente al árbol actual del repo. Por eso este PR se limita a ajustar documentación que seguía describiendo comportamientos que ya no corresponden al sistema real.

## Qué cambia

- `README.md`
  - Aclara que `EXPO_PUBLIC_ALLOWED_UNITS` restringe el acceso del cliente a unidades explícitas.
  - Marca `EXPO_PUBLIC_ALLOW_ALL_UNITS` y `EXPO_PUBLIC_BYPASS_SCOPE` como flags legacy/no-op en el runtime actual.
  - Elimina la narrativa de bypass RBAC desde flags públicos.

- `docs/DEPLOY.md`
  - Alinea la documentación de despliegue con el comportamiento real de esos flags legacy.
  - Evita interpretar `EXPO_PUBLIC_BYPASS_SCOPE` como un bypass operativo válido.

- `docs/clinical-decision-log-template-nnn-icea.md`
  - Corrige la afirmación de que HANDOVER no persistía eventos dedicados de decisión clínica.
  - Deja explícito el estado real:
    - sí existe persistencia de `ClinicalDecisionEvent` para superficies IA ya cableadas en SBAR/NIC/NOC;
    - no existe todavía feedback clínico dedicado para salidas ICEA+;
    - no toda la gobernanza NNN + ICEA+ está automatizada de punta a punta.

## Qué no cambia

- No hay cambios de código runtime.
- No se tocan contratos backend/frontend.
- No se modifican FHIR mappings, sync, auth, RBAC ni bridge ICEA.
- No se cierra aquí una auditoría completa de secretos, trazabilidad universal por campo ni un barrido E2E global del frontend.

## Validaciones ejecutadas

- `pnpm -w typecheck`
- `pnpm -w lint:ci`

## Alcance y lectura correcta

Este PR debe leerse como una **reconciliación documental del Word vs main** y una **corrección puntual de drift**.

No certifica el repositorio como completamente auditado ni production-ready; solo alinea la documentación afectada con el comportamiento real actualmente observado en `main`.