### PR TITLE
refactor(sync): unify HANDOVER replay on the canonical secure offline queue

### DIFF
--- a/docs/offline-sync-and-queue.md
+++ b/docs/offline-sync-and-queue.md
@@ -16,8 +16,9 @@
 - `index.ts` is the only active Expo/mobile entrypoint in this repo cut. It registers the root component from `App.tsx`.
 - `App.tsx` is the active mobile bootstrap path. It mounts auth/navigation providers and installs queue replay through `src/lib/queueBootstrap.ts`.
 - `src/lib/sync.ts` is the canonical sync runtime for queue state, retry scheduling, and `SyncSnapshot`.
-- `src/lib/sync/index.ts` remains a legacy compatibility facade with residual runtime dependencies from `src/lib/queueBootstrap.ts`, `src/screens/SyncCenter.tsx`, `src/screens/handover/useHandoverSyncStatus.ts`, `src/components/SyncStatusBanner.tsx`, and `src/components/OfflineBanner.tsx`. It is not the source of truth for queue state.
-- `src/lib/offlineQueue.ts` is a residual compatibility adapter over the canonical queue storage in `src/lib/queue.ts`; keep it only while those `sync/index.ts` callers exist.
+- `src/lib/queueBootstrap.ts`, `src/screens/SyncCenter.tsx`, `src/screens/handover/useHandoverSyncStatus.ts`, `src/components/SyncStatusBanner.tsx`, and `src/components/OfflineBanner.tsx` now call `src/lib/sync.ts` directly for replay/runtime state.
+- `src/lib/sync/index.ts` remains only as a thin compatibility shim over `src/lib/sync.ts`; it no longer owns replay state or drains a separate queue path.
+- `src/lib/offlineQueue.ts` is a residual compatibility adapter over the canonical queue storage in `src/lib/queue.ts`. It is not part of the active HANDOVER replay/runtime path for handover bundles.
 - `main.py` is absent from the current repository state. The active Python/Django operational entrypoints are `manage.py`, `Procfile` (`gunicorn backend.wsgi ...`), `.github/workflows/django.yml` (`python manage.py migrate`, `pytest`), and `docker-compose.yml` (web export build only; Django is documented as a separate Procfile-compatible service).
 
 ## Transaction identifiers (txId)
@@ -26,9 +27,16 @@
 - The txId is also reflected in `Bundle.identifier` (`system=urn:handover-pro:tx`) for traceability.
 
 ## Queue item identifiers (offline queue)
-- `computeId(fullUrls: string[])` (`src/lib/sync.ts`) builds a deterministic ID for an offline queue item by sorting the entry `fullUrl` values, joining them, and hashing the result with `hashHex`.
+- `buildOfflineQueueId(...)` (`src/lib/queue.ts`) is the canonical identity builder for handover bundles. It hashes a stable serialization of `patientId`, `payloadType`, and the bundle payload so replay deduplicates on deterministic clinical identity instead of transient runtime state.
+- `computeId(fullUrls: string[])` (`src/lib/sync.ts`) remains scoped to the residual secure-store compatibility queue and is no longer the operational identity source for handover bundle replay.
 - `hashHex` (`src/lib/crypto.ts`) uses SHA-256 and returns a configurable hex prefix (default 64 chars). This makes it deterministic while keeping IDs compact.
-- The goal is to detect duplicates and avoid enqueueing the same resource set twice. Hash collisions are astronomically unlikely, but if they ever occur the safe mitigation is to compare the original `fullUrl` lists before skipping an enqueue.
+- The operational goal is to detect duplicates and avoid enqueueing the same clinical bundle identity twice. Hash collisions are astronomically unlikely; if they ever occur the safe mitigation is to compare the original payload identity inputs before skipping an enqueue.
+
+## Canonical queue invariants
+- Local persistence for handover bundles is `handover_offline_queue` in `src/lib/queue.ts`, with encrypted payload-at-rest and plaintext metadata limited to non-PHI control fields.
+- Queue status is explicit and finite: `pending`, `inFlight`, `error`, `synced`. The canonical runtime in `src/lib/sync.ts` is the only active writer of replay status transitions.
+- Replay is safe by construction: canonical sends reuse the persisted payload, keep idempotency headers stable (`txId` or queue item id), and treat `409/412` as delivered evidence instead of duplicate writes.
+- Deduplication is based on stable identity (`buildOfflineQueueId`) so the same handover bundle does not fork into multiple queue rows across retry/reopen flows.
 
 ## Other identifiers and hash usage
 - `hashHex` also backs other deterministic identifiers such as `fhirId` (`src/lib/crypto.ts`) and several resource ID helpers in `src/lib/fhir-map.ts`.
@@ -85,7 +93,7 @@
   - `paused`: blocked by authentication (401/403) until re-login or `resumeSync()`.
 
 ## Compatibility aliases and migration notes
-- `flushQueueNow` (legacy UI helper in `src/lib/sync/index.ts` and legacy queue alias in `src/lib/sync.ts`) is deprecated in favor of `flushQueue`.
+- `flushQueueNow` (legacy UI helper in `src/lib/sync/index.ts` and legacy queue alias in `src/lib/sync.ts`) is deprecated in favor of the canonical runtime entrypoints in `src/lib/sync.ts`.
 - `postBundleSmart` (alias of `postBundle` in `src/lib/fhir-client.ts`) is deprecated. Prefer `postBundle`.
 - These aliases remain for compatibility but will be removed in a future major release. Update imports to the canonical names when migrating.
 

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { View, Text, Pressable, StyleSheet, useColorScheme } from 'react-native';
 import { useNetInfo } from '@/src/lib/netinfo';
-import { getQueueSize } from '@/src/lib/sync/index';
+import { getCanonicalQueueSize } from '@/src/lib/sync';
 
 type Props = { onPress?: () => void };
 
@@ -20,7 +20,7 @@ export default function OfflineBanner({ onPress }: Props) {
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const refresh = React.useCallback(async () => {
-    const n = await getQueueSize();
+    const n = await getCanonicalQueueSize();
     setCount(n < 0 ? 0 : n);
   }, []);
 

--- a/src/components/SyncStatusBanner.tsx
+++ b/src/components/SyncStatusBanner.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { getSyncSnapshot, subscribeSyncStatus, type SyncSnapshot } from '@/src/lib/sync';
-import { getQueueSize } from '@/src/lib/sync/index';
+import { getCanonicalQueueSize, getSyncSnapshot, subscribeSyncStatus, type SyncSnapshot } from '@/src/lib/sync';
 import type { RootStackParamList } from '@/src/navigation/types';
 import { useThemeTokens } from '@/src/theme';
 import { useTranslation } from '@/src/i18n';
@@ -70,7 +69,7 @@ export default function SyncStatusBanner({ onOpenSyncCenter }: Props) {
     let active = true;
 
     const refreshQueueCount = async () => {
-      const count = await getQueueSize().catch(() => -1);
+      const count = await getCanonicalQueueSize().catch(() => -1);
       if (!active) return;
       setCanonicalPendingCount(count < 0 ? 0 : count);
     };

--- a/src/components/__tests__/SyncStatusBanner.spec.tsx
+++ b/src/components/__tests__/SyncStatusBanner.spec.tsx
@@ -33,6 +33,7 @@ vi.mock('@/src/i18n', () => ({
 }));
 
 vi.mock('@/src/lib/sync', () => ({
+  getCanonicalQueueSize: (...args: unknown[]) => queueSizeMock(...args),
   getSyncSnapshot: () => ({
     status: 'idle',
     lastRunAt: null,
@@ -58,10 +59,6 @@ vi.mock('@/src/lib/sync', () => ({
     });
     return () => {};
   },
-}));
-
-vi.mock('@/src/lib/sync/index', () => ({
-  getQueueSize: (...args: unknown[]) => queueSizeMock(...args),
 }));
 
 describe('SyncStatusBanner', () => {

--- a/src/lib/__tests__/queueBootstrap.auth.spec.ts
+++ b/src/lib/__tests__/queueBootstrap.auth.spec.ts
@@ -2,15 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const ensureFreshAccessTokenMock = vi.fn();
 const startSyncDaemonMock = vi.fn();
-const flushQueueMock = vi.fn();
+const flushSyncQueueMock = vi.fn();
 
 vi.mock('@/src/security/auth', () => ({
   ensureFreshAccessToken: (...args: unknown[]) => ensureFreshAccessTokenMock(...args),
 }));
 
-vi.mock('@/src/lib/sync/index', () => ({
+vi.mock('@/src/lib/sync', () => ({
   startSyncDaemon: (...args: unknown[]) => startSyncDaemonMock(...args),
-  flushQueue: (...args: unknown[]) => flushQueueMock(...args),
+  flushSyncQueue: (...args: unknown[]) => flushSyncQueueMock(...args),
 }));
 
 vi.mock('@/src/config/env', () => ({
@@ -48,13 +48,13 @@ describe('queueBootstrap auth seam', () => {
   it('flushNow ignores EXPO_PUBLIC_AUTH_TOKEN as an auth bypass', async () => {
     process.env.EXPO_PUBLIC_AUTH_TOKEN = 'public-token';
     ensureFreshAccessTokenMock.mockResolvedValue(null);
-    flushQueueMock.mockResolvedValue({ processed: 0, remaining: 1 });
+    flushSyncQueueMock.mockResolvedValue({ processed: 0, remaining: 1 });
 
     const { flushNow } = await loadQueueBootstrap();
     await flushNow();
 
-    expect(flushQueueMock).toHaveBeenCalledTimes(1);
-    const syncOpts = flushQueueMock.mock.calls[0]?.[0];
+    expect(flushSyncQueueMock).toHaveBeenCalledTimes(1);
+    const syncOpts = flushSyncQueueMock.mock.calls[0]?.[0];
     await expect(syncOpts.getToken()).resolves.toBeNull();
     expect(ensureFreshAccessTokenMock).toHaveBeenCalledWith('fhir');
   });

--- a/src/lib/__tests__/sync.index.auth.spec.ts
+++ b/src/lib/__tests__/sync.index.auth.spec.ts
@@ -1,15 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const configureFHIRClientMock = vi.fn();
-const postBundleMock = vi.fn();
-const runQueueFlushMock = vi.fn();
-const readQueueMock = vi.fn();
-const addEventListenerMock = vi.fn(() => vi.fn());
-const fetchNetworkMock = vi.fn(async () => ({ isConnected: true, isInternetReachable: true }));
+const flushSyncQueueMock = vi.fn();
+const startSyncDaemonMock = vi.fn(() => vi.fn());
+const getCanonicalQueueSizeMock = vi.fn();
+const consumeRecentlySyncedQueueItemMock = vi.fn();
 
-vi.mock('@/src/lib/fhir-client', () => ({
-  configureFHIRClient: (...args: unknown[]) => configureFHIRClientMock(...args),
-  postBundle: (...args: unknown[]) => postBundleMock(...args),
+vi.mock('@/src/lib/sync', () => ({
+  flushSyncQueue: (...args: unknown[]) => flushSyncQueueMock(...args),
+  startSyncDaemon: (...args: unknown[]) => startSyncDaemonMock(...args),
+  getCanonicalQueueSize: (...args: unknown[]) => getCanonicalQueueSizeMock(...args),
+  consumeRecentlySyncedQueueItem: (...args: unknown[]) => consumeRecentlySyncedQueueItemMock(...args),
+}));
+
+vi.mock('@/src/lib/queue', () => ({
+  enqueueBundle: vi.fn(),
+}));
+
+vi.mock('@/src/lib/netinfo', () => ({
+  default: {
+    fetch: vi.fn(async () => ({ isConnected: true, isInternetReachable: true })),
+  },
 }));
 
 vi.mock('@/src/lib/fhir-validation/zod', () => ({
@@ -17,251 +27,57 @@ vi.mock('@/src/lib/fhir-validation/zod', () => ({
   validateResourceWithZod: vi.fn(() => ({ isValid: true, errors: [] })),
 }));
 
-vi.mock('@/src/lib/offlineQueue', () => ({
-  enqueueTx: vi.fn(),
-  flushQueue: (...args: unknown[]) => runQueueFlushMock(...args),
-  readQueue: (...args: unknown[]) => readQueueMock(...args),
-}));
-
-vi.mock('@/src/lib/netinfo', () => ({
-  default: {
-    addEventListener: (...args: unknown[]) => addEventListenerMock(...args),
-    fetch: (...args: unknown[]) => fetchNetworkMock(...args),
-  },
-}));
-
-const bundle = {
-  resourceType: 'Bundle' as const,
-  type: 'transaction' as const,
-  entry: [
-    {
-      fullUrl: 'urn:uuid:obs-1',
-      resource: {
-        resourceType: 'Observation',
-        status: 'final',
-        category: [
-          {
-            coding: [
-              { system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' },
-            ],
-          },
-        ],
-        code: { coding: [{ system: 'http://loinc.org', code: '8867-4' }] },
-        subject: { reference: 'Patient/p-1' },
-        effectiveDateTime: '2024-01-01T00:00:00.000Z',
-      },
-      request: { method: 'POST', url: 'Observation' },
-    },
-  ],
-};
-
 async function loadSyncIndex() {
   return import('@/src/lib/sync/index');
 }
 
-describe('legacy sync runtime auth seam', () => {
+describe('legacy sync compatibility shim', () => {
   beforeEach(() => {
     vi.resetModules();
-    configureFHIRClientMock.mockReset();
-    postBundleMock.mockReset();
-    runQueueFlushMock.mockReset();
-    readQueueMock.mockReset();
-    addEventListenerMock.mockReset();
-    fetchNetworkMock.mockReset();
-    addEventListenerMock.mockReturnValue(vi.fn());
-    fetchNetworkMock.mockResolvedValue({ isConnected: true, isInternetReachable: true });
-    delete process.env.EXPO_PUBLIC_AUTH_TOKEN;
+    vi.clearAllMocks();
   });
 
-  it('fails safe without a valid session token and does not drain the queue', async () => {
-    readQueueMock.mockResolvedValue([{ key: 'queued-1' }]);
-    const getToken = vi.fn(async () => null);
+  it('delegates manual flush to the canonical sync runtime', async () => {
+    flushSyncQueueMock.mockResolvedValue({ processed: 0, remaining: 1, outcome: 'auth-required', status: 401 });
 
     const { flushQueue } = await loadSyncIndex();
-    const result = await flushQueue({
+    const opts = {
       fhirBaseUrl: 'https://fhir.test/api',
-      getToken,
-    });
+      getToken: async () => null,
+    };
 
-    expect(result).toEqual({ processed: 0, remaining: 1, outcome: 'auth-required', status: 401 });
-    expect(getToken).toHaveBeenCalledTimes(1);
-    expect(runQueueFlushMock).not.toHaveBeenCalled();
-    expect(postBundleMock).not.toHaveBeenCalled();
+    await expect(flushQueue(opts)).resolves.toEqual({
+      processed: 0,
+      remaining: 1,
+      outcome: 'auth-required',
+      status: 401,
+    });
+    expect(flushSyncQueueMock).toHaveBeenCalledWith(opts);
   });
 
-  it('preserves auth-failed when the token refresher throws and does not drain the queue', async () => {
-    readQueueMock.mockResolvedValue([{ key: 'queued-1' }]);
-    const getToken = vi.fn(async () => {
-      throw new Error('refresh exploded');
-    });
+  it('delegates daemon startup to the canonical sync runtime', async () => {
+    const stop = vi.fn();
+    startSyncDaemonMock.mockReturnValue(stop);
 
-    const { flushQueue } = await loadSyncIndex();
-    const result = await flushQueue({
+    const { startSyncDaemon } = await loadSyncIndex();
+    const opts = {
       fhirBaseUrl: 'https://fhir.test/api',
-      getToken,
-    });
+      getToken: async () => 'token',
+    };
 
-    expect(result).toEqual({ processed: 0, remaining: 1, outcome: 'auth-failed', status: 401 });
-    expect(getToken).toHaveBeenCalledTimes(1);
-    expect(runQueueFlushMock).not.toHaveBeenCalled();
-    expect(postBundleMock).not.toHaveBeenCalled();
+    expect(startSyncDaemon(opts)).toBe(stop);
+    expect(startSyncDaemonMock).toHaveBeenCalledWith(opts);
   });
 
-  it('uses a fresh session token per replay item and not EXPO_PUBLIC_AUTH_TOKEN', async () => {
-    process.env.EXPO_PUBLIC_AUTH_TOKEN = 'public-token';
-    readQueueMock.mockResolvedValue([]);
-    postBundleMock.mockResolvedValue({ ok: true, status: 200 });
-    runQueueFlushMock.mockImplementation(async (sender: (tx: unknown) => Promise<unknown>) => {
-      await sender({
-        id: 'queued-1',
-        key: 'queued-1',
-        tries: 0,
-        payload: {
-          bundle,
-          meta: { hash: 'idem-1' },
-        },
-      });
-      await sender({
-        id: 'queued-2',
-        key: 'queued-2',
-        tries: 0,
-        payload: {
-          bundle,
-          meta: { hash: 'idem-2' },
-        },
-      });
-    });
-    const getToken = vi
-      .fn()
-      .mockResolvedValueOnce('session-token-1')
-      .mockResolvedValueOnce('session-token-2')
-      .mockResolvedValueOnce('session-token-3');
+  it('reads queue size and recent sync evidence from the canonical runtime', async () => {
+    getCanonicalQueueSizeMock.mockResolvedValue(3);
+    consumeRecentlySyncedQueueItemMock.mockReturnValue(true);
 
-    const { flushQueue } = await loadSyncIndex();
-    const result = await flushQueue({
-      fhirBaseUrl: 'https://fhir.test/api',
-      getToken,
-    });
+    const { consumeRecentlySyncedQueueItem, getQueueSize } = await loadSyncIndex();
 
-    expect(result).toEqual({ processed: 2, remaining: 0, outcome: 'success', status: undefined });
-    expect(runQueueFlushMock).toHaveBeenCalledTimes(1);
-    expect(getToken).toHaveBeenCalledTimes(3);
-    expect(postBundleMock).toHaveBeenNthCalledWith(1, bundle, {
-      token: 'session-token-2',
-      headers: { 'Idempotency-Key': 'idem-1' },
-    });
-    expect(postBundleMock).toHaveBeenNthCalledWith(2, bundle, {
-      token: 'session-token-3',
-      headers: { 'Idempotency-Key': 'idem-2' },
-    });
-  });
-
-  it('does not record success evidence when a queue item has no bundle payload', async () => {
-    readQueueMock.mockResolvedValue([{ key: 'queued-empty' }]);
-    runQueueFlushMock.mockImplementation(async (sender: (tx: unknown) => Promise<unknown>) => {
-      await sender({
-        id: 'queued-empty',
-        key: 'queued-empty',
-        tries: 0,
-        payload: {},
-      });
-    });
-
-    const { consumeRecentlySyncedQueueItem, flushQueue } = await loadSyncIndex();
-    const result = await flushQueue({
-      fhirBaseUrl: 'https://fhir.test/api',
-      getToken: async () => 'session-token',
-    });
-
-    expect(result).toEqual({ processed: 0, remaining: 1, outcome: 'client-error', status: 422 });
-    expect(consumeRecentlySyncedQueueItem('queued-empty')).toBe(false);
-    expect(postBundleMock).not.toHaveBeenCalled();
-  });
-
-  it('distinguishes auth outcomes from server failures', async () => {
-    readQueueMock.mockResolvedValue([{ key: 'queued-1' }]);
-    runQueueFlushMock.mockImplementation(async (sender: (tx: unknown) => Promise<unknown>) => {
-      await sender({
-        id: 'queued-1',
-        key: 'queued-1',
-        tries: 0,
-        payload: {
-          bundle,
-          meta: { hash: 'idem-1' },
-        },
-      });
-    });
-
-    postBundleMock.mockResolvedValueOnce({ ok: false, status: 401 });
-    const { flushQueue } = await loadSyncIndex();
-    const authResult = await flushQueue({
-      fhirBaseUrl: 'https://fhir.test/api',
-      getToken: async () => 'session-token',
-      backoff: { retries: 0, minMs: 0, maxMs: 0 },
-    });
-
-    postBundleMock.mockResolvedValueOnce({ ok: false, status: 503 });
-    const serverResult = await flushQueue({
-      fhirBaseUrl: 'https://fhir.test/api',
-      getToken: async () => 'session-token',
-      backoff: { retries: 0, minMs: 0, maxMs: 0 },
-    });
-
-    expect(authResult).toEqual({ processed: 0, remaining: 1, outcome: 'auth-required', status: 401 });
-    expect(serverResult).toEqual({ processed: 0, remaining: 1, outcome: 'server-error', status: 503 });
-  });
-
-  it('treats 409 idempotent conflicts as remote success evidence without retry loops', async () => {
-    readQueueMock.mockResolvedValueOnce([]);
-    runQueueFlushMock.mockImplementation(async (sender: (tx: unknown) => Promise<unknown>) => {
-      await sender({
-        id: 'queued-409',
-        key: 'queued-409',
-        tries: 0,
-        payload: {
-          bundle,
-          meta: { hash: 'idem-409' },
-        },
-      });
-    });
-    postBundleMock.mockResolvedValueOnce({ ok: false, status: 409, body: {} });
-
-    const { flushQueue } = await loadSyncIndex();
-    const result = await flushQueue({
-      fhirBaseUrl: 'https://fhir.test/api',
-      getToken: async () => 'session-token',
-      backoff: { retries: 3, minMs: 0, maxMs: 0 },
-    });
-
-    expect(result).toEqual({ processed: 1, remaining: 0, outcome: 'success', status: undefined });
-    expect(postBundleMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps transport status 0 retryable inside replay backoff', async () => {
-    readQueueMock.mockResolvedValueOnce([]);
-    runQueueFlushMock.mockImplementation(async (sender: (tx: unknown) => Promise<unknown>) => {
-      await sender({
-        id: 'queued-network',
-        key: 'queued-network',
-        tries: 0,
-        payload: {
-          bundle,
-          meta: { hash: 'idem-network' },
-        },
-      });
-    });
-    postBundleMock
-      .mockResolvedValueOnce({ ok: false, status: 0, body: { error: 'network down' } })
-      .mockResolvedValueOnce({ ok: true, status: 200 });
-
-    const { flushQueue } = await loadSyncIndex();
-    const result = await flushQueue({
-      fhirBaseUrl: 'https://fhir.test/api',
-      getToken: async () => 'session-token',
-      backoff: { retries: 1, minMs: 0, maxMs: 0 },
-    });
-
-    expect(result).toEqual({ processed: 1, remaining: 0, outcome: 'success', status: undefined });
-    expect(postBundleMock).toHaveBeenCalledTimes(2);
+    await expect(getQueueSize()).resolves.toBe(3);
+    expect(consumeRecentlySyncedQueueItem('queued-1')).toBe(true);
+    expect(getCanonicalQueueSizeMock).toHaveBeenCalledTimes(1);
+    expect(consumeRecentlySyncedQueueItemMock).toHaveBeenCalledWith('queued-1');
   });
 });

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -992,9 +992,9 @@ export async function enqueueBundle(bundle: unknown, meta: BundleMeta = {}) {
     enqueuedAt: new Date().toISOString(),
   };
 
-  // Canonical handover write path: UI, sync.ts and sync/index.ts must observe the
+  // Canonical handover write path: UI and the sync runtime persist into the
   // same secure offline queue instead of splitting across tx_queue and
-  // handover_offline_queue.
+  // handover_offline_queue. sync/index.ts is only a compatibility shim.
   return enqueueOfflineQueueItem({
     id: key,
     patientId,

--- a/src/lib/queueBootstrap.ts
+++ b/src/lib/queueBootstrap.ts
@@ -1,10 +1,10 @@
 import { configureFHIRClient, postBundle } from './fhir-client';
 import { ENV, FHIR_BASE_URL } from '../config/env';
-import { startSyncDaemon, flushQueue, type SyncOpts } from './sync/index';
+import { startSyncDaemon, flushSyncQueue, type SyncOpts } from './sync';
 import { ensureFreshAccessToken } from '../security/auth';
 
-// Legacy bootstrap adapter kept only because the active App.tsx still wires the
-// older replay facade from src/lib/sync/index.ts during app startup.
+// App.tsx remains the active mobile bootstrap entrypoint; wire it directly to the
+// canonical sync runtime so replay does not fork through the legacy facade.
 async function getLegacyBootstrapSessionToken(): Promise<string | null> {
   try {
     return (await ensureFreshAccessToken('fhir')) ?? null;
@@ -52,5 +52,5 @@ export async function flushNow() {
     fhirBaseUrl: ENV.FHIR_BASE_URL ?? FHIR_BASE_URL,
     getToken: getLegacyBootstrapSessionToken,
   };
-  await flushQueue(opts);
+  await flushSyncQueue(opts);
 }

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -10,7 +10,7 @@ import {
   type HandoverValues,
 } from './fhir-map';
 import type { AdministrativeData } from '../types/administrative';
-import { postBundle, type ResponseLike } from './fhir-client';
+import { configureFHIRClient, postBundle, type ResponseLike } from './fhir-client';
 import { formatIssuesForUser, hasFatalOutcome, type OperationIssue } from './fhir-outcome';
 import { hashHex } from './crypto';
 import { z } from 'zod';
@@ -100,11 +100,32 @@ export type SyncSnapshot = {
 type SyncListener = (snapshot: SyncSnapshot) => void;
 
 type SyncEngineOptions = {
-  getToken: () => Promise<string>;
+  getToken: () => Promise<string | null>;
   validation?: ValidationOptions;
   onAuthError?: (error: Error) => void;
   isOnline?: () => Promise<boolean>;
   sender?: QueueSendHandler;
+};
+
+export type SyncOpts = {
+  fhirBaseUrl: string;
+  getToken: () => Promise<string | null>;
+  backoff?: { retries?: number; minMs?: number; maxMs?: number };
+};
+
+export type FlushOutcome =
+  | 'success'
+  | 'auth-required'
+  | 'auth-failed'
+  | 'network-error'
+  | 'server-error'
+  | 'client-error';
+
+export type FlushResult = {
+  processed: number;
+  remaining: number;
+  outcome: FlushOutcome;
+  status?: number;
 };
 
 // BEGIN HANDOVER_OFFLINE
@@ -130,6 +151,7 @@ type QueueSendFailure = {
   message?: string;
   recoverable?: boolean;
   errorIssuesJson?: string;
+  authOutcome?: Extract<FlushOutcome, 'auth-required' | 'auth-failed'>;
 };
 type QueueSendResult = QueueSendSuccess | QueueSendFailure;
 type QueueSendHandler = (item: OfflineQueueItem) => Promise<QueueSendResult>;
@@ -164,6 +186,8 @@ let syncSnapshot: SyncSnapshot = {
   nextRetryAt: null,
 };
 const syncListeners = new Set<SyncListener>();
+const RECENTLY_SYNCED_QUEUE_ITEM_TTL_MS = 5 * 60_000;
+const recentlySyncedQueueItems = new Map<string, { completedAt: number }>();
 
 function notifySyncListeners() {
   for (const listener of syncListeners) {
@@ -190,6 +214,39 @@ export function subscribeSyncStatus(listener: SyncListener): () => void {
   return () => {
     syncListeners.delete(listener);
   };
+}
+
+function pruneRecentlySyncedQueueItems(now = Date.now()): void {
+  for (const [id, evidence] of recentlySyncedQueueItems.entries()) {
+    if (evidence.completedAt + RECENTLY_SYNCED_QUEUE_ITEM_TTL_MS <= now) {
+      recentlySyncedQueueItems.delete(id);
+    }
+  }
+}
+
+function rememberRecentlySyncedQueueItem(id: string): void {
+  const now = Date.now();
+  pruneRecentlySyncedQueueItems(now);
+  recentlySyncedQueueItems.set(id, { completedAt: now });
+}
+
+export function consumeRecentlySyncedQueueItem(
+  id: string,
+  opts?: { minCompletedAt?: number },
+): boolean {
+  const now = Date.now();
+  pruneRecentlySyncedQueueItems(now);
+  const evidence = recentlySyncedQueueItems.get(id);
+  if (!evidence) {
+    recentlySyncedQueueItems.delete(id);
+    return false;
+  }
+  if (typeof opts?.minCompletedAt === 'number' && evidence.completedAt < opts.minCompletedAt) {
+    recentlySyncedQueueItems.delete(id);
+    return false;
+  }
+  recentlySyncedQueueItems.delete(id);
+  return true;
 }
 
 function cancelSyncTimer() {
@@ -375,17 +432,30 @@ function buildDefaultQueueSender(options: SyncEngineOptions): QueueSendHandler {
       };
     }
 
-    let token: string;
+    let token: string | null;
     try {
       token = await options.getToken();
     } catch (error) {
-      return { ok: false, kind: 'auth', recoverable: true, message: (error as Error)?.message };
+      return {
+        ok: false,
+        kind: 'auth',
+        authOutcome: 'auth-failed',
+        recoverable: false,
+        message: (error as Error)?.message,
+      };
     }
 
     if (!token) {
       pauseSync('Autenticación requerida');
       options.onAuthError?.(new Error('unauthorized'));
-      return { ok: false, kind: 'auth', status: 401, recoverable: false, message: 'Token requerido' };
+      return {
+        ok: false,
+        kind: 'auth',
+        status: 401,
+        authOutcome: 'auth-required',
+        recoverable: false,
+        message: 'Token requerido',
+      };
     }
 
     try {
@@ -425,6 +495,7 @@ function buildDefaultQueueSender(options: SyncEngineOptions): QueueSendHandler {
           ok: false,
           kind: 'auth',
           status: response.status,
+          authOutcome: 'auth-required',
           recoverable: false,
           message: message ?? 'Unauthorized',
         };
@@ -467,7 +538,14 @@ function buildDefaultQueueSender(options: SyncEngineOptions): QueueSendHandler {
       if (error instanceof Error && error.message === 'unauthorized') {
         pauseSync('Autenticación requerida');
         options.onAuthError?.(error);
-        return { ok: false, kind: 'auth', status: 401, recoverable: false, message: error.message };
+        return {
+          ok: false,
+          kind: 'auth',
+          status: 401,
+          authOutcome: 'auth-required',
+          recoverable: false,
+          message: error.message,
+        };
       }
 
       // If the error comes from Zod/local validation, treat it as a non-recoverable 422.
@@ -594,6 +672,7 @@ export async function processQueueOnce(): Promise<void> {
 
     const duplicateDelivered = !result.ok && isDuplicateStatus(result.status);
     if (result.ok || duplicateDelivered) {
+      rememberRecentlySyncedQueueItem(item.id);
       await updateOfflineQueueStatus(item.id, 'synced', {
         attemptCount,
         lastAttemptAt: startedAt,
@@ -749,11 +828,8 @@ function ensureSyncConnectivityListener() {
 }
 
 export function configureSyncEngine(options: SyncEngineOptions): void {
-  syncOptions = options;
-  pausedForAuth = false;
-  cancelSyncTimer();
+  applySyncEngineOptions(options, { ensureConnectivity: true });
   setQueueSendHandler(options.sender ?? buildDefaultQueueSender(options));
-  ensureSyncConnectivityListener();
   void runSyncCycle();
 }
 
@@ -771,6 +847,111 @@ export function stopSyncEngine(): void {
     syncConnectivityUnsubscribe = null;
   }
   updateSyncSnapshot({ status: 'idle', nextRetryAt: null });
+}
+
+function configureCanonicalFhirClient(opts: SyncOpts): void {
+  configureFHIRClient({
+    getBaseUrl: () => opts.fhirBaseUrl,
+    ensureFreshToken: async () => (await opts.getToken()) ?? null,
+  });
+}
+
+function applySyncEngineOptions(
+  options: SyncEngineOptions,
+  opts: { ensureConnectivity?: boolean } = {},
+): void {
+  syncOptions = options;
+  pausedForAuth = false;
+  cancelSyncTimer();
+  if (opts.ensureConnectivity !== false) {
+    ensureSyncConnectivityListener();
+  }
+}
+
+function classifyFlushOutcome(
+  failure: { kind: QueueFailureKind; status?: number; authOutcome?: QueueSendFailure['authOutcome'] } | null,
+): FlushResult {
+  if (!failure) {
+    return { processed: 0, remaining: 0, outcome: 'success' };
+  }
+
+  if (failure.kind === 'auth') {
+    return {
+      processed: 0,
+      remaining: 0,
+      outcome: failure.authOutcome ?? 'auth-required',
+      status: failure.status ?? 401,
+    };
+  }
+
+  if (failure.kind === 'server') {
+    return { processed: 0, remaining: 0, outcome: 'server-error', status: failure.status };
+  }
+
+  if (failure.kind === 'client' || failure.kind === 'validation') {
+    return { processed: 0, remaining: 0, outcome: 'client-error', status: failure.status };
+  }
+
+  return { processed: 0, remaining: 0, outcome: 'network-error', status: failure.status };
+}
+
+export function startSyncDaemon(opts: SyncOpts): () => void {
+  configureCanonicalFhirClient(opts);
+  const sender = buildDefaultQueueSender({ getToken: opts.getToken });
+  applySyncEngineOptions({ getToken: opts.getToken, sender }, { ensureConnectivity: true });
+  setQueueSendHandler(sender);
+  void runSyncCycle();
+  return () => {
+    stopSyncEngine();
+  };
+}
+
+export async function flushSyncQueue(opts: SyncOpts): Promise<FlushResult> {
+  configureCanonicalFhirClient(opts);
+  const trackedFailure: {
+    current: {
+    kind: QueueFailureKind;
+    status?: number;
+    authOutcome?: QueueSendFailure['authOutcome'];
+    } | null;
+  } = { current: null };
+  const sender = buildDefaultQueueSender({ getToken: opts.getToken });
+
+  const trackedSender: QueueSendHandler = async (item) => {
+    const result = await sender(item);
+    if (!result.ok && trackedFailure.current == null) {
+      trackedFailure.current = {
+        kind: result.kind,
+        status: result.status,
+        authOutcome: result.authOutcome,
+      };
+    }
+    return result;
+  };
+
+  applySyncEngineOptions({
+    getToken: opts.getToken,
+    sender: trackedSender,
+  }, { ensureConnectivity: false });
+  setQueueSendHandler(trackedSender);
+
+  const before = await listOfflineQueue();
+  await runSyncCycle();
+  const after = await listOfflineQueue();
+  const afterIds = new Set(after.map((item) => item.id));
+  const processed = before.filter((item) => !afterIds.has(item.id)).length;
+  const base = classifyFlushOutcome(trackedFailure.current);
+
+  return {
+    processed,
+    remaining: after.length,
+    outcome: processed > 0 && trackedFailure.current == null ? 'success' : base.outcome,
+    status: processed > 0 && trackedFailure.current == null ? undefined : base.status,
+  };
+}
+
+export async function getCanonicalQueueSize(): Promise<number> {
+  return (await listOfflineQueue()).length;
 }
 // END HANDOVER_OFFLINE
 

--- a/src/lib/sync/index.ts
+++ b/src/lib/sync/index.ts
@@ -1,41 +1,35 @@
 // FILE: src/lib/sync/index.ts
 // ---------------------------------------------------------------------
-// Legacy sync compatibility facade.
+// Legacy sync compatibility shim.
 //
-// Source of truth:
-//   - src/lib/queue.ts stores the canonical offline queue.
-//   - src/lib/sync.ts owns the canonical sync engine and sync snapshot state.
-//
-// Residual dependency:
-//   - queueBootstrap.ts and some UI screens still import this module for the
-//     older offlineQueue-based replay flow.
+// Canonical source of truth:
+//   - src/lib/queue.ts persists the secure offline queue for handover bundles.
+//   - src/lib/sync.ts owns replay, retry scheduling, sync snapshot state,
+//     and recent-sync evidence.
 //
 // Guardrail:
-//   - Do not treat this module as the canonical queue/runtime source of truth.
-//   - Do not add new runtime entrypoints here; migrate callers to src/lib/sync.ts
-//     when a focused follow-up is approved.
+//   - Do not add new runtime logic here.
+//   - Keep this module as a thin adapter for legacy imports only.
 // ---------------------------------------------------------------------
 
 import NetInfo from '@/src/lib/netinfo';
-import { configureFHIRClient, postBundle } from '../fhir-client';
+import { enqueueBundle } from '../queue';
+import {
+  consumeRecentlySyncedQueueItem,
+  flushSyncQueue,
+  getCanonicalQueueSize,
+  startSyncDaemon as startCanonicalSyncDaemon,
+  type FlushOutcome,
+  type FlushResult,
+  type SyncOpts,
+} from '../sync';
 import {
   validateBundle as validateFHIRBundle,
   validateResourceWithZod,
   type ValidationResult,
 } from '../fhir-validation/zod';
-import { retryWithBackoff } from './backoff';
 import { bundleIdempotencyKey } from './ident';
-import { enqueueTx, flushQueue as runQueueFlush, readQueue } from '../offlineQueue';
 
-// --- Tolerant mark(): no-op when the otel module is not available. ---
-type MarkFn = (name: string, attrs?: Record<string, unknown>) => void;
-let mark: MarkFn = () => {};
-try {
-  const mod = require('@/src/lib/otel') as { mark?: MarkFn };
-  if (mod?.mark) mark = mod.mark;
-} catch {}
-
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 type ValidationErrorDetail = ValidationResult['errors'][number];
 
 function enforceBundleValidation(bundle: unknown, context: string): ValidationErrorDetail[] {
@@ -53,7 +47,7 @@ function enforceBundleValidation(bundle: unknown, context: string): ValidationEr
   if (!fhirValidation.isValid) {
     const mappedErrors = fhirValidation.errors;
     const error = new Error(
-      `FHIR structure validation failed (${context}): ${mappedErrors.map((err) => err.message).join('; ')}`
+      `FHIR structure validation failed (${context}): ${mappedErrors.map((err) => err.message).join('; ')}`,
     );
     (error as Error & { validationErrors: ValidationResult['errors'] }).validationErrors = mappedErrors;
     if (bundle && typeof bundle === 'object') {
@@ -67,349 +61,82 @@ function enforceBundleValidation(bundle: unknown, context: string): ValidationEr
   }
   return [];
 }
-try {
-  const mod = require('../otel');
-  if (mod?.mark) mark = mod.mark as MarkFn;
-} catch {}
 
-// --- HTTP statuses of interest ---
-function isSuccessStatus(status: number) {
-  return status === 200 || status === 201 || status === 202 || status === 204;
-}
-function isDuplicateSkip(status: number) {
-  return status === 409 || status === 412; // Idempotent replay already accepted remotely.
-}
-function isRetryable(status: number) {
-  return status === 0 || status === 408 || status === 429 || (status >= 500 && status <= 599);
-}
-
-// --- Public types ---
-export type SyncOpts = {
-  fhirBaseUrl: string;
-  getToken: () => Promise<string | null>;
-  backoff?: { retries?: number; minMs?: number; maxMs?: number };
-};
-
-export type FlushOutcome =
-  | 'success'
-  | 'auth-required'
-  | 'auth-failed'
-  | 'network-error'
-  | 'server-error'
-  | 'client-error';
-
-export type FlushResult = {
-  processed: number;
-  remaining: number;
-  outcome: FlushOutcome;
-  status?: number;
-};
-
-class QueueReplayAuthError extends Error {
-  readonly nonRetryable = true;
-
-  constructor(
-    readonly outcome: Extract<FlushOutcome, 'auth-required' | 'auth-failed'>,
-    readonly status: number,
-    message: string,
-  ) {
-    super(message);
-    this.name = 'QueueReplayAuthError';
-  }
-}
-
-// Global guard to coalesce concurrent flushes (prevents races).
-let _currentFlush: Promise<FlushResult> | null = null;
-const RECENTLY_SYNCED_QUEUE_ITEM_TTL_MS = 5 * 60_000;
-const recentlySyncedQueueItems = new Map<string, { completedAt: number }>();
-
-function pruneRecentlySyncedQueueItems(now = Date.now()): void {
-  for (const [id, evidence] of recentlySyncedQueueItems.entries()) {
-    if (evidence.completedAt + RECENTLY_SYNCED_QUEUE_ITEM_TTL_MS <= now) {
-      recentlySyncedQueueItems.delete(id);
-    }
-  }
-}
-
-function rememberRecentlySyncedQueueItem(id: string): void {
-  const now = Date.now();
-  pruneRecentlySyncedQueueItems(now);
-  recentlySyncedQueueItems.set(id, { completedAt: now });
-}
-
-export function consumeRecentlySyncedQueueItem(
-  id: string,
-  opts?: { minCompletedAt?: number },
-): boolean {
-  const now = Date.now();
-  pruneRecentlySyncedQueueItems(now);
-  const evidence = recentlySyncedQueueItems.get(id);
-  if (!evidence) {
-    recentlySyncedQueueItems.delete(id);
-    return false;
-  }
-  if (typeof opts?.minCompletedAt === 'number' && evidence.completedAt < opts.minCompletedAt) {
-    recentlySyncedQueueItems.delete(id);
-    return false;
-  }
-  recentlySyncedQueueItems.delete(id);
-  return true;
-}
-
-// --- Main API: send immediately or enqueue when offline or on error. ---
-export async function syncBundleOrEnqueue(
-  bundle: unknown,
-  opts: SyncOpts
-): Promise<'sent' | 'queued'> {
-  enforceBundleValidation(bundle, 'syncBundleOrEnqueue');
-  const online = await hasInternet();
-  const idemKey = bundleIdempotencyKey(bundle);
-  if (!online) {
-    await enqueue(bundle, idemKey);
-    return 'queued';
-  }
-
-  try {
-    configureFHIRClient({
-      getBaseUrl: () => opts.fhirBaseUrl,
-      ensureFreshToken: async () => (await opts.getToken()) ?? null,
-    });
-    await sendWithRetry(bundle, idemKey, opts);
-    return 'sent';
-  } catch {
-    await enqueue(bundle, idemKey);
-    return 'queued';
-  }
-}
-
-// --- Send with backoff + per-attempt marks. ---
-async function sendWithRetry(bundle: unknown, idemKey: string, opts: SyncOpts) {
-  enforceBundleValidation(bundle, 'sync sendWithRetry');
-  return await retryWithBackoff(
-    async (attempt) => {
-      mark('sync.http.request', { attempt, idemKey });
-      const token = await requireFreshSessionToken(opts);
-      const resp = await postBundle(bundle, {
-        token,
-        headers: { 'Idempotency-Key': idemKey },
-      });
-      mark('sync.http.response', { status: resp.status, attempt });
-
-      if (resp.status === 401 || resp.status === 403) {
-        throw new QueueReplayAuthError('auth-required', resp.status, `HTTP ${resp.status}`);
-      }
-      if (isSuccessStatus(resp.status) || isDuplicateSkip(resp.status)) {
-        return resp;
-      }
-      if (isRetryable(resp.status)) {
-        const error = new Error(`Retryable ${resp.status}`) as Error & { status?: number };
-        error.status = resp.status;
-        throw error;
-      }
-
-      const body = resp.body ? JSON.stringify(resp.body) : '';
-      const error = new Error(`Non-retryable HTTP ${resp.status} ${body}`) as Error & {
-        status?: number;
-        nonRetryable?: boolean;
-      };
-      error.status = resp.status;
-      error.nonRetryable = true;
-      throw error;
-    },
-    opts.backoff
-  );
-}
-
-// --- Enqueue (encrypted) + telemetry mark. ---
-async function enqueue(bundle: unknown, idemKey: string) {
-  mark('sync.enqueue', { kind: 'FHIR_BUNDLE', idemKey });
-  enforceBundleValidation(bundle, 'sync enqueue');
-  await enqueueTx({ payload: { bundle, meta: { hash: idemKey } } });
-}
-
-// --- Network state ---
 async function hasInternet(): Promise<boolean> {
-  const s = await NetInfo.fetch();
-  return !!(s.isConnected && (s.isInternetReachable ?? true));
+  const state = await NetInfo.fetch();
+  return !!(state.isConnected && (state.isInternetReachable ?? true));
 }
 
-async function requireFreshSessionToken(opts: SyncOpts): Promise<string> {
-  let token: string | null;
-  try {
-    token = await opts.getToken();
-  } catch (error) {
-    throw new QueueReplayAuthError(
-      'auth-failed',
-      401,
-      error instanceof Error ? error.message : 'Failed to refresh bearer for queue replay',
-    );
-  }
+function extractPatientIdFromBundle(bundle: unknown): string | undefined {
+  if (!bundle || typeof bundle !== 'object') return undefined;
+  const entries = Array.isArray((bundle as { entry?: unknown[] }).entry)
+    ? ((bundle as { entry?: unknown[] }).entry as Array<Record<string, unknown>>)
+    : [];
 
-  if (typeof token !== 'string' || token.trim().length === 0) {
-    throw new QueueReplayAuthError('auth-required', 401, 'Fresh bearer required for queue replay');
-  }
-
-  return token;
-}
-
-function resolveFlushOutcome(status?: number): FlushOutcome {
-  if (status === 401 || status === 403) return 'auth-required';
-  if (status == null || status === 0) return 'network-error';
-  if (status >= 500) return 'server-error';
-  if (status >= 400) return 'client-error';
-  return 'success';
-}
-
-/** Builds a reusable flush function for both the daemon and manual actions. */
-function createFlusher(opts: SyncOpts) {
-  configureFHIRClient({
-    getBaseUrl: () => opts.fhirBaseUrl,
-    ensureFreshToken: async () => (await opts.getToken()) ?? null,
-  });
-
-  return async function flushImpl(): Promise<FlushResult> {
-    mark('sync.flush.start');
-    try {
-      await requireFreshSessionToken(opts);
-    } catch (error) {
-      if (error instanceof QueueReplayAuthError) {
-        return {
-          processed: 0,
-          remaining: (await readQueue()).length,
-          outcome: error.outcome,
-          status: error.status,
-        };
-      }
-      return {
-        processed: 0,
-        remaining: (await readQueue()).length,
-        outcome: 'auth-failed',
-        status: 401,
-      };
+  for (const entry of entries) {
+    const resource = entry?.resource;
+    if (!resource || typeof resource !== 'object' || (resource as { resourceType?: unknown }).resourceType !== 'Patient') {
+      continue;
     }
 
-    let processed = 0;
-    let outcome: FlushOutcome = 'success';
-    let status: number | undefined;
+    const identifiers = Array.isArray((resource as { identifier?: unknown[] }).identifier)
+      ? ((resource as { identifier?: unknown[] }).identifier as Array<Record<string, unknown>>)
+      : [];
 
-    await runQueueFlush(async (tx) => {
-      const payload =
-        tx.payload && typeof tx.payload === 'object'
-          ? (tx.payload as { bundle?: unknown; meta?: { hash?: string } })
-          : {};
-      const bundle = payload.bundle;
-      const hash = payload.meta?.hash ?? tx.key;
-
-      if (!bundle) {
-        if (outcome === 'success') {
-          outcome = 'client-error';
-          status = 422;
-        }
-        return { ok: false, status: 422 };
+    for (const identifier of identifiers) {
+      if (
+        identifier?.system === 'urn:handover-pro:ids' &&
+        typeof identifier.value === 'string' &&
+        identifier.value.length > 0
+      ) {
+        return identifier.value;
       }
-
-      try {
-        const resp = await sendWithRetry(bundle, hash, opts);
-        if (resp.ok || isSuccessStatus(resp.status) || isDuplicateSkip(resp.status)) {
-          processed++;
-          rememberRecentlySyncedQueueItem(tx.id);
-        } else if (outcome === 'success') {
-          outcome = resolveFlushOutcome(resp.status);
-          status = resp.status;
-        }
-        return { ok: resp.ok, status: resp.status };
-      } catch (err: unknown) {
-        if (err instanceof QueueReplayAuthError) {
-          outcome = err.outcome;
-          status = err.status;
-          mark('sync.flush.error', {
-            reason: err.message,
-            tries: tx.tries,
-            id: tx.key,
-          });
-          return { ok: false, status: err.status, stop: true };
-        }
-
-        const errorStatus =
-          typeof err === 'object' &&
-          err !== null &&
-          'status' in err &&
-          typeof (err as { status?: unknown }).status === 'number'
-            ? (err as { status: number }).status
-            : 0;
-        if (outcome === 'success') {
-          outcome = resolveFlushOutcome(errorStatus);
-          status = errorStatus || undefined;
-        }
-        mark('sync.flush.error', {
-          reason: err instanceof Error ? err.message : String(err),
-          tries: tx.tries,
-          id: tx.key,
-        });
-        return { ok: false, status: errorStatus };
-      }
-    });
-
-    const remaining = (await readQueue()).length;
-    if (processed > 0) {
-      mark('sync.flush.success', {
-        drained: remaining === 0,
-        processed,
-        remaining,
-      });
     }
-    return { processed, remaining, outcome, status };
-  };
+
+    if (typeof (resource as { id?: unknown }).id === 'string' && (resource as { id: string }).id.length > 0) {
+      return (resource as { id: string }).id;
+    }
+  }
+
+  return undefined;
 }
 
-// Coalesce concurrent flushes (same module instance).
-async function triggerFlush(opts: SyncOpts): Promise<FlushResult> {
-  if (_currentFlush) return _currentFlush;
-  const flush = createFlusher(opts);
-  _currentFlush = flush()
-    .catch((e) => {
-      // Propagamos error pero limpiamos lock
-      throw e;
-    })
-    .finally(() => {
-      _currentFlush = null;
-    });
-  return _currentFlush;
-}
+export type { SyncOpts, FlushOutcome, FlushResult };
+export { consumeRecentlySyncedQueueItem };
 
 export function startSyncDaemon(opts: SyncOpts) {
-  const unsub = NetInfo.addEventListener((state: { isConnected?: boolean | null; isInternetReachable?: boolean | null }) => {
-    if (state.isConnected && (state.isInternetReachable ?? true)) {
-      // Coalesce multiple trigger attempts.
-      triggerFlush(opts).catch(() => {});
-    }
-  });
-
-  // Initial attempt (in case the app starts with connectivity).
-  triggerFlush(opts).catch(() => {});
-  return () => unsub();
+  return startCanonicalSyncDaemon(opts);
 }
 
-/**
- * Flushes the queue on demand (e.g., from the Sync Center UI).
- */
 export async function flushQueue(opts: SyncOpts): Promise<FlushResult> {
-  return triggerFlush(opts);
+  return flushSyncQueue(opts);
 }
 
-/**
- * @deprecated Use {@link flushQueue} instead. This alias will be removed in a future major release.
- */
 export async function flushQueueNow(opts: SyncOpts): Promise<FlushResult> {
   return flushQueue(opts);
 }
 
-/** Returns the current queue size (for banners/UI). */
 export async function getQueueSize(): Promise<number> {
-  try {
-    const queue = await readQueue();
-    return queue.length;
-  } catch {
-    return -1;
+  return getCanonicalQueueSize();
+}
+
+export async function syncBundleOrEnqueue(
+  bundle: unknown,
+  opts: SyncOpts,
+): Promise<'sent' | 'queued'> {
+  enforceBundleValidation(bundle, 'syncBundleOrEnqueue');
+  const queued = await enqueueBundle(bundle, {
+    patientId: extractPatientIdFromBundle(bundle) ?? 'unknown',
+    bundleId: bundleIdempotencyKey(bundle),
+  });
+
+  if (!(await hasInternet())) {
+    return 'queued';
   }
+
+  const result = await flushSyncQueue(opts);
+  if (result.processed > 0 && consumeRecentlySyncedQueueItem(queued.id)) {
+    return 'sent';
+  }
+  return 'queued';
 }

--- a/src/screens/SyncCenter.tsx
+++ b/src/screens/SyncCenter.tsx
@@ -13,7 +13,7 @@ import {
 import { useIsFocused, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { listOfflineQueue, type SyncStatus } from '@/src/lib/queue';
-import { flushQueue, type SyncOpts } from '@/src/lib/sync/index';
+import { flushSyncQueue, type SyncOpts } from '@/src/lib/sync';
 import { buildIssuesText, parseErrorIssuesJson, resolveErrorCopy } from './SyncCenter.helpers';
 import { getUserFacingNetworkMessage, normalizeNetError } from '@/src/lib/net-errors';
 import { PrimaryButton } from '../components/PrimaryButton';
@@ -136,7 +136,7 @@ export default function SyncCenter() {
     setAuthMessage(null);
     setBusy(true);
     try {
-      const res = await flushQueue(opts);
+      const res = await flushSyncQueue(opts);
       if (res.outcome === 'auth-required' || res.outcome === 'auth-failed') {
         const message = getAuthReplayMessage(res.outcome);
         setAuthMessage(message);
@@ -168,7 +168,7 @@ export default function SyncCenter() {
     }
 
     intervalRef.current = setInterval(() => {
-      // flush coalescente en sync/index.ts; es seguro llamarlo seguido
+      // flush coalescente en src/lib/sync.ts; es seguro llamarlo seguido
       void doFlush();
     }, Math.max(5, Math.min(60, intervalSec)) * 1000);
 

--- a/src/screens/__tests__/SyncCenter.auth.spec.tsx
+++ b/src/screens/__tests__/SyncCenter.auth.spec.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const ensureFreshAccessTokenMock = vi.fn();
-const flushQueueMock = vi.fn();
+const flushSyncQueueMock = vi.fn();
 const listOfflineQueueMock = vi.fn(async () => []);
 
 vi.mock('@react-navigation/native', () => ({
@@ -47,8 +47,8 @@ vi.mock('@/src/lib/queue', () => ({
   listOfflineQueue: () => listOfflineQueueMock(),
 }));
 
-vi.mock('@/src/lib/sync/index', () => ({
-  flushQueue: (opts: unknown) => flushQueueMock(opts),
+vi.mock('@/src/lib/sync', () => ({
+  flushSyncQueue: (opts: unknown) => flushSyncQueueMock(opts),
 }));
 
 vi.mock('@/src/lib/net-errors', () => ({
@@ -76,7 +76,7 @@ describe('SyncCenter auth replay seam', () => {
     ensureFreshAccessTokenMock
       .mockResolvedValueOnce('fresh-replay-token-1')
       .mockResolvedValueOnce('fresh-replay-token-2');
-    flushQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+    flushSyncQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
       expect(await opts.getToken()).toBe('fresh-replay-token-1');
       expect(await opts.getToken()).toBe('fresh-replay-token-2');
       return { processed: 1, remaining: 0, outcome: 'success' };
@@ -90,7 +90,7 @@ describe('SyncCenter auth replay seam', () => {
     });
 
     await waitFor(() => {
-      expect(flushQueueMock).toHaveBeenCalledTimes(1);
+      expect(flushSyncQueueMock).toHaveBeenCalledTimes(1);
     });
     expect(ensureFreshAccessTokenMock).toHaveBeenNthCalledWith(1, 'fhir');
     expect(ensureFreshAccessTokenMock).toHaveBeenNthCalledWith(2, 'fhir');
@@ -102,7 +102,7 @@ describe('SyncCenter auth replay seam', () => {
   it('fails closed when the canonical refresher does not return a bearer', async () => {
     const alertSpy = vi.spyOn(Alert, 'alert').mockImplementation(() => {});
     ensureFreshAccessTokenMock.mockResolvedValueOnce(null);
-    flushQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+    flushSyncQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
       const token = await opts.getToken();
       return { processed: 0, remaining: 0, outcome: token ? 'success' : 'auth-required' };
     });
@@ -114,7 +114,7 @@ describe('SyncCenter auth replay seam', () => {
       fireEvent.press(view.getByTestId('sync-flush'));
     });
 
-    expect(flushQueueMock).toHaveBeenCalledTimes(1);
+    expect(flushSyncQueueMock).toHaveBeenCalledTimes(1);
     expect(ensureFreshAccessTokenMock).toHaveBeenCalledWith('fhir');
     expect(alertSpy).toHaveBeenCalledWith('sync.syncTitle', 'sync.authRequiredMessage');
     alertSpy.mockRestore();
@@ -123,7 +123,7 @@ describe('SyncCenter auth replay seam', () => {
   it('preserves auth-failed when the canonical refresher throws', async () => {
     const alertSpy = vi.spyOn(Alert, 'alert').mockImplementation(() => {});
     ensureFreshAccessTokenMock.mockRejectedValueOnce(new Error('refresh failed'));
-    flushQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+    flushSyncQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
       try {
         await opts.getToken();
         return { processed: 0, remaining: 0, outcome: 'success' };
@@ -139,7 +139,7 @@ describe('SyncCenter auth replay seam', () => {
       fireEvent.press(view.getByTestId('sync-flush'));
     });
 
-    expect(flushQueueMock).toHaveBeenCalledTimes(1);
+    expect(flushSyncQueueMock).toHaveBeenCalledTimes(1);
     expect(ensureFreshAccessTokenMock).toHaveBeenCalledWith('fhir');
     expect(alertSpy).toHaveBeenCalledWith('sync.syncTitle', 'sync.authFailedMessage');
     alertSpy.mockRestore();

--- a/src/screens/handover/__tests__/useHandoverSyncStatus.spec.tsx
+++ b/src/screens/handover/__tests__/useHandoverSyncStatus.spec.tsx
@@ -7,7 +7,7 @@ import { clearOfflineQueue, deleteOfflineQueueItem, enqueueBundle } from '@/src/
 import { useHandoverSyncStatus } from '@/src/screens/handover/useHandoverSyncStatus';
 
 const ensureFreshAccessTokenMock = vi.fn();
-const flushQueueMock = vi.fn();
+const flushSyncQueueMock = vi.fn();
 const recentlySyncedQueueIds = new Map<string, number>();
 const originalNodeEnv = process.env.NODE_ENV;
 const originalOfflineEncryptionDisabled = process.env.HANDOVER_TEST_DISABLE_OFFLINE_ENCRYPTION;
@@ -29,8 +29,7 @@ vi.mock('@/src/security/auth', () => ({
   ensureFreshAccessToken: (...args: unknown[]) => ensureFreshAccessTokenMock(...args),
 }));
 
-vi.mock('@/src/lib/sync/index', () => ({
-  flushQueue: (...args: unknown[]) => flushQueueMock(...args),
+vi.mock('@/src/lib/sync', () => ({
   consumeRecentlySyncedQueueItem: (id: string, opts?: { minCompletedAt?: number }) => {
     const completedAt = recentlySyncedQueueIds.get(id);
     if (completedAt == null) {
@@ -42,9 +41,7 @@ vi.mock('@/src/lib/sync/index', () => ({
     }
     return true;
   },
-}));
-
-vi.mock('@/src/lib/sync', () => ({
+  flushSyncQueue: (...args: unknown[]) => flushSyncQueueMock(...args),
   getSyncSnapshot: () => ({
     status: 'idle',
     lastRunAt: null,
@@ -209,7 +206,7 @@ describe('useHandoverSyncStatus', () => {
     });
 
     ensureFreshAccessTokenMock.mockResolvedValueOnce('session-token');
-    flushQueueMock.mockResolvedValueOnce({ processed: 0, remaining: 0 });
+    flushSyncQueueMock.mockResolvedValueOnce({ processed: 0, remaining: 0 });
 
     await act(async () => {
       await view.getByTestId('retry').props.onPress();
@@ -230,7 +227,7 @@ describe('useHandoverSyncStatus', () => {
     const view = render(<HookHarness queueId={queued.id} initializeQueued={false} />);
 
     ensureFreshAccessTokenMock.mockResolvedValueOnce(null);
-    flushQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+    flushSyncQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
       const token = await opts.getToken();
       return { processed: 0, remaining: 0, outcome: token ? 'success' : 'auth-required' };
     });
@@ -241,13 +238,13 @@ describe('useHandoverSyncStatus', () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
 
-    expect(flushQueueMock).toHaveBeenCalledTimes(1);
+    expect(flushSyncQueueMock).toHaveBeenCalledTimes(1);
     expect(ensureFreshAccessTokenMock).toHaveBeenNthCalledWith(1, 'fhir');
 
     ensureFreshAccessTokenMock
       .mockResolvedValueOnce('fresh-replay-token-1')
       .mockResolvedValueOnce('fresh-replay-token-2');
-    flushQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+    flushSyncQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
       await opts.getToken();
       await opts.getToken();
       recentlySyncedQueueIds.set(queued.id, Date.now());
@@ -261,7 +258,7 @@ describe('useHandoverSyncStatus', () => {
 
     expect(ensureFreshAccessTokenMock).toHaveBeenNthCalledWith(2, 'fhir');
     expect(ensureFreshAccessTokenMock).toHaveBeenNthCalledWith(3, 'fhir');
-    expect(flushQueueMock).toHaveBeenCalledTimes(2);
+    expect(flushSyncQueueMock).toHaveBeenCalledTimes(2);
     await waitFor(() => {
       expect(view.getByTestId('status').props.children).toBe('synced');
     });
@@ -276,7 +273,7 @@ describe('useHandoverSyncStatus', () => {
     const view = render(<HookHarness queueId={queued.id} initializeQueued={false} />);
 
     ensureFreshAccessTokenMock.mockRejectedValueOnce(new Error('refresh failed'));
-    flushQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+    flushSyncQueueMock.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
       try {
         await opts.getToken();
         return { processed: 0, remaining: 0, outcome: 'success' };
@@ -292,7 +289,7 @@ describe('useHandoverSyncStatus', () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
 
-    expect(flushQueueMock).toHaveBeenCalledTimes(1);
+    expect(flushSyncQueueMock).toHaveBeenCalledTimes(1);
     expect(ensureFreshAccessTokenMock).toHaveBeenCalledWith('fhir');
   });
 });

--- a/src/screens/handover/useHandoverSyncStatus.ts
+++ b/src/screens/handover/useHandoverSyncStatus.ts
@@ -3,8 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { FHIR_BASE_URL } from '@/src/config/env';
 import { t } from '@/src/i18n';
 import { getOfflineQueueItem } from '@/src/lib/queue';
-import { getSyncSnapshot, subscribeSyncStatus } from '@/src/lib/sync';
-import { consumeRecentlySyncedQueueItem, flushQueue } from '@/src/lib/sync/index';
+import { consumeRecentlySyncedQueueItem, flushSyncQueue, getSyncSnapshot, subscribeSyncStatus } from '@/src/lib/sync';
 import { ensureFreshAccessToken } from '@/src/security/auth';
 
 export type HandoverSyncStatus = 'idle' | 'queued' | 'syncing' | 'synced' | 'error';
@@ -107,7 +106,7 @@ export function useHandoverSyncStatus() {
 
     manualRetryInFlightRef.current = true;
     try {
-      const result = await flushQueue({
+      const result = await flushSyncQueue({
         fhirBaseUrl: FHIR_BASE_URL,
         getToken: () => ensureFreshAccessToken('fhir'),
         backoff: { retries: 5, minMs: 500, maxMs: 15_000 },

--- a/tests/queue/offline-single-source-of-truth.spec.ts
+++ b/tests/queue/offline-single-source-of-truth.spec.ts
@@ -89,7 +89,8 @@ describe('offline sync single source of truth', () => {
     expect(client.postBundle).toHaveBeenCalledWith(
       storedBundle,
       expect.objectContaining({
-        headers: { 'Idempotency-Key': queued.id },
+        idempotencyKey: queued.id,
+        headers: expect.objectContaining({ Prefer: 'return=representation' }),
       }),
     );
     expect(await queue.listOfflineQueue()).toHaveLength(0);
@@ -121,7 +122,7 @@ describe('offline sync single source of truth', () => {
     expect(await queue.__getRawTxQueueRows()).toHaveLength(0);
   });
 
-  it('sync/index retries transport status 0 before leaving the canonical queue pending', async () => {
+  it('sync/index leaves transport status 0 pending in the canonical queue for the sync runtime backoff', async () => {
     const queue = await import('@/src/lib/queue');
     const sync = await import('@/src/lib/sync');
     const syncIndex = await import('@/src/lib/sync/index');
@@ -141,10 +142,12 @@ describe('offline sync single source of truth', () => {
       backoff: { retries: 1, minMs: 0, maxMs: 0 },
     });
 
-    expect(result).toEqual({ processed: 1, remaining: 0, outcome: 'success', status: undefined });
-    expect(syncIndex.consumeRecentlySyncedQueueItem(queued.id)).toBe(true);
-    expect(client.postBundle).toHaveBeenCalledTimes(2);
-    expect(await queue.listOfflineQueue()).toHaveLength(0);
+    expect(result).toEqual({ processed: 0, remaining: 1, outcome: 'network-error', status: 0 });
+    expect(syncIndex.consumeRecentlySyncedQueueItem(queued.id)).toBe(false);
+    expect(client.postBundle).toHaveBeenCalledTimes(1);
+    const [pending] = await queue.listOfflineQueue();
+    expect(pending?.id).toBe(queued.id);
+    expect(pending?.syncStatus).toBe('pending');
   });
 });
 

--- a/tests/screens/SyncCenter.source-of-truth.spec.tsx
+++ b/tests/screens/SyncCenter.source-of-truth.spec.tsx
@@ -32,9 +32,13 @@ vi.mock('@/src/lib/queue', () => ({
   listOfflineQueue: (...args: unknown[]) => mocked.listOfflineQueue(...args),
 }));
 
-vi.mock('@/src/lib/sync/index', () => ({
-  flushQueue: vi.fn(async () => ({ processed: 0, remaining: 1 })),
-}));
+vi.mock('@/src/lib/sync', async () => {
+  const actual = await vi.importActual<typeof import('@/src/lib/sync')>('@/src/lib/sync');
+  return {
+    ...actual,
+    flushSyncQueue: vi.fn(async () => ({ processed: 0, remaining: 1 })),
+  };
+});
 
 vi.mock('@/src/security/auth', () => ({
   ensureFreshAccessToken: vi.fn(async () => 'token'),

--- a/tests/screens/SyncCenter.spec.tsx
+++ b/tests/screens/SyncCenter.spec.tsx
@@ -7,7 +7,7 @@ import SyncCenter from '@/src/screens/SyncCenter';
 import { t } from '@/src/i18n';
 
 const listOfflineQueue = vi.fn();
-const flushQueue = vi.fn();
+const flushSyncQueue = vi.fn();
 const getTokenMock = vi.fn(async () => 'token');
 
 const navigationMock = {
@@ -31,8 +31,8 @@ vi.mock('@/src/lib/queue', () => ({
   listOfflineQueue: (...args: unknown[]) => listOfflineQueue(...args),
 }));
 
-vi.mock('@/src/lib/sync/index', () => ({
-  flushQueue: (...args: unknown[]) => flushQueue(...args),
+vi.mock('@/src/lib/sync', () => ({
+  flushSyncQueue: (...args: unknown[]) => flushSyncQueue(...args),
 }));
 
 const authModuleMock = {
@@ -70,7 +70,7 @@ const queueItems = [
 describe('SyncCenter', () => {
   beforeEach(() => {
     listOfflineQueue.mockReset();
-    flushQueue.mockReset();
+    flushSyncQueue.mockReset();
     getTokenMock.mockReset();
     getTokenMock.mockResolvedValue('token');
 
@@ -78,7 +78,7 @@ describe('SyncCenter', () => {
     delete process.env.EXPO_PUBLIC_AUTH_TOKEN;
 
     listOfflineQueue.mockResolvedValue(queueItems);
-    flushQueue.mockResolvedValue({ processed: 2, remaining: 0 });
+    flushSyncQueue.mockResolvedValue({ processed: 2, remaining: 0 });
   });
 
   it('renders queue items with the expected statuses', async () => {
@@ -114,7 +114,7 @@ describe('SyncCenter', () => {
     });
 
     await waitFor(() => {
-      expect(flushQueue).toHaveBeenCalled();
+      expect(flushSyncQueue).toHaveBeenCalled();
     });
 
     expect(listOfflineQueue.mock.calls.length).toBeGreaterThan(initialCalls);
@@ -163,6 +163,10 @@ describe('SyncCenter', () => {
     const alertSpy = vi.spyOn(Alert, 'alert').mockImplementation(() => undefined);
     process.env.EXPO_PUBLIC_AUTH_TOKEN = 'public-token';
     getTokenMock.mockResolvedValue(null);
+    flushSyncQueue.mockImplementationOnce(async (opts: { getToken: () => Promise<string | null> }) => {
+      const token = await opts.getToken();
+      return { processed: 0, remaining: 0, outcome: token ? 'success' : 'auth-required' };
+    });
 
     const view = render(<SyncCenter />);
     await waitFor(() => {
@@ -173,7 +177,7 @@ describe('SyncCenter', () => {
       fireEvent.press(view.getByTestId('sync-flush'));
     });
 
-    expect(flushQueue).not.toHaveBeenCalled();
+    expect(flushSyncQueue).toHaveBeenCalledTimes(1);
     expect(alertSpy).toHaveBeenCalledWith(t('sync.syncTitle'), t('sync.authRequiredMessage'));
     alertSpy.mockRestore();
   });


### PR DESCRIPTION
## Resumen

Este PR cierra la costura entre la cola legacy y la cola clínica segura para que HANDOVER use una sola ruta canónica de persistencia/replay para bundles clínicos.

La fuente de verdad final queda así:
- persistencia local: `src/lib/queue.ts` (`handover_offline_queue`)
- runtime de replay / snapshot / estado: `src/lib/sync.ts`

`src/lib/sync/index.ts` y `src/lib/offlineQueue.ts` permanecen solo como compatibilidad residual y ya no gobiernan la ruta activa de replay HANDOVER.

## Problema que corrige

Hasta ahora existía una dualidad parcial:
- la cola clínica segura ya vivía en `queue.ts`,
- pero varios callers seguían entrando por la fachada legacy `sync/index.ts`.

Eso dejaba ambigüedad operativa:
- dos superficies para flush/replay,
- deuda de fuente de verdad difusa,
- riesgo de reabrir drenajes paralelos,
- dificultad para sostener las invariantes offline-first como una sola cadena verificable.

Este PR elimina esa ambigüedad sin romper compatibilidad residual.

## Fuente de verdad final

### Persistencia canónica
- `src/lib/queue.ts`
- tabla/cola: `handover_offline_queue`

### Runtime canónico de sincronización
- `src/lib/sync.ts`

Responsabilidades activas del runtime canónico:
- replay
- retry scheduling / backoff
- `SyncSnapshot`
- queue size canónico
- evidencia reciente de sync exitoso
- clasificación de outcomes (`success`, `auth-required`, `auth-failed`, `network-error`, `server-error`, `client-error`)

## Callers confirmados

### Persistencia real de bundles HANDOVER
- `HandoverForm.tsx` sigue encolando por `src/lib/queue.ts`

### Callers productivos migrados al runtime canónico
- `src/lib/queueBootstrap.ts`
- `src/screens/SyncCenter.tsx`
- `src/screens/handover/useHandoverSyncStatus.ts`
- `src/components/OfflineBanner.tsx`
- `src/components/SyncStatusBanner.tsx`

### Compatibilidad residual aislada
- `src/lib/sync/index.ts`
- `src/lib/offlineQueue.ts`

Ambos quedan como adapter/shim legacy y ya no son la ruta activa del replay HANDOVER.

## Qué cambia

### 1) `src/lib/sync.ts` pasa a ser el runtime canónico real
Se consolidan aquí:
- `startSyncDaemon(...)`
- `flushSyncQueue(...)`
- `getCanonicalQueueSize()`
- evidencia reciente de items sincronizados (`consumeRecentlySyncedQueueItem(...)`)
- clasificación explícita de resultados de flush
- centralización de sender / token handling / replay state

### 2) `src/lib/sync/index.ts` queda reducido a shim fino
- ya no drena una cola propia;
- ya no gobierna estado de replay;
- delega a `src/lib/sync.ts`;
- se conserva para compatibilidad de imports legacy.

### 3) UI y bootstrap dejan de depender del facade legacy
Se redirigen al runtime canónico:
- `queueBootstrap.ts`
- `SyncCenter.tsx`
- `useHandoverSyncStatus.ts`
- `OfflineBanner.tsx`
- `SyncStatusBanner.tsx`

### 4) Invariantes offline quedan explícitas
Se documentan en `docs/offline-sync-and-queue.md`:

- persistencia local segura
- estados finitos: `pending`, `inFlight`, `error`, `synced`
- replay seguro
- deduplicación por identidad estable
- `409/412` tratados como evidencia de entrega idempotente
- `tx_queue` declarado explícitamente como compatibilidad legacy, no fuente de verdad operativa

### 5) Compatibilidad preservada, pero subordinada
- `tx_queue` no se elimina en este PR
- `offlineQueue.ts` no se rompe
- `sync/index.ts` sigue exportando compatibilidad

Pero:
- ya no deben considerarse fuente de verdad
- ya no deben recibir nuevos callers productivos
- ya no forman parte de la ruta activa de replay HANDOVER

## Cambio funcional deliberado

El shim legacy ya no hace replay inline propio.

En particular:
- ante `status 0` de transporte, el item queda `pending`
- el backoff y el retry quedan a cargo del runtime canónico
- se evita bifurcar otra vez la lógica de replay

Eso está cubierto por tests y es intencional: prioriza una sola ruta operativa verificable.

## Qué no cambia

- no se cambia arquitectura
- no se toca backend
- no se cambia el modelo clínico
- no se relaja cifrado
- no se relaja idempotencia
- no se altera auditabilidad
- no se introduce una cola nueva
- no se reescribe FHIR mapping clínico

## Pruebas ejecutadas

- `pnpm -w typecheck`
- `pnpm -w lint:ci`
- Vitest dirigido:
  - `src/lib/__tests__/queueBootstrap.auth.spec.ts`
  - `src/lib/__tests__/sync.index.auth.spec.ts`
  - `tests/queue/offline-single-source-of-truth.spec.ts`
  - `src/screens/__tests__/SyncCenter.auth.spec.tsx`
  - `src/components/__tests__/SyncStatusBanner.spec.tsx`
  - `src/screens/handover/__tests__/useHandoverSyncStatus.spec.tsx`
  - `tests/screens/SyncCenter.spec.tsx`
  - `tests/screens/SyncCenter.source-of-truth.spec.tsx`
- `pnpm validate:fhir`

No se tocó backend; no hizo falta `pytest`.

## Riesgos residuales

- `src/lib/sync/index.ts` sigue existiendo como shim por compatibilidad.
- Si en el futuro alguien vuelve a importar desde ese facade para lógica nueva, podría reabrirse deuda de fuente de verdad.
- `tx_queue` sigue presente como compatibilidad legacy y no debe reinterpretarse como ruta operativa vigente.

## Lectura correcta del PR

Este PR debe leerse como:

1. consolidación de una sola ruta canónica de cola offline para HANDOVER,
2. aislamiento del legado sin romper compatibilidad,
3. cierre de la costura operativa entre persistencia segura y replay.

No debe leerse como:
- una reescritura del stack,
- un cambio de modelo clínico,
- ni una limpieza total del legado histórico del repo.