### PR TITLE
fix(sync): preserve fresh-bearer replay semantics and classify auth failures correctly

### DIFF
--- a/docs/offline-sync-and-queue.md
+++ b/docs/offline-sync-and-queue.md
@@ -36,6 +36,7 @@
 - Local persistence for handover bundles is `handover_offline_queue` in `src/lib/queue.ts`, with encrypted payload-at-rest and plaintext metadata limited to non-PHI control fields.
 - Queue status is explicit and finite: `pending`, `inFlight`, `error`, `synced`. The canonical runtime in `src/lib/sync.ts` is the only active writer of replay status transitions.
 - Replay is safe by construction: canonical sends reuse the persisted payload, keep idempotency headers stable (`txId` or queue item id), and treat `409/412` as delivered evidence instead of duplicate writes.
+- Auth replay is fail-closed: `401` pauses the engine and requires a fresh bearer before resuming, while `403` is preserved as a terminal auth failure on the queue item instead of degrading into generic network/server retry paths.
 - Deduplication is based on stable identity (`buildOfflineQueueId`) so the same handover bundle does not fork into multiple queue rows across retry/reopen flows.
 
 ## Other identifiers and hash usage
@@ -90,7 +91,7 @@
   - `idle`: no pending work or waiting for new work.
   - `running`: processing the queue.
   - `backoff`: waiting for the next retry (e.g., after 5xx or no network).
-  - `paused`: blocked by authentication (401/403) until re-login or `resumeSync()`.
+  - `paused`: blocked by authentication. `401` pauses replay awaiting re-login/refresh; `403` pauses the engine after marking the affected item as `error` so permissions failures do not loop indefinitely.
 
 ## Compatibility aliases and migration notes
 - `flushQueueNow` (legacy UI helper in `src/lib/sync/index.ts` and legacy queue alias in `src/lib/sync.ts`) is deprecated in favor of the canonical runtime entrypoints in `src/lib/sync.ts`.

--- a/src/lib/__tests__/sync-errors.spec.ts
+++ b/src/lib/__tests__/sync-errors.spec.ts
@@ -16,4 +16,9 @@ describe('sync-errors', () => {
   it('usa el mensaje de validación remota para 422', () => {
     expect(resolveSyncErrorMessage(422)).toBe(t('sync.validationFailedMessage'));
   });
+
+  it('distingue 401 de 403 en el copy de replay', () => {
+    expect(resolveSyncErrorMessage(401)).toBe(t('sync.authRequiredMessage'));
+    expect(resolveSyncErrorMessage(403)).toBe(t('sync.authFailedMessage'));
+  });
 });

--- a/src/lib/fhir-client.ts
+++ b/src/lib/fhir-client.ts
@@ -217,7 +217,7 @@ const extractMrn = (patient: any): string | undefined => {
 // END HANDOVER D6 – fetchPatientSummary
 
 type AuthHooks = {
-  ensureFreshToken?: () => Promise<string | null>;
+  ensureFreshToken?: (reason?: string) => Promise<string | null>;
   logout?: () => Promise<void> | void;
   getBaseUrl?: () => string | undefined;
   getSession?: () => Promise<HandoverSession | null> | HandoverSession | null;
@@ -322,6 +322,15 @@ type NormalizedOutcome = {
   fatal: boolean;
   outcome: OperationOutcome;
 };
+
+type AuthStatusError = Error & { status: 401 | 403 };
+
+function createAuthStatusError(status: 401 | 403): AuthStatusError {
+  const error = new Error(status === 403 ? 'forbidden' : 'unauthorized') as AuthStatusError;
+  error.name = 'AuthStatusError';
+  error.status = status;
+  return error;
+}
 
 const normalizeOutcome = (maybeOutcome: unknown): NormalizedOutcome | null => {
   if (!maybeOutcome || typeof maybeOutcome !== 'object') return null;
@@ -486,7 +495,7 @@ const fetchFHIRWithConfig = (runtimeConfig: FhirClientRuntimeConfig) => {
           !isHTTPError && typeof error === 'object' && error !== null && 'status' in error;
         if (isHTTPError || isHttpErrorLike) {
           if (maybeHttpError.status === 401 && !retried) {
-            const freshToken = hooks.ensureFreshToken ? await hooks.ensureFreshToken() : null;
+            const freshToken = hooks.ensureFreshToken ? await hooks.ensureFreshToken('401') : null;
             if (freshToken) {
               try {
                 return await attempt(freshToken, true);
@@ -497,9 +506,12 @@ const fetchFHIRWithConfig = (runtimeConfig: FhirClientRuntimeConfig) => {
                   typeof retryHTTPErrorCtor === 'function' && retryError instanceof retryHTTPErrorCtor;
                 const isRetryHttpErrorLike =
                   !isRetryHTTPError && typeof retryError === 'object' && retryError !== null && 'status' in retryError;
-                if ((isRetryHTTPError || isRetryHttpErrorLike) && maybeRetryHttpError.status === 401) {
+                if (
+                  (isRetryHTTPError || isRetryHttpErrorLike) &&
+                  (maybeRetryHttpError.status === 401 || maybeRetryHttpError.status === 403)
+                ) {
                   if (runtimeConfig.logout) await runtimeConfig.logout();
-                  throw new Error('unauthorized');
+                  throw createAuthStatusError(maybeRetryHttpError.status === 403 ? 403 : 401);
                 }
                 if (isRetryHTTPError || isRetryHttpErrorLike) {
                   return handleHttpError(maybeRetryHttpError);
@@ -508,12 +520,12 @@ const fetchFHIRWithConfig = (runtimeConfig: FhirClientRuntimeConfig) => {
               }
             }
             if (runtimeConfig.logout) await runtimeConfig.logout();
-            throw new Error('unauthorized');
+            throw createAuthStatusError(401);
           }
 
           if (maybeHttpError.status === 401 || maybeHttpError.status === 403) {
             if (runtimeConfig.logout) await runtimeConfig.logout();
-            throw new Error('unauthorized');
+            throw createAuthStatusError(maybeHttpError.status === 403 ? 403 : 401);
           }
 
           return handleHttpError(maybeHttpError);
@@ -692,13 +704,23 @@ const idempotencyKey =
       isAbortError ||
       /network request failed|failed to fetch|network error|timeout/i.test(errorMessage);
     const isUnauthorized = errorMessage.toLowerCase().includes('unauthorized');
+    const isForbidden = errorMessage.toLowerCase().includes('forbidden');
     const status =
       typeof error?.status === 'number'
         ? error.status
+        : isForbidden
+          ? 403
         : isUnauthorized
           ? 401
           : 0;
-    const code = isUnauthorized ? 'login' : status === 0 || isTransportFailure ? 'network' : 'invalid';
+    const code =
+      status === 401
+        ? 'login'
+        : status === 403
+          ? 'forbidden'
+          : status === 0 || isTransportFailure
+            ? 'network'
+            : 'invalid';
     return {
       ok: false,
       status,

--- a/src/lib/fhir-client.ts
+++ b/src/lib/fhir-client.ts
@@ -510,7 +510,6 @@ const fetchFHIRWithConfig = (runtimeConfig: FhirClientRuntimeConfig) => {
                   (isRetryHTTPError || isRetryHttpErrorLike) &&
                   (maybeRetryHttpError.status === 401 || maybeRetryHttpError.status === 403)
                 ) {
-                  if (runtimeConfig.logout) await runtimeConfig.logout();
                   throw createAuthStatusError(maybeRetryHttpError.status === 403 ? 403 : 401);
                 }
                 if (isRetryHTTPError || isRetryHttpErrorLike) {

--- a/src/lib/sync-errors.ts
+++ b/src/lib/sync-errors.ts
@@ -54,8 +54,11 @@ export function resolveSyncErrorMessage(status?: number | null, fallback?: strin
   if (status === 422) {
     return t('sync.validationFailedMessage');
   }
-  if (status === 401 || status === 403) {
+  if (status === 401) {
     return t('sync.authRequiredMessage');
+  }
+  if (status === 403) {
+    return t('sync.authFailedMessage');
   }
   if (typeof status === 'number') {
     return t('sync.syncErrorStatusMessage', { status });

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -308,6 +308,10 @@ function isAuthStatus(status?: number): boolean {
   return status === 401 || status === 403;
 }
 
+function isTerminalAuthStatus(status?: number): status is 403 {
+  return status === 403;
+}
+
 function classifyQueueFailureKind(status?: number): QueueFailureKind {
   if (isDuplicateStatus(status)) return 'duplicate';
   if (isAuthStatus(status)) return 'auth';
@@ -489,15 +493,16 @@ function buildDefaultQueueSender(options: SyncEngineOptions): QueueSendHandler {
         response.message;
 
       if (isAuthStatus(response.status)) {
-        pauseSync('Autenticación requerida');
+        const authMessage = resolveSyncErrorMessage(response.status, message);
+        pauseSync(authMessage);
         options.onAuthError?.(new Error('unauthorized'));
         return {
           ok: false,
           kind: 'auth',
           status: response.status,
-          authOutcome: 'auth-required',
+          authOutcome: response.status === 403 ? 'auth-failed' : 'auth-required',
           recoverable: false,
-          message: message ?? 'Unauthorized',
+          message: authMessage,
         };
       }
 
@@ -707,9 +712,24 @@ export async function processQueueOnce(): Promise<void> {
       continue;
     }
 
+    if (isAuthError && isTerminalAuthStatus(status)) {
+      const errorMessage = resolveSyncErrorMessage(status, result.message);
+      pauseSync(errorMessage);
+      syncOptions?.onAuthError?.(new Error('forbidden'));
+      await updateOfflineQueueStatus(item.id, 'error', {
+        attemptCount,
+        lastAttemptAt: startedAt,
+        errorMessage,
+        errorStatus: status,
+        errorIssuesJson: cappedIssuesJson,
+      });
+      updateSyncSnapshot({ lastError: errorMessage });
+      continue;
+    }
+
     if (recoverable || isAuthError) {
       if (isAuthError) {
-        pauseSync('Autenticación requerida');
+        pauseSync(resolveSyncErrorMessage(status, result.message));
         syncOptions?.onAuthError?.(new Error('unauthorized'));
       }
       const nextAttempts = attemptCount;
@@ -852,7 +872,6 @@ export function stopSyncEngine(): void {
 function configureCanonicalFhirClient(opts: SyncOpts): void {
   configureFHIRClient({
     getBaseUrl: () => opts.fhirBaseUrl,
-    ensureFreshToken: async () => (await opts.getToken()) ?? null,
   });
 }
 

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -925,52 +925,70 @@ export function startSyncDaemon(opts: SyncOpts): () => void {
   };
 }
 
+let currentFlushPromise: Promise<FlushResult> | null = null;
+
 export async function flushSyncQueue(opts: SyncOpts): Promise<FlushResult> {
-  configureCanonicalFhirClient(opts);
-  const trackedFailure: {
-    current: {
-    kind: QueueFailureKind;
-    status?: number;
-    authOutcome?: QueueSendFailure['authOutcome'];
-    } | null;
-  } = { current: null };
-  const sender = buildDefaultQueueSender({ getToken: opts.getToken });
+  if (currentFlushPromise) {
+    return currentFlushPromise;
+  }
 
-  const trackedSender: QueueSendHandler = async (item) => {
-    const result = await sender(item);
-    if (!result.ok && trackedFailure.current == null) {
-      trackedFailure.current = {
-        kind: result.kind,
-        status: result.status,
-        authOutcome: result.authOutcome,
-      };
-    }
-    return result;
-  };
+  currentFlushPromise = (async () => {
+    configureCanonicalFhirClient(opts);
+    const trackedFailure: {
+      current: {
+      kind: QueueFailureKind;
+      status?: number;
+      authOutcome?: QueueSendFailure['authOutcome'];
+      } | null;
+    } = { current: null };
+    const sender = buildDefaultQueueSender({ getToken: opts.getToken });
 
-  applySyncEngineOptions({
-    getToken: opts.getToken,
-    sender: trackedSender,
-  }, { ensureConnectivity: false });
-  setQueueSendHandler(trackedSender);
+    const trackedSender: QueueSendHandler = async (item) => {
+      const result = await sender(item);
+      if (!result.ok && trackedFailure.current == null) {
+        trackedFailure.current = {
+          kind: result.kind,
+          status: result.status,
+          authOutcome: result.authOutcome,
+        };
+      }
+      return result;
+    };
 
-  const before = await listOfflineQueue();
-  await runSyncCycle();
-  const after = await listOfflineQueue();
-  const afterIds = new Set(after.map((item) => item.id));
-  const processed = before.filter((item) => !afterIds.has(item.id)).length;
-  const base = classifyFlushOutcome(trackedFailure.current);
+    applySyncEngineOptions({
+      getToken: opts.getToken,
+      sender: trackedSender,
+    }, { ensureConnectivity: false });
+    setQueueSendHandler(trackedSender);
 
-  return {
-    processed,
-    remaining: after.length,
-    outcome: processed > 0 && trackedFailure.current == null ? 'success' : base.outcome,
-    status: processed > 0 && trackedFailure.current == null ? undefined : base.status,
-  };
+    const before = await listOfflineQueue();
+    await runSyncCycle();
+    const after = await listOfflineQueue();
+    const afterIds = new Set(after.map((item) => item.id));
+    const processed = before.filter((item) => !afterIds.has(item.id)).length;
+    const base = classifyFlushOutcome(trackedFailure.current);
+
+    return {
+      processed,
+      remaining: after.length,
+      outcome: processed > 0 && trackedFailure.current == null ? 'success' : base.outcome,
+      status: processed > 0 && trackedFailure.current == null ? undefined : base.status,
+    };
+  })();
+
+  try {
+    return await currentFlushPromise;
+  } finally {
+    currentFlushPromise = null;
+  }
 }
 
 export async function getCanonicalQueueSize(): Promise<number> {
-  return (await listOfflineQueue()).length;
+  try {
+    return (await listOfflineQueue()).length;
+  } catch {
+    return -1;
+  }
 }
 // END HANDOVER_OFFLINE
 

--- a/src/security/auth.tsx
+++ b/src/security/auth.tsx
@@ -968,7 +968,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     configureFHIRClient({
       getToken: () => AuthService.getAccessToken(),
-      ensureFreshToken: () => ensureFreshToken("fhir"),
+      ensureFreshToken: (reason?: string) => ensureFreshToken(reason ?? "fhir"),
       getSession: () => getCurrentSession(),
       logout: async () =>
         logoutAndClear({

--- a/tests/fhir-client.spec.ts
+++ b/tests/fhir-client.spec.ts
@@ -114,6 +114,59 @@ describe('postBundle', () => {
     expect(result.message).toContain('Bad data');
   });
 
+  it('preserves 403 responses instead of collapsing them into 401', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ detail: 'Forbidden' }), { status: 403 }));
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+    const { postBundle } = await loadClient();
+
+    const result = await postBundle(bundle, { token: 'tk' });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+    expect(result.issue?.[0]?.code).toBe('forbidden');
+  });
+
+  it('forces a fresh token after a real 401 before replaying the bundle', async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      call += 1;
+      const headers = new Headers(init?.headers);
+      if (call === 1) {
+        expect(headers.get('Authorization')).toBe('Bearer stale-token');
+        return new Response(JSON.stringify({ detail: 'Unauthorized' }), { status: 401 });
+      }
+      expect(headers.get('Authorization')).toBe('Bearer fresh-token');
+      return new Response(JSON.stringify({ resourceType: 'Bundle', id: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/fhir+json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+    const { configureFHIRClient, postBundle } = await loadClient();
+    const refreshSpy = vi.fn(async (reason?: string) => {
+      expect(reason).toBe('401');
+      return 'fresh-token';
+    });
+
+    configureFHIRClient({
+      ensureFreshToken: refreshSpy,
+      logout: vi.fn(),
+    });
+
+    const result = await postBundle(bundle, { token: 'stale-token' });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      json: { resourceType: 'Bundle', id: 'ok' },
+      location: undefined,
+    });
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('returns json undefined when error body cannot be parsed', async () => {
     const fetchMock = vi
       .fn()

--- a/tests/fhir-client.spec.ts
+++ b/tests/fhir-client.spec.ts
@@ -167,6 +167,35 @@ describe('postBundle', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it.each([401, 403])('calls logout only once when replay still fails with %s after refresh', async (finalStatus) => {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      return new Response(
+        JSON.stringify({ detail: finalStatus === 403 ? 'Forbidden' : 'Unauthorized' }),
+        {
+          status: call === 1 ? 401 : finalStatus,
+          headers: { 'Content-Type': 'application/fhir+json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+    const { configureFHIRClient, postBundle } = await loadClient();
+    const logoutSpy = vi.fn();
+
+    configureFHIRClient({
+      ensureFreshToken: vi.fn(async () => 'fresh-token'),
+      logout: logoutSpy,
+    });
+
+    const result = await postBundle(bundle, { token: 'stale-token' });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(finalStatus);
+    expect(logoutSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('returns json undefined when error body cannot be parsed', async () => {
     const fetchMock = vi
       .fn()

--- a/tests/queue/offline-queue.spec.ts
+++ b/tests/queue/offline-queue.spec.ts
@@ -380,5 +380,80 @@ describe('offline queue end-to-end', () => {
     expect(failed?.syncStatus).toBe('error');
     expect(failed?.errorStatus).toBe(400);
   });
+
+  it('fails closed on 403 by marking the replay as terminal instead of retrying forever', async () => {
+    await queue.createOfflineQueueItem({
+      payload: { bundle: { resourceType: 'Bundle', type: 'transaction', entry: [] } },
+      patientId: 'pat-403',
+    });
+
+    const sender = vi.fn(async () => ({ ok: false as const, status: 403, message: 'forbidden' }));
+    sync.setQueueSendHandler(sender);
+
+    await sync.processQueueOnce();
+    sender.mockClear();
+    await sync.processQueueOnce();
+
+    const [failed] = await queue.listOfflineQueue();
+    expect(sender).not.toHaveBeenCalled();
+    expect(failed?.syncStatus).toBe('error');
+    expect(failed?.errorStatus).toBe(403);
+    expect(failed?.errorMessage).toBe('Falló la actualización de autenticación. Inicia sesión de nuevo.');
+  });
+
+  it('canonical replay preserves auth hooks, refreshes after 401, and succeeds once without duplicating the transaction', async () => {
+    const client = await import('@/src/lib/fhir-client');
+    const bundle = sync.buildTransactionBundleForQueue({ patientId: 'pat-refresh-runtime' } as any, {
+      now: '2025-01-01T00:00:00.000Z',
+    });
+    const queued = await queue.enqueueBundle(bundle, { patientId: 'pat-refresh-runtime' });
+
+    const refreshSpy = vi.fn(async (reason?: string) => {
+      expect(reason).toBe('401');
+      return 'fresh-bearer';
+    });
+    const logoutSpy = vi.fn();
+    client.configureFHIRClient({
+      ensureFreshToken: refreshSpy,
+      logout: logoutSpy,
+    });
+
+    const authHeaders: string[] = [];
+    const idempotencyKeys: string[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      authHeaders.push(headers.get('Authorization') ?? '');
+      idempotencyKeys.push(headers.get('Idempotency-Key') ?? '');
+
+      if (authHeaders.length === 1) {
+        return new Response(JSON.stringify({ detail: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/fhir+json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ resourceType: 'Bundle', id: 'replay-ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/fhir+json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const result = await sync.flushSyncQueue({
+      fhirBaseUrl: 'https://example.test',
+      getToken: async () => 'stale-bearer',
+      backoff: { retries: 1, minMs: 0, maxMs: 0 },
+    });
+
+    expect(result).toEqual({ processed: 1, remaining: 0, outcome: 'success', status: undefined });
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(logoutSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(authHeaders).toEqual(['Bearer stale-bearer', 'Bearer fresh-bearer']);
+    expect(idempotencyKeys).toEqual([queued.id, queued.id]);
+    expect(await queue.listOfflineQueue()).toHaveLength(0);
+    expect(sync.consumeRecentlySyncedQueueItem(queued.id)).toBe(true);
+    expect(sync.consumeRecentlySyncedQueueItem(queued.id)).toBe(false);
+  });
 });
 

--- a/tests/queue/offline-single-source-of-truth.spec.ts
+++ b/tests/queue/offline-single-source-of-truth.spec.ts
@@ -149,5 +149,31 @@ describe('offline sync single source of truth', () => {
     expect(pending?.id).toBe(queued.id);
     expect(pending?.syncStatus).toBe('pending');
   });
+
+  it('sync/index reports 403 replays as auth-failed and keeps the item terminal in the canonical queue', async () => {
+    const queue = await import('@/src/lib/queue');
+    const sync = await import('@/src/lib/sync');
+    const syncIndex = await import('@/src/lib/sync/index');
+    const client = await import('@/src/lib/fhir-client');
+    const bundle = sync.buildTransactionBundleForQueue({ patientId: 'pat-sync-index-403' } as any, {
+      now: '2025-01-01T00:00:00.000Z',
+    });
+
+    const queued = await queue.enqueueBundle(bundle, { patientId: 'pat-sync-index-403' });
+    (client.postBundle as unknown as Mock).mockResolvedValue({ ok: false, status: 403, body: { error: 'forbidden' } });
+
+    const result = await syncIndex.flushQueue({
+      fhirBaseUrl: 'https://example.test',
+      getToken: async () => 'token',
+      backoff: { retries: 0, minMs: 0, maxMs: 0 },
+    });
+
+    const [failed] = await queue.listOfflineQueue();
+    expect(result).toEqual({ processed: 0, remaining: 1, outcome: 'auth-failed', status: 403 });
+    expect(syncIndex.consumeRecentlySyncedQueueItem(queued.id)).toBe(false);
+    expect(failed?.id).toBe(queued.id);
+    expect(failed?.syncStatus).toBe('error');
+    expect(failed?.errorStatus).toBe(403);
+  });
 });
 

--- a/tests/queue/offline-single-source-of-truth.spec.ts
+++ b/tests/queue/offline-single-source-of-truth.spec.ts
@@ -175,5 +175,53 @@ describe('offline sync single source of truth', () => {
     expect(failed?.syncStatus).toBe('error');
     expect(failed?.errorStatus).toBe(403);
   });
+
+  it('canonical flush coalesces concurrent callers so a pending row is sent only once', async () => {
+    const queue = await import('@/src/lib/queue');
+    const sync = await import('@/src/lib/sync');
+    const client = await import('@/src/lib/fhir-client');
+    const bundle = sync.buildTransactionBundleForQueue({ patientId: 'pat-concurrent-flush' } as any, {
+      now: '2025-01-01T00:00:00.000Z',
+    });
+
+    const queued = await queue.enqueueBundle(bundle, { patientId: 'pat-concurrent-flush' });
+    let release!: () => void;
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    (client.postBundle as unknown as Mock).mockImplementationOnce(async () => {
+      await inFlight;
+      return { ok: true, status: 200 };
+    });
+
+    const flushA = sync.flushSyncQueue({
+      fhirBaseUrl: 'https://example.test',
+      getToken: async () => 'token',
+    });
+    const flushB = sync.flushSyncQueue({
+      fhirBaseUrl: 'https://example.test',
+      getToken: async () => 'token',
+    });
+
+    release();
+    const [resultA, resultB] = await Promise.all([flushA, flushB]);
+
+    expect(resultA).toEqual({ processed: 1, remaining: 0, outcome: 'success', status: undefined });
+    expect(resultB).toEqual({ processed: 1, remaining: 0, outcome: 'success', status: undefined });
+    expect(client.postBundle).toHaveBeenCalledTimes(1);
+    expect(sync.consumeRecentlySyncedQueueItem(queued.id)).toBe(true);
+    expect(await queue.listOfflineQueue()).toHaveLength(0);
+  });
+
+  it('getCanonicalQueueSize returns -1 when the canonical queue read fails', async () => {
+    const queue = await import('@/src/lib/queue');
+    const sync = await import('@/src/lib/sync');
+    const listSpy = vi.spyOn(queue, 'listOfflineQueue').mockRejectedValueOnce(new Error('read failed'));
+
+    await expect(sync.getCanonicalQueueSize()).resolves.toBe(-1);
+
+    listSpy.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Resumen

Este PR endurece el replay canónico de bundles clínicos para que:

- use bearer fresco tras un `401` real;
- preserve `403` como fallo terminal de autenticación/autorización;
- no degrade errores auth a network/server genéricos;
- mantenga idempotencia estable durante el replay;
- siga desacoplando el éxito clínico del bridge ICEA.

El alcance es quirúrgico: no cambia arquitectura, no toca backend y no mezcla analytics con el flujo clínico base.

## Causa raíz

Había tres problemas en el seam de replay/auth:

1. `403` podía colapsarse a auth genérica en `fhir-client.ts`, perdiendo semántica operativa.
2. `401` y `403` compartían tratamiento insuficientemente diferenciado en `sync.ts`.
3. Faltaba demostrar con evidencia ejecutada que el runtime canónico conservaba `ensureFreshToken/logout` al pasar por `configureCanonicalFhirClient()` y que el replay realmente hacía:
   - stale bearer,
   - `401`,
   - refresh real,
   - retry con bearer fresco,
   - éxito sin duplicación.

## Qué cambia

### 1) `fhir-client.ts`
- `ensureFreshToken` ahora admite `reason?: string`;
- se introduce `AuthStatusError` para preservar `401` y `403` con su status real;
- el retry tras `401` llama `ensureFreshToken('401')`;
- si tras el refresh vuelve `401` o aparece `403`, se preserva el status correcto;
- el outcome final distingue:
  - `401` → `login`
  - `403` → `forbidden`
  - `0/network` → `network`

### 2) `sync.ts`
- se distingue explícitamente `403` como auth terminal:
  - el item pasa a `error`;
  - el engine queda `paused`;
  - no entra en loop infinito.
- `401` permanece fail-closed pero reintentable solo con bearer fresco válido.
- el copy/estado de pausa usa `resolveSyncErrorMessage(...)` en vez de colapsar todo a “autenticación requerida”.
- `configureCanonicalFhirClient()` deja de sobreescribir `ensureFreshToken`; conserva los hooks ya registrados por `AuthProvider`.

### 3) `sync-errors.ts`
- `401` y `403` ya no comparten el mismo mensaje:
  - `401` → `sync.authRequiredMessage`
  - `403` → `sync.authFailedMessage`

### 4) Documentación mínima
- `docs/offline-sync-and-queue.md` deja explícito:
  - `401` pausa el replay hasta refresh/login;
  - `403` se conserva como fallo terminal en cola y no debe degradar a retry genérico.

## Qué no cambia

- no se toca backend;
- no se cambian contratos API;
- no se modifica arquitectura;
- no se altera el modelo clínico;
- no se toca ICEA ni analytics;
- no se cambia la lógica de éxito clínico, que sigue dependiendo del write FHIR y no del bridge ICEA.

## Clasificación final de errores de replay

- `401` → `auth-required`
  - pausa fail-closed;
  - exige bearer fresco;
  - puede completar replay si el refresh real funciona.

- `403` → `auth-failed`
  - terminal;
  - el item pasa a `error`;
  - sin retry infinito.

- `409/412` → evidencia de entrega idempotente
  - tratados como éxito clínico de replay.

- `422` → error de validación terminal

- otros `4xx` → client error terminal

- `5xx` → server error reintentable

- `0` / timeout / transporte → network error reintentable

## Pruebas ejecutadas

- `pnpm -w typecheck`
- `pnpm -w lint:ci`
- `pnpm exec vitest run tests/fhir-client.spec.ts src/lib/__tests__/sync-errors.spec.ts tests/queue/offline-queue.spec.ts tests/queue/offline-single-source-of-truth.spec.ts`

Resultado reportado:
- 4 archivos
- 34 tests
- todos passing

## Cobertura nueva o ajustada

- `tests/fhir-client.spec.ts`
  - preserva `403` como `403`
  - fuerza refresh real tras `401`
  - reintenta con bearer fresco

- `tests/queue/offline-queue.spec.ts`
  - `403` terminal fail-closed
  - prueba canónica end-to-end:
    - stale bearer
    - `401`
    - refresh real
    - retry con bearer fresco
    - mismo `Idempotency-Key`
    - sin duplicación
    - item removido de cola al éxito

- `tests/queue/offline-single-source-of-truth.spec.ts`
  - el shim/runtime reporta `403` como `auth-failed`
  - el item queda terminal en la cola canónica

- `src/lib/__tests__/sync-errors.spec.ts`
  - copy separado para `401` vs `403`

## Riesgos residuales

- Este PR cierra el seam de replay/auth, no todos los gaps globales del repositorio.
- La semántica correcta depende de que `setAuthHooks` siga haciendo merge y no replacement; la prueba nueva reduce mucho ese riesgo, pero no sustituye disciplina futura sobre ese punto.
- No sustituye auditorías backend más amplias de seguridad o permisos.

## Lectura correcta del PR

Este PR debe leerse como:

1. hardening del replay canónico de bundles,
2. separación correcta de auth outcomes (`401` vs `403`),
3. preservación del refresh real de bearer e idempotencia estable.

No debe leerse como:
- un cambio de arquitectura,
- una revisión integral del backend,
- ni un cierre total de todos los blockers del proyecto.