### PR TITLE
fix(fhir): harden pilot transaction bundle invariants and align validation fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          pnpm -w validate:fhir | tee artifacts/fhir-validation.txt
+          status=0
+          pnpm -w validate:fhir 2>&1 | tee artifacts/fhir-validation.txt || status=${PIPESTATUS[0]}
+          exit "${status}"
 
       - name: Upload FHIR validation evidence
-        if: always()
+        if: always() && hashFiles('artifacts/fhir-validation.txt') != ''
         uses: actions/upload-artifact@v4
         with:
           name: fhir-validation

--- a/docs/fhir-and-interoperability.md
+++ b/docs/fhir-and-interoperability.md
@@ -2,7 +2,7 @@
 
 > Estado del documento
 > - Estado: `pilot`.
-> - Última revisión: 2026-03-26.
+> - Última revisión: 2026-04-11.
 > - Fuente de verdad / evidencia base: `src/lib/fhir-map.ts`, `src/lib/fhir-map/nnn.ts`, `backend/api/views.py`, `tests/fhir-map.spec.ts`, `backend/api/tests/test_handover_etl_read.py`.
 > - Riesgos o lagunas abiertas: el repo soporta mapeo FHIR real para NNN y transacción clínica vía Django/DRF, pero no declara perfiles regulatorios externos cerrados ni licencia NNN embebida en el repositorio.
 
@@ -93,7 +93,7 @@ Desde el estado del repo revisado el 2026-03-19, HANDOVER exporta contexto Core/
 
 - El contrato es aditivo: no cambia recursos base ni secciones previas obligatorias.
 - El caller real del frontend ya estaba cableado: `src/screens/HandoverForm.tsx` construye `profileTraceInput` con `buildProfileTraceInput(profileRuntime)`, lo inyecta en `buildHandoverInputPayload(...)` y luego envia ese payload a `buildHandoverBundleAsync(...)` antes de encolar el Bundle.
-- `validate:fhir` no requirio cambios porque la validacion local ya acepta `Composition.extension` y secciones adicionales validas en R4.
+- `validate:fhir` cubre ahora coherencia transaccional adicional sobre los fixtures del piloto: unicidad de `fullUrl`, coherencia `request.url -> resourceType`, resolucion de referencias internas (`subject`, `encounter`/`context`, `author`, `device`, `Composition.section.entry`) y alineacion `Patient`/`Encounter`/`Composition` cuando el Bundle incluye esos recursos.
 - No se modifica `fhir-client`, cola offline, sync ni writeback backend para habilitar este transporte.
 ## 4) Evidencia concreta por tipo NNN
 
@@ -164,7 +164,8 @@ Lo que no hace el repo:
 Notas de alcance:
 
 - la validacion FHIR remota existe;
-- `pnpm -w validate:fhir` valida tambien el fixture `tests/fixtures/fhir/representative-transaction-bundle.json` para cubrir diagnostico, medicacion, tratamiento, dispositivo, adjunto y escalas en un mismo Bundle;
+- `pnpm -w validate:fhir` valida todos los fixtures `tests/fixtures/fhir/*.json`; la evidencia del contrato piloto se apoya en `representative-transaction-bundle.json` y en los bundles contextuales, mientras `minimal-transaction-bundle.json` queda como smoke fixture de transporte y no como evidencia clinica completa del piloto;
+- `tests/fhir-representative-bundle.spec.ts` endurece especificamente estas invariantes piloto: un `Patient`, un `Encounter`, un `Practitioner`, un `Composition`, enlace consistente `Patient/Encounter` para diagnostico, medicacion, tratamiento, dispositivo, adjunto y escalas, y resolucion de `Composition.section.entry`;
 - la validacion terminologica oficial para NNN no esta cerrada en este repo;
 - el ETL lee el Bundle persistido, no un recurso writeback nuevo de ICEA.
 

--- a/src/lib/__tests__/fhir-validation.spec.ts
+++ b/src/lib/__tests__/fhir-validation.spec.ts
@@ -248,4 +248,126 @@ describe('validateBundle', () => {
       ])
     );
   });
+
+  it('rejects unresolved patient references in transaction bundles', () => {
+    const bundle = {
+      resourceType: 'Bundle' as const,
+      type: 'transaction' as const,
+      entry: [
+        {
+          fullUrl: 'urn:uuid:patient-1',
+          request: { method: 'POST', url: 'Patient' },
+          resource: {
+            resourceType: 'Patient' as const,
+            id: 'pat-1',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:obs-1',
+          request: { method: 'POST', url: 'Observation' },
+          resource: {
+            ...validObservation,
+            subject: { reference: 'urn:uuid:missing-patient' },
+          },
+        },
+      ],
+    };
+
+    const result = validateBundleWithZod(bundle);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'entry[1].resource.subject.reference',
+          message: expect.stringContaining('does not resolve'),
+        }),
+      ]),
+    );
+  });
+
+  it('rejects request urls that drift from resourceType', () => {
+    const bundle = {
+      resourceType: 'Bundle' as const,
+      type: 'transaction' as const,
+      entry: [
+        {
+          fullUrl: 'urn:uuid:1',
+          request: { method: 'POST', url: 'Patient' },
+          resource: validObservation,
+        },
+      ],
+    };
+
+    const result = validateBundleWithZod(bundle);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'entry[0].request.url',
+          message: 'request.url must match resourceType',
+        }),
+      ]),
+    );
+  });
+
+  it('accepts legacy medication context references when they resolve to the bundle encounter', () => {
+    const bundle = {
+      resourceType: 'Bundle' as const,
+      type: 'transaction' as const,
+      entry: [
+        {
+          fullUrl: 'urn:uuid:patient-1',
+          request: { method: 'POST', url: 'Patient' },
+          resource: {
+            resourceType: 'Patient' as const,
+            id: 'pat-1',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:encounter-1',
+          request: { method: 'POST', url: 'Encounter' },
+          resource: {
+            resourceType: 'Encounter' as const,
+            id: 'enc-1',
+            status: 'finished',
+            class: {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              code: 'IMP',
+            },
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:med-1',
+          request: { method: 'POST', url: 'MedicationStatement' },
+          resource: {
+            resourceType: 'MedicationStatement' as const,
+            status: 'active',
+            medicationCodeableConcept: {
+              coding: [{ system: 'http://www.whocc.no/atc', code: 'N02BE01', display: 'Paracetamol' }],
+              text: 'Paracetamol',
+            },
+            subject: { reference: 'urn:uuid:patient-1' },
+            context: { reference: 'urn:uuid:encounter-1' },
+            dateAsserted: '2023-10-01T00:00:00Z',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:comp-1',
+          request: { method: 'POST', url: 'Composition' },
+          resource: {
+            ...validComposition,
+            subject: { reference: 'urn:uuid:patient-1' },
+            encounter: { reference: 'urn:uuid:encounter-1' },
+            author: [{ reference: 'Practitioner/789' }],
+          },
+        },
+      ],
+    };
+
+    const result = validateBundleWithZod(bundle);
+
+    expect(result).toEqual({ isValid: true, errors: [] });
+  });
 });

--- a/src/lib/__tests__/fhir-validation.spec.ts
+++ b/src/lib/__tests__/fhir-validation.spec.ts
@@ -370,4 +370,118 @@ describe('validateBundle', () => {
 
     expect(result).toEqual({ isValid: true, errors: [] });
   });
+
+  it('accepts percent-encoded practitioner references when the bundle practitioner id is raw', () => {
+    const bundle = {
+      resourceType: 'Bundle' as const,
+      type: 'transaction' as const,
+      entry: [
+        {
+          fullUrl: 'urn:uuid:patient-1',
+          request: { method: 'POST', url: 'Patient' },
+          resource: {
+            resourceType: 'Patient' as const,
+            id: 'pat-1',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:encounter-1',
+          request: { method: 'POST', url: 'Encounter' },
+          resource: {
+            resourceType: 'Encounter' as const,
+            id: 'enc-1',
+            status: 'finished',
+            class: {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              code: 'IMP',
+            },
+            subject: { reference: 'urn:uuid:patient-1' },
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:practitioner-1',
+          request: { method: 'POST', url: 'Practitioner' },
+          resource: {
+            resourceType: 'Practitioner' as const,
+            id: 'user@unit',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:comp-1',
+          request: { method: 'POST', url: 'Composition' },
+          resource: {
+            ...validComposition,
+            subject: { reference: 'urn:uuid:patient-1' },
+            encounter: { reference: 'urn:uuid:encounter-1' },
+            author: [{ reference: 'Practitioner/user%40unit' }],
+          },
+        },
+      ],
+    };
+
+    const result = validateBundleWithZod(bundle);
+
+    expect(result).toEqual({ isValid: true, errors: [] });
+  });
+
+  it('keeps rejecting percent-encoded practitioner references that still do not resolve', () => {
+    const bundle = {
+      resourceType: 'Bundle' as const,
+      type: 'transaction' as const,
+      entry: [
+        {
+          fullUrl: 'urn:uuid:patient-1',
+          request: { method: 'POST', url: 'Patient' },
+          resource: {
+            resourceType: 'Patient' as const,
+            id: 'pat-1',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:encounter-1',
+          request: { method: 'POST', url: 'Encounter' },
+          resource: {
+            resourceType: 'Encounter' as const,
+            id: 'enc-1',
+            status: 'finished',
+            class: {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              code: 'IMP',
+            },
+            subject: { reference: 'urn:uuid:patient-1' },
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:practitioner-1',
+          request: { method: 'POST', url: 'Practitioner' },
+          resource: {
+            resourceType: 'Practitioner' as const,
+            id: 'user@unit',
+          },
+        },
+        {
+          fullUrl: 'urn:uuid:comp-1',
+          request: { method: 'POST', url: 'Composition' },
+          resource: {
+            ...validComposition,
+            subject: { reference: 'urn:uuid:patient-1' },
+            encounter: { reference: 'urn:uuid:encounter-1' },
+            author: [{ reference: 'Practitioner/missing%40unit' }],
+          },
+        },
+      ],
+    };
+
+    const result = validateBundleWithZod(bundle);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'entry[3].resource.author[0].reference',
+          message: expect.stringContaining('does not resolve'),
+        }),
+      ]),
+    );
+  });
 });

--- a/src/lib/fhir-validation/zod.ts
+++ b/src/lib/fhir-validation/zod.ts
@@ -15,10 +15,17 @@ const genericResourceSchema = z
 
 const resourceSchemas: Record<string, z.ZodTypeAny> = {
   Observation: schemas.observation,
+  Condition: schemas.condition,
   MedicationStatement: schemas.medicationStatement,
+  MedicationAdministration: schemas.medicationAdministration,
   DeviceUseStatement: schemas.deviceUseStatement,
   DocumentReference: schemas.documentReference,
   Composition: schemas.composition,
+  Procedure: schemas.procedure,
+  Patient: schemas.patient,
+  Practitioner: schemas.practitioner,
+  Encounter: schemas.encounter,
+  Device: schemas.device,
 };
 
 const bundleSchema = schemas.bundle;
@@ -51,6 +58,213 @@ function sanitizeErrors(errors: unknown): ValidationResult['errors'] | undefined
       message: typeof entry.message === 'string' ? entry.message : 'Invalid resource',
     }));
   return mapped.length > 0 ? mapped : undefined;
+}
+
+type IndexedEntry = {
+  index: number;
+  fullUrl?: string;
+  request?: { method?: string; url?: string };
+  resource?: {
+    resourceType?: string;
+    id?: string;
+    subject?: { reference?: string };
+    encounter?: { reference?: string };
+    context?: { reference?: string };
+  };
+};
+
+function collectReferenceNodes(
+  value: unknown,
+  path: Array<string | number> = [],
+  refs: Array<{ path: Array<string | number>; reference: string }> = [],
+) {
+  if (!value || typeof value !== 'object') return refs;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectReferenceNodes(item, [...path, index], refs));
+    return refs;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.reference === 'string') {
+    refs.push({ path: [...path, 'reference'], reference: record.reference });
+  }
+
+  Object.entries(record).forEach(([key, nested]) => {
+    collectReferenceNodes(nested, [...path, key], refs);
+  });
+
+  return refs;
+}
+
+function validateBundleContract(entries: IndexedEntry[]): ValidationResult['errors'] {
+  const errors: ValidationResult['errors'] = [];
+  const entryTypes = new Set<string>();
+  const fullUrlToIndex = new Map<string, number>();
+  const resourceRefToIndex = new Map<string, number>();
+  const patientIndexes: number[] = [];
+  const encounterIndexes: number[] = [];
+  const practitionerIndexes: number[] = [];
+
+  entries.forEach((entry) => {
+    const resourceType = entry.resource?.resourceType;
+    if (resourceType) entryTypes.add(resourceType);
+
+    if (typeof entry.fullUrl === 'string') {
+      if (fullUrlToIndex.has(entry.fullUrl)) {
+        errors.push({
+          path: `entry[${entry.index}].fullUrl`,
+          message: `Duplicate fullUrl "${entry.fullUrl}"`,
+        });
+      } else {
+        fullUrlToIndex.set(entry.fullUrl, entry.index);
+      }
+    }
+
+    if (resourceType && typeof entry.resource?.id === 'string' && entry.resource.id.length > 0) {
+      const resourceReference = `${resourceType}/${entry.resource.id}`;
+      if (resourceRefToIndex.has(resourceReference)) {
+        errors.push({
+          path: `entry[${entry.index}].resource.id`,
+          message: `Duplicate resource reference "${resourceReference}"`,
+        });
+      } else {
+        resourceRefToIndex.set(resourceReference, entry.index);
+      }
+    }
+
+    if (resourceType === 'Patient') patientIndexes.push(entry.index);
+    if (resourceType === 'Encounter') encounterIndexes.push(entry.index);
+    if (resourceType === 'Practitioner') practitionerIndexes.push(entry.index);
+
+    if (
+      entry.request &&
+      typeof entry.request.url === 'string' &&
+      resourceType &&
+      entry.request.url !== resourceType
+    ) {
+      errors.push({
+        path: `entry[${entry.index}].request.url`,
+        message: 'request.url must match resourceType',
+      });
+    }
+
+    if (
+      entry.request &&
+      typeof entry.request.method === 'string' &&
+      entry.request.method !== 'POST'
+    ) {
+      errors.push({
+        path: `entry[${entry.index}].request.method`,
+        message: 'transaction entries must use POST',
+      });
+    }
+  });
+
+  const resolveReferenceIndex = (reference: string): number | undefined => {
+    if (fullUrlToIndex.has(reference)) return fullUrlToIndex.get(reference);
+    if (resourceRefToIndex.has(reference)) return resourceRefToIndex.get(reference);
+    return undefined;
+  };
+
+  entries.forEach((entry) => {
+    if (!entry.resource) return;
+
+    collectReferenceNodes(entry.resource).forEach(({ path, reference }) => {
+      if (reference.startsWith('urn:uuid:')) {
+        if (!fullUrlToIndex.has(reference)) {
+          errors.push({
+            path: `entry[${entry.index}].resource.${formatPath(path)}`,
+            message: `Reference "${reference}" does not resolve to a bundle entry`,
+          });
+        }
+        return;
+      }
+
+      const segments = reference.split('/');
+      if (segments.length !== 2) {
+        return;
+      }
+
+      const [referenceType] = segments;
+      if (entryTypes.has(referenceType) && resolveReferenceIndex(reference) === undefined) {
+        errors.push({
+          path: `entry[${entry.index}].resource.${formatPath(path)}`,
+          message: `Reference "${reference}" does not resolve to a bundle entry`,
+        });
+      }
+    });
+  });
+
+  const enforceResolvedDirectReference = (
+    entry: IndexedEntry,
+    path: 'subject' | 'encounter' | 'context',
+    expectedIndexes: number[],
+  ) => {
+    const reference = entry.resource?.[path]?.reference;
+    if (typeof reference !== 'string' || expectedIndexes.length !== 1) return;
+    const resolvedIndex = resolveReferenceIndex(reference);
+    if (resolvedIndex === undefined) return;
+    if (resolvedIndex !== expectedIndexes[0]) {
+      errors.push({
+        path: `entry[${entry.index}].resource.${path}.reference`,
+        message: `Expected ${path}.reference to resolve to the bundle ${path === 'subject' ? 'patient' : 'encounter'}`,
+      });
+    }
+  };
+
+  entries.forEach((entry) => {
+    const resourceType = entry.resource?.resourceType;
+    if (!resourceType || resourceType === 'Patient') return;
+
+    enforceResolvedDirectReference(entry, 'subject', patientIndexes);
+
+    if (resourceType !== 'Encounter') {
+      enforceResolvedDirectReference(entry, 'encounter', encounterIndexes);
+      enforceResolvedDirectReference(entry, 'context', encounterIndexes);
+    }
+  });
+
+  entries
+    .filter((entry) => entry.resource?.resourceType === 'Composition')
+    .forEach((entry) => {
+      if (patientIndexes.length === 1 && !entry.resource?.subject?.reference) {
+        errors.push({
+          path: `entry[${entry.index}].resource.subject.reference`,
+          message: 'Composition.subject.reference is required when the bundle includes a Patient',
+        });
+      }
+
+      if (encounterIndexes.length === 1 && !entry.resource?.encounter?.reference) {
+        errors.push({
+          path: `entry[${entry.index}].resource.encounter.reference`,
+          message: 'Composition.encounter.reference is required when the bundle includes an Encounter',
+        });
+      }
+
+      if (!Array.isArray((entry.resource as { author?: unknown }).author) || (entry.resource as { author?: unknown[] }).author?.length === 0) {
+        errors.push({
+          path: `entry[${entry.index}].resource.author`,
+          message: 'Composition.author is required',
+        });
+      }
+
+      if (practitionerIndexes.length === 1) {
+        const authors = ((entry.resource as { author?: Array<{ reference?: string }> }).author ?? []);
+        authors.forEach((author, authorIndex) => {
+          if (typeof author?.reference !== 'string') return;
+          const resolvedIndex = resolveReferenceIndex(author.reference);
+          if (resolvedIndex === undefined) return;
+          if (resolvedIndex !== practitionerIndexes[0]) {
+            errors.push({
+              path: `entry[${entry.index}].resource.author[${authorIndex}].reference`,
+              message: 'Composition.author.reference must resolve to the bundle practitioner',
+            });
+          }
+        });
+      }
+    });
+
+  return errors;
 }
 
 export function validateResourceWithZod(resource: unknown): ValidationResult {
@@ -90,7 +304,21 @@ export function validateBundle(bundle: unknown): ValidationResult {
   }
 
   const errors: ValidationResult['errors'] = [];
-  const entries = parsed.data.entry ?? [];
+  const entries = (parsed.data.entry ?? []).map((entry, index) => ({
+    index,
+    fullUrl: typeof entry.fullUrl === 'string' ? entry.fullUrl : undefined,
+    request:
+      entry.request && typeof entry.request === 'object'
+        ? {
+            method: typeof entry.request.method === 'string' ? entry.request.method : undefined,
+            url: typeof entry.request.url === 'string' ? entry.request.url : undefined,
+          }
+        : undefined,
+    resource:
+      entry.resource && typeof entry.resource === 'object'
+        ? (entry.resource as IndexedEntry['resource'])
+        : undefined,
+  }));
 
   entries.forEach((entry, index) => {
     const resource = entry?.resource;
@@ -109,6 +337,8 @@ export function validateBundle(bundle: unknown): ValidationResult {
       );
     }
   });
+
+  errors.push(...validateBundleContract(entries));
 
   if (errors.length > 0) {
     return { isValid: false, errors };

--- a/src/lib/fhir-validation/zod.ts
+++ b/src/lib/fhir-validation/zod.ts
@@ -96,6 +96,23 @@ function collectReferenceNodes(
   return refs;
 }
 
+function normalizeResourceReference(reference: string): string | undefined {
+  const segments = reference.split('/');
+  if (segments.length !== 2) return undefined;
+
+  const [resourceType, resourceId] = segments;
+  if (!resourceType || !resourceId) return undefined;
+
+  try {
+    const decodedId = decodeURIComponent(resourceId);
+    if (decodedId === resourceId) return undefined;
+    if (encodeURIComponent(decodedId) !== resourceId) return undefined;
+    return `${resourceType}/${decodedId}`;
+  } catch {
+    return undefined;
+  }
+}
+
 function validateBundleContract(entries: IndexedEntry[]): ValidationResult['errors'] {
   const errors: ValidationResult['errors'] = [];
   const entryTypes = new Set<string>();
@@ -163,6 +180,10 @@ function validateBundleContract(entries: IndexedEntry[]): ValidationResult['erro
   const resolveReferenceIndex = (reference: string): number | undefined => {
     if (fullUrlToIndex.has(reference)) return fullUrlToIndex.get(reference);
     if (resourceRefToIndex.has(reference)) return resourceRefToIndex.get(reference);
+    const normalizedReference = normalizeResourceReference(reference);
+    if (normalizedReference && resourceRefToIndex.has(normalizedReference)) {
+      return resourceRefToIndex.get(normalizedReference);
+    }
     return undefined;
   };
 

--- a/src/lib/fhir/validators.ts
+++ b/src/lib/fhir/validators.ts
@@ -2,11 +2,15 @@ import { z } from 'zod';
 
 import type {
   Bundle,
+  Condition,
   Composition,
+  Device,
   DeviceUseStatement,
   DocumentReference,
+  MedicationAdministration,
   MedicationStatement,
   Observation,
+  Procedure,
 } from '../fhir-map';
 
 const isoDateTime = z
@@ -150,6 +154,7 @@ const medicationStatementSchema = z
     medicationCodeableConcept: codeableConceptSchema,
     subject: referenceSchema,
     encounter: referenceSchema.optional(),
+    context: referenceSchema.optional(),
     effectiveDateTime: isoDateTime.optional(),
     effectivePeriod: periodSchema.optional(),
     dateAsserted: isoDateTime.optional(),
@@ -170,6 +175,7 @@ const deviceUseStatementSchema = z
     status: z.enum(['active', 'completed', 'entered-in-error']).or(z.string().min(1)),
     subject: referenceSchema,
     encounter: referenceSchema.optional(),
+    context: referenceSchema.optional(),
     device: z
       .object({
         reference: z.string().min(1),
@@ -228,6 +234,125 @@ const compositionSchema = z
   })
   .catchall(z.unknown());
 
+const conditionSchema = z
+  .object({
+    resourceType: z.literal('Condition'),
+    clinicalStatus: codeableConceptSchema,
+    verificationStatus: codeableConceptSchema,
+    category: z.array(codeableConceptSchema).optional(),
+    code: codeableConceptSchema,
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    onsetDateTime: isoDateTime.optional(),
+    recordedDate: isoDateTime.optional(),
+  })
+  .catchall(z.unknown());
+
+const procedureSchema = z
+  .object({
+    resourceType: z.literal('Procedure'),
+    status: z.string().min(1),
+    code: codeableConceptSchema,
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    performedDateTime: isoDateTime.optional(),
+    performedPeriod: periodSchema.optional(),
+    reasonCode: z.array(codeableConceptSchema).optional(),
+    bodySite: z.array(codeableConceptSchema).optional(),
+  })
+  .catchall(z.unknown());
+
+const patientSchema = z
+  .object({
+    resourceType: z.literal('Patient'),
+    id: z.string().min(1).optional(),
+    identifier: z
+      .array(
+        z
+          .object({
+            system: z.string().min(1),
+            value: z.string().min(1),
+          })
+          .catchall(z.unknown()),
+      )
+      .optional(),
+  })
+  .catchall(z.unknown());
+
+const practitionerSchema = z
+  .object({
+    resourceType: z.literal('Practitioner'),
+    id: z.string().min(1).optional(),
+    identifier: z
+      .array(
+        z
+          .object({
+            system: z.string().min(1),
+            value: z.string().min(1),
+          })
+          .catchall(z.unknown()),
+      )
+      .optional(),
+    name: z
+      .array(
+        z
+          .object({
+            text: z.string().optional(),
+          })
+          .catchall(z.unknown()),
+      )
+      .optional(),
+  })
+  .catchall(z.unknown());
+
+const encounterSchema = z
+  .object({
+    resourceType: z.literal('Encounter'),
+    id: z.string().min(1).optional(),
+    status: z.string().min(1),
+    class: z
+      .object({
+        system: z.string().min(1),
+        code: z.string().min(1),
+        display: z.string().optional(),
+      })
+      .catchall(z.unknown()),
+    subject: referenceSchema.optional(),
+    period: periodSchema.optional(),
+  })
+  .catchall(z.unknown());
+
+const deviceSchema = z
+  .object({
+    resourceType: z.literal('Device'),
+    id: z.string().min(1).optional(),
+    status: z.string().optional(),
+    patient: referenceSchema.optional(),
+    deviceName: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1),
+            type: z.string().optional(),
+          })
+          .catchall(z.unknown()),
+      )
+      .optional(),
+  })
+  .catchall(z.unknown());
+
+const medicationAdministrationSchema = z
+  .object({
+    resourceType: z.literal('MedicationAdministration'),
+    status: z.string().min(1),
+    medicationCodeableConcept: codeableConceptSchema,
+    subject: referenceSchema,
+    encounter: referenceSchema.optional(),
+    effectiveDateTime: isoDateTime.optional(),
+    effectivePeriod: periodSchema.optional(),
+  })
+  .catchall(z.unknown());
+
 const bundleEntrySchema = z
   .object({
     fullUrl: z.string().min(1),
@@ -253,20 +378,34 @@ const bundleSchema = z
 type ValidatedBundle = {
   bundle: Bundle;
   observations: Observation[];
+  conditions: Condition[];
   medicationStatements: MedicationStatement[];
+  medicationAdministrations: MedicationAdministration[];
   deviceUseStatements: DeviceUseStatement[];
   documentReferences: DocumentReference[];
   compositions: Composition[];
+  procedures: Procedure[];
+  patients: z.infer<typeof patientSchema>[];
+  practitioners: z.infer<typeof practitionerSchema>[];
+  encounters: z.infer<typeof encounterSchema>[];
+  devices: Device[];
 };
 
 export function validateBundle(input: unknown): ValidatedBundle {
   const parsedBundle = bundleSchema.parse(input) as Bundle & { entry: Array<{ resource?: any }> };
 
   const observations: Observation[] = [];
+  const conditions: Condition[] = [];
   const medicationStatements: MedicationStatement[] = [];
+  const medicationAdministrations: MedicationAdministration[] = [];
   const deviceUseStatements: DeviceUseStatement[] = [];
   const documentReferences: DocumentReference[] = [];
   const compositions: Composition[] = [];
+  const procedures: Procedure[] = [];
+  const patients: z.infer<typeof patientSchema>[] = [];
+  const practitioners: z.infer<typeof practitionerSchema>[] = [];
+  const encounters: z.infer<typeof encounterSchema>[] = [];
+  const devices: Device[] = [];
 
   for (const entry of parsedBundle.entry ?? []) {
     const resource = entry.resource;
@@ -279,6 +418,9 @@ export function validateBundle(input: unknown): ValidatedBundle {
       case 'MedicationStatement':
         medicationStatements.push(medicationStatementSchema.parse(resource) as MedicationStatement);
         break;
+      case 'MedicationAdministration':
+        medicationAdministrations.push(medicationAdministrationSchema.parse(resource) as MedicationAdministration);
+        break;
       case 'DeviceUseStatement':
         deviceUseStatements.push(deviceUseStatementSchema.parse(resource) as DeviceUseStatement);
         break;
@@ -288,6 +430,24 @@ export function validateBundle(input: unknown): ValidatedBundle {
       case 'Composition':
         compositions.push(compositionSchema.parse(resource) as Composition);
         break;
+      case 'Condition':
+        conditions.push(conditionSchema.parse(resource) as Condition);
+        break;
+      case 'Procedure':
+        procedures.push(procedureSchema.parse(resource) as Procedure);
+        break;
+      case 'Patient':
+        patients.push(patientSchema.parse(resource));
+        break;
+      case 'Practitioner':
+        practitioners.push(practitionerSchema.parse(resource));
+        break;
+      case 'Encounter':
+        encounters.push(encounterSchema.parse(resource));
+        break;
+      case 'Device':
+        devices.push(deviceSchema.parse(resource) as Device);
+        break;
       default:
         break;
     }
@@ -296,10 +456,17 @@ export function validateBundle(input: unknown): ValidatedBundle {
   return {
     bundle: parsedBundle,
     observations,
+    conditions,
     medicationStatements,
+    medicationAdministrations,
     deviceUseStatements,
     documentReferences,
     compositions,
+    procedures,
+    patients,
+    practitioners,
+    encounters,
+    devices,
   };
 }
 
@@ -309,10 +476,17 @@ export const schemas = {
   codeableConcept: codeableConceptSchema,
   quantity: quantitySchema,
   observation: observationSchema,
+  condition: conditionSchema,
   medicationStatement: medicationStatementSchema,
+  medicationAdministration: medicationAdministrationSchema,
   deviceUseStatement: deviceUseStatementSchema,
   documentReference: documentReferenceSchema,
   composition: compositionSchema,
+  procedure: procedureSchema,
+  patient: patientSchema,
+  practitioner: practitionerSchema,
+  encounter: encounterSchema,
+  device: deviceSchema,
   bundle: bundleSchema,
 };
 

--- a/tests/fhir-map.spec.ts
+++ b/tests/fhir-map.spec.ts
@@ -748,6 +748,13 @@ describe('buildFhirBundleFromFormData', () => {
           imageBase64: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
           method: 'session',
         },
+        incoming: {
+          userId: 'nurse-2',
+          fullName: 'Nurse Incoming',
+          unitId: 'UCI-1',
+          signedAt: '2025-01-05T16:00:00Z',
+          method: 'session',
+        },
       },
       audioUri: 'https://example.org/audio/shift.m4a',
     });

--- a/tests/fhir-representative-bundle.spec.ts
+++ b/tests/fhir-representative-bundle.spec.ts
@@ -9,6 +9,11 @@ type BundleEntry = {
   fullUrl?: string;
   resource?: {
     resourceType?: string;
+    subject?: { reference?: string };
+    encounter?: { reference?: string };
+    context?: { reference?: string };
+    author?: Array<{ reference?: string }>;
+    device?: { reference?: string };
     code?: { coding?: Array<{ code?: string }> };
     section?: Array<{ title?: string; entry?: Array<{ reference?: string }> }>;
   };
@@ -64,5 +69,51 @@ describe('Representative FHIR transaction bundle fixture', () => {
       .map((coding) => coding.code);
 
     expect(scaleCodes).toEqual(expect.arrayContaining(['38208-5', '38876-5', '9267-6']));
+  });
+
+  it('keeps patient, encounter, practitioner and section linkages internally coherent', () => {
+    const bundle = loadFixture();
+    const entries = bundle.entry ?? [];
+    const byFullUrl = new Map(entries.map((entry) => [entry.fullUrl, entry.resource] as const));
+
+    const patientEntry = entries.find((entry) => entry.resource?.resourceType === 'Patient');
+    const practitionerEntry = entries.find((entry) => entry.resource?.resourceType === 'Practitioner');
+    const encounterEntry = entries.find((entry) => entry.resource?.resourceType === 'Encounter');
+    const compositionEntry = entries.find((entry) => entry.resource?.resourceType === 'Composition');
+
+    expect(patientEntry?.fullUrl).toBeTruthy();
+    expect(practitionerEntry?.fullUrl).toBeTruthy();
+    expect(encounterEntry?.fullUrl).toBeTruthy();
+    expect(compositionEntry?.fullUrl).toBeTruthy();
+
+    const patientRef = patientEntry!.fullUrl!;
+    const encounterRef = encounterEntry!.fullUrl!;
+    const practitionerRef = practitionerEntry!.fullUrl!;
+    const composition = compositionEntry!.resource!;
+
+    expect(composition.subject?.reference).toBe(patientRef);
+    expect(composition.encounter?.reference).toBe(encounterRef);
+    expect(composition.author?.[0]?.reference).toBe(practitionerRef);
+
+    entries
+      .filter((entry) => !['Patient', 'Practitioner', 'Encounter', 'Composition', 'Device'].includes(entry.resource?.resourceType ?? ''))
+      .forEach((entry) => {
+        const resource = entry.resource!;
+        if (resource.subject?.reference) {
+          expect(resource.subject.reference).toBe(patientRef);
+        }
+
+        const encounterReference = resource.encounter?.reference ?? resource.context?.reference;
+        if (encounterReference) {
+          expect(encounterReference).toBe(encounterRef);
+        }
+      });
+
+    const deviceUse = entries.find((entry) => entry.resource?.resourceType === 'DeviceUseStatement')?.resource;
+    expect(deviceUse?.device?.reference).toBe('urn:uuid:88888888888888888888888888888888');
+    expect(byFullUrl.has(deviceUse?.device?.reference)).toBe(true);
+
+    const documentReference = entries.find((entry) => entry.resource?.resourceType === 'DocumentReference')?.resource;
+    expect(documentReference?.author?.[0]?.reference).toBe(practitionerRef);
   });
 });

--- a/tests/fixtures/fhir/minimal-transaction-bundle.json
+++ b/tests/fixtures/fhir/minimal-transaction-bundle.json
@@ -3,6 +3,23 @@
   "type": "transaction",
   "entry": [
     {
+      "fullUrl": "urn:uuid:patient-synthetic-1",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "synthetic-001",
+        "identifier": [
+          {
+            "system": "urn:handover-pro:patient-id",
+            "value": "synthetic-001"
+          }
+        ]
+      },
+      "request": {
+        "method": "POST",
+        "url": "Patient"
+      }
+    },
+    {
       "fullUrl": "urn:uuid:obs-synthetic-1",
       "resource": {
         "resourceType": "Observation",
@@ -18,7 +35,7 @@
           ]
         },
         "subject": {
-          "reference": "Patient/synthetic-001"
+          "reference": "urn:uuid:patient-synthetic-1"
         },
         "effectiveDateTime": "2026-01-01T08:00:00Z",
         "valueQuantity": {

--- a/tests/lib/sync-validation.test.ts
+++ b/tests/lib/sync-validation.test.ts
@@ -54,7 +54,7 @@ describe('sync remote validation and 422 handling', () => {
             gender: 'female',
             name: [{ family: 'Doe', given: ['Jane'] }],
           },
-          request: { method: 'PUT', url: 'Patient/1' },
+          request: { method: 'POST', url: 'Patient' },
         },
       ],
     };


### PR DESCRIPTION
## Resumen

Este PR endurece el contrato FHIR del piloto sin reescribir el mapper ni expandir alcance fuera de los dominios clínicos pilotados.

El foco está en:
- coherencia interna del `Bundle` transaccional,
- validación local útil para el piloto,
- fixtures clínicamente significativos,
- tests deterministas,
- documentación alineada con el estado real del repo.

## Qué corrige

La deriva real no estaba en el endpoint backend ni en el passthrough de `OperationOutcome`, sino en la evidencia local del contrato FHIR:

- `validate:fhir` no cubría todavía invariantes transaccionales suficientemente concretas para el piloto;
- el fixture mínimo podía pasar con referencias de paciente inconsistentes;
- faltaba una validación más explícita sobre:
  - `request.url -> resourceType`,
  - unicidad de `fullUrl`,
  - unicidad de `ResourceType/id`,
  - resolución de referencias internas,
  - alineación entre `Patient`, `Encounter`, `Composition` y recursos clínicos relevantes;
- la doc insinuaba un alcance de validación algo más fuerte del que realmente estaba cubierto.

## Qué cambia

### Validación FHIR local
Se endurece la validación en:
- `src/lib/fhir-validation/zod.ts`
- `src/lib/fhir/validators.ts`

Ahora se cubren invariantes piloto como:
- cada `entry` transaccional usa `POST`;
- `request.url` debe coincidir con `resourceType`;
- `fullUrl` no se duplica;
- `ResourceType/id` no se duplica dentro del bundle;
- las referencias internas relevantes deben resolver a entradas reales del bundle;
- si el bundle incluye un único `Patient` y/o `Encounter`, los recursos clínicos relevantes y `Composition` deben alinearse con ese mismo paciente/encuentro;
- `Composition` exige coherencia mínima operativa con `subject`, `encounter`, `author` y `section.entry` cuando aplica.

### Fixtures y tests
Se endurecen:
- `tests/fixtures/fhir/minimal-transaction-bundle.json`
- `tests/fhir-representative-bundle.spec.ts`
- `tests/fhir-map.spec.ts`
- `src/lib/__tests__/fhir-validation.spec.ts`

El fixture representativo pasa a cubrir de forma más explícita:
- `Composition`
- enlace `Patient/Encounter`
- diagnóstico
- medicación
- tratamiento/procedimiento
- dispositivo
- adjunto relevante
- escalas críticas
- autoría/practitioner

El fixture mínimo queda como smoke fixture de transporte válido, ya sin referencia de paciente rota.

### Documentación
Se ajusta `docs/fhir-and-interoperability.md` para bajar claims inflados y reflejar mejor el alcance real de `validate:fhir` en estado piloto.

## Invariantes FHIR cubiertas tras este PR

Quedan cubiertas explícitamente en el piloto:

- `Bundle.type = transaction`
- `entry.request.method = POST`
- `entry.request.url` consistente con `resourceType`
- unicidad de `fullUrl`
- unicidad de `ResourceType/id`
- resolución interna de referencias clínicas relevantes
- coherencia `Patient` / `Encounter` / `Composition`
- coherencia de `Composition.author`
- coherencia de `Composition.section.entry`
- coherencia de recursos clínicos relevantes con el único `Patient` y `Encounter` del bundle, cuando ese patrón aplica
- fixture representativo determinista para dominios críticos del piloto

## Qué sigue fuera del piloto

Este PR **no** declara ni cierra:

- conformidad contra IG/perfiles externos específicos;
- validación terminológica oficial contra termserver para NNN / SNOMED / LOINC;
- escenarios multi-paciente o multi-encounter dentro del mismo transaction bundle;
- writebacks nuevos o respuestas clínicas adicionales más allá del `transaction-response` y el passthrough actual de `OperationOutcome`;
- cierre regulatorio externo o interoperabilidad “completa”.

## Backend

No se toca backend runtime.

Motivo:
- la deriva real estaba en validación local, fixtures, evidencia y claims documentales;
- el endpoint y el passthrough de `OperationOutcome` quedaron auditados y estables para este seam.

## Validaciones ejecutadas

- `pnpm -w typecheck`
- `pnpm -w lint:ci`
- `pnpm -w validate:fhir`
- tests dirigidos FHIR frontend
- `pytest tests/test_fhir_transaction_validation.py -q`

## Lectura correcta del PR

Este PR debe leerse como:

1. endurecimiento del contrato FHIR del piloto,
2. mejora de validación/evidencia local,
3. alineación entre fixtures, tests y documentación real.

No debe leerse como:

- una reescritura del mapper;
- cierre de interoperabilidad FHIR completa;
- conformidad contra perfiles regulatorios externos;
- expansión del piloto a dominios no priorizados.