### PR TITLE
fix(icea): isolate clinical success from post-FHIR shadow-side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,12 +367,14 @@ HANDOVER incluye ahora un puente analitico dedicado hacia ICEA+ que se activa **
 Que hace HANDOVER:
 - estructura y mapea el Bundle FHIR a un payload analitico v1;
 - envia la solicitud de scoring de forma desacoplada y no bloqueante;
+- degrada de forma honesta si fallan outbox, persistencia tecnica, snapshot o bridge, sin cambiar el exito clinico ya confirmado;
 - persiste estado visible, hash, warnings, modo de scoring y resumen minimo del resultado;
-- expone endpoints `/api/icea/bridge/*` para UI y dashboards.
+- expone endpoints `/api/icea/bridge/*` solo para trazabilidad tecnica y superficies agregadas/admin autorizadas.
 
 Que no hace HANDOVER:
 - no ejecuta el motor matematico de ICEA+;
 - no afirma conclusiones clinicas definitivas en `immediate_provisional`;
+- no habilita dashboards nominales, scoring individual, resumen causal visible ni evaluacion profesional individual;
 - no permite llamadas directas desde la app movil a ICEA+.
 
 Flags principales:
@@ -381,7 +383,7 @@ Flags principales:
 
 Mientras el upstream ICEA+ no publique un endpoint real de status para score, HANDOVER no inventa polling: el estado local visible pasa a ser la fuente operativa y solo se intenta refresh remoto cuando el cliente pide `refresh=true` y existe `ICEA_BRIDGE_STATUS_PATH` configurado.
 
-En postura de piloto prudente, HANDOVER conserva la trazabilidad tecnica del bridge pero suprime cualquier salida ICEA paciente-a-paciente en la UI operativa, incluido score individual, resumen causal y soporte bedside visible.
+En postura de piloto prudente, HANDOVER conserva la trazabilidad tecnica del bridge pero suprime cualquier salida ICEA paciente-a-paciente en la UI operativa, incluido score individual, resumen causal, soporte bedside visible y cualquier uso nominal o punitivo.
 
 Documentacion relacionada:
 - [Bridge analitico ICEA+](docs/icea-bridge.md)

--- a/backend/api/icea_transaction.py
+++ b/backend/api/icea_transaction.py
@@ -101,7 +101,10 @@ def persist_successful_transaction_icea_side_effects(
         logger.exception("ICEA outbox enqueue failed after successful clinical transaction")
 
     if persist_bundle_record is not None:
-        persist_bundle_record(bundle=bundle, request=request)
+        try:
+            persist_bundle_record(bundle=bundle, request=request)
+        except Exception:
+            logger.exception("ICEA bundle persistence failed after successful clinical transaction")
 
     try:
         snapshot_callback(bundle=bundle, request=request)

--- a/backend/api/tests/test_icea_transaction.py
+++ b/backend/api/tests/test_icea_transaction.py
@@ -95,3 +95,50 @@ class IceaTransactionFlowRegressionTests(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(order, ['outbox', 'persist', 'snapshot', 'bridge'])
+
+    @patch('backend.api.icea_transaction.logger')
+    @patch('backend.api.views._create_audit_event_for_transaction', autospec=True)
+    @patch('backend.api.views._post_transaction_to_fhir')
+    def test_successful_transaction_keeps_clinical_201_when_bundle_record_persistence_fails(
+        self,
+        mock_fhir_post,
+        _mock_audit,
+        mock_logger,
+    ):
+        order: list[str] = []
+        mock_fhir_post.return_value = build_fhir_response()
+
+        def record(name: str, *, error: Exception | None = None):
+            def _inner(*args, **kwargs):
+                order.append(name)
+                if error is not None:
+                    raise error
+                return None
+
+            return _inner
+
+        with patch(
+            'backend.api.views.enqueue_icea_outbound_event_for_transaction',
+            side_effect=record('outbox'),
+        ), patch(
+            'backend.api.views._persist_handover_bundle_record',
+            side_effect=record('persist', error=RuntimeError('bundle store unavailable')),
+        ), patch(
+            'backend.api.views.ensure_pipeline_snapshot_from_bundle',
+            side_effect=record('snapshot'),
+        ), patch(
+            'backend.api.views.enqueue_icea_bridge_request_for_transaction',
+            side_effect=record('bridge'),
+        ):
+            response = self.client.post(
+                self.url,
+                data=build_icea_bundle(bundle_id='bundle-persist-fail-001', patient_id='pat-persist-fail-001', unit_id='icu-a'),
+                format='json',
+                HTTP_IDEMPOTENCY_KEY='req-persist-fail-001',
+            )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(order, ['outbox', 'persist', 'snapshot', 'bridge'])
+        mock_logger.exception.assert_called_once_with(
+            'ICEA bundle persistence failed after successful clinical transaction',
+        )

--- a/docs/icea-bridge.md
+++ b/docs/icea-bridge.md
@@ -2,25 +2,27 @@
 
 ## Objetivo
 
-HANDOVER construye y entrega un payload analitico trazable hacia ICEA+ **despues** de persistir con exito la transaccion clinica. El calculo analitico sigue viviendo en ICEA+; HANDOVER no duplica el motor matematico.
+HANDOVER construye y entrega un payload analitico trazable hacia ICEA+ **solo despues** de confirmar con exito la transaccion clinica FHIR. El calculo analitico sigue viviendo en ICEA+; HANDOVER no duplica el motor matematico.
 
 Principios aplicados:
 - clinica primero: un fallo de ICEA+ no revierte el guardado del handover;
+- shadow mode estricto: outbox, snapshots, bridge y cualquier persistencia tecnica post-FHIR degradan de forma best-effort y no contaminan el exito clinico ya confirmado;
 - backend unico: React Native solo consume el backend HANDOVER;
 - scoring honesto: `immediate_provisional` no implica conclusiones definitivas ni habilita score individual visible;
 - trazabilidad completa: request id, hash, contrato y estado quedan persistidos en HANDOVER.
 
 ## Flujo real
 
-1. `POST /api/fhir/transaction` persiste el Bundle FHIR y el `HandoverBundleRecord`.
-2. HANDOVER actualiza el snapshot tecnico del pipeline ICEA ya existente.
-3. Si `ENABLE_ICEA_BRIDGE=true`, HANDOVER crea o actualiza un `IceaBridgeRequest`.
-4. Se construye el payload analitico v1 en `backend/api/icea_payload_mapper.py`.
-5. La entrega a ICEA+ se intenta de forma desacoplada y best-effort desde `backend/api/icea_bridge_service.py`.
-6. El scheduler del bridge tiene una sola fuente de verdad: el service programa entregas nuevas al crear el request y evita reprogramar una request ya `queued`; los retries admin reutilizan el mismo helper con `force=true`.
-7. HANDOVER persiste el ultimo estado visible (`queued`, `sent`, `accepted`, `pending`, `scored`, `failed`, `stale`) y un resumen minimo del score si ICEA+ lo devuelve.
-8. Los fallos retryables del submit del bridge se reintentan de forma acotada y con backoff; si se agotan, la request termina en `failed` con el ultimo error persistido.
-9. Cualquier `accepted` o `pending` que no alcance resolucion dentro de la ventana configurada expira a `stale`, de modo que no queda un pending indefinido.
+1. `POST /api/fhir/transaction` confirma primero la transaccion clinica contra FHIR.
+2. Solo despues de ese exito, HANDOVER dispara side effects tecnicos best-effort: outbox ICEA+, persistencia local `HandoverBundleRecord`, snapshot tecnico y bridge.
+3. Si falla cualquiera de esas costuras tecnicas post-FHIR, HANDOVER conserva el exito clinico y degrada de forma honesta la trazabilidad/analitica derivada.
+4. Si `ENABLE_ICEA_BRIDGE=true`, HANDOVER crea o actualiza un `IceaBridgeRequest`.
+5. Se construye el payload analitico v1 en `backend/api/icea_payload_mapper.py`.
+6. La entrega a ICEA+ se intenta de forma desacoplada y best-effort desde `backend/api/icea_bridge_service.py`.
+7. El scheduler del bridge tiene una sola fuente de verdad: el service programa entregas nuevas al crear el request y evita reprogramar una request ya `queued`; los retries admin reutilizan el mismo helper con `force=true`.
+8. HANDOVER persiste el ultimo estado visible (`queued`, `sent`, `accepted`, `pending`, `scored`, `failed`, `stale`) y un resumen minimo del score si ICEA+ lo devuelve.
+9. Los fallos retryables del submit del bridge se reintentan de forma acotada y con backoff; si se agotan, la request termina en `failed` con el ultimo error persistido.
+10. Cualquier `accepted` o `pending` que no alcance resolucion dentro de la ventana configurada expira a `stale`, de modo que no queda un pending indefinido.
 
 ## Payload analitico v1
 
@@ -245,6 +247,19 @@ En shadow mode prudente, activar `EXPO_PUBLIC_ENABLE_ICEA_PATIENT_RISK` no debe 
 - el contrato v1 ya no entrega IDs nominales de profesional al payload analitico del bridge;
 - Ningun campo del envelope contextual debe interpretarse como causalidad, benchmarking causal o explicabilidad clinica fuerte.
 - El dashboard debe tratar `provisional=true` y `insufficientEvidence=true` como resultados no concluyentes y no mostrar score individual visible.
+
+## Shadow mode vinculante
+
+Permanece en shadow mode:
+- outbox tecnico ICEA+, snapshots de pipeline, `IceaBridgeRequest`, `/api/icea/bridge/*` y superficies agregadas/admin derivadas;
+- cualquier payload, warning o estado del bridge existe para trazabilidad tecnica y lectura agregada autorizada, no para decidir exito clinico del handover;
+- la costura backend `patient-risk` solo puede entenderse como seam gobernado y suprimido en la UI clinica operativa mientras siga el shadow mode prudente.
+
+No debe usarse jamas como evaluacion individual:
+- score numerico individual visible;
+- ranking, benchmarking nominal o uso punitivo sobre profesionales;
+- resumen causal cerrado o atribucion causal del resultado enfermero;
+- sustitucion del juicio clinico, del cierre operativo del handover o del criterio asistencial habitual.
 
 ## Riesgos residuales
 

--- a/docs/icea-integration.md
+++ b/docs/icea-integration.md
@@ -13,12 +13,10 @@
 Tras un `POST /api/fhir/transaction` exitoso, HANDOVER:
 
 1. confirma primero la transaccion clinica contra FHIR;
-2. persiste el Bundle local para ETL;
-3. crea/actualiza snapshot de pipeline;
-4. encola un webhook tecnico ICEA+;
-5. si el bridge esta habilitado, construye y envia el payload analitico versionado sin identificadores nominales de profesional.
+2. dispara solo despues side effects tecnicos best-effort: outbox ICEA+, persistencia local para ETL/readback, snapshot y bridge;
+3. si el bridge esta habilitado, construye y envia el payload analitico versionado sin identificadores nominales de profesional.
 
-Si ICEA+ falla, el guardado clinico no se revierte.
+Si ICEA+, el outbox, la persistencia tecnica local o el bridge fallan, el guardado clinico no se revierte y la degradacion debe quedar en el plano tecnico/analitico.
 
 Evidencia:
 
@@ -148,7 +146,17 @@ Lo que no debe afirmarse:
 - restringe enfermeria por `unitId`;
 - devuelve solo estado prudente, warnings y trazabilidad tecnica; no expone score numerico individual ni resumen causal en la UI operativa;
 - el endpoint puede seguir existiendo como costura backend gobernada, pero en `shadow` prudente la app clinica no debe renderizar ninguna salida ICEA paciente-a-paciente;
+- no debe reinterpretarse como scoring bedside, evaluacion individual, ranking profesional ni causalidad cerrada;
 - puede exponer `provisional`, `complete`, `insufficient_evidence`, `failed`, `stale` solo para trazabilidad tecnica o superficies agregadas/admin autorizadas.
+
+## 7.1) Shadow mode vinculante
+
+Mientras ICEA/ICEA+ siga en shadow mode dentro de HANDOVER:
+
+- el flujo clinico operativo se mide por el exito del submit FHIR y no por el estado del outbox, snapshot, bridge o cualquier scoring derivado;
+- dashboards, resumenes y observabilidad ICEA deben permanecer agregados y no nominales;
+- cualquier error ICEA debe degradar con honestidad y no romper el handover;
+- ningun artefacto ICEA debe usarse para evaluacion individual, accion punitiva o atribucion causal cerrada.
 
 Evidencia:
 


### PR DESCRIPTION
Aísla el éxito clínico del handover frente a fallos técnicos post-FHIR del bridge ICEA.

Cambios principales:

evita que una falla en persist_bundle_record rompa un POST /api/fhir/transaction ya aceptado por FHIR;
mantiene ICEA/ICEA+ en shadow mode, agregado y no bloqueante;
endurece la regresión que verifica que el 201 clínico se conserva aunque falle la persistencia técnica post-FHIR;
corrige README y documentación ICEA para dejar explícito que no hay uso individual, nominal, punitivo ni causal cerrado.

Validación reportada:

typecheck en verde;
pytest dirigido de icea_transaction, icea_bridge e icea_webhook en verde;
sin cambios UI ni nuevas superficies analíticas.

Límite honesto:

si falla la persistencia técnica post-FHIR, el handover clínico ya no se rompe, pero ETL/readback y trazabilidad derivada pueden quedar degradados, lo que es consistente con shadow mode.