### PR TITLE
fix(audit): align audit-log write permissions without changing RC verdict

### DIFF
--- a/backend/api/tests/test_audit_log_models.py
+++ b/backend/api/tests/test_audit_log_models.py
@@ -53,7 +53,7 @@ class AuditLogViewTests(TestCase):
         )
         self.client.force_authenticate(user=user, token=user.claims)
 
-        self._perm_patcher = patch.object(AuditLogView, "permission_classes", [AllowAny])
+        self._perm_patcher = patch.object(AuditLogView, "get_permissions", return_value=[AllowAny()])
         self._auth_patcher = patch.object(AuditLogView, "authentication_classes", [])
         self._perm_patcher.start()
         self._auth_patcher.start()
@@ -209,3 +209,40 @@ class AuditLogViewTests(TestCase):
 class AuditMetaSanitizationTests(TestCase):
     def test_sanitize_client_audit_meta_returns_none_for_invalid_root(self):
         self.assertIsNone(sanitize_client_audit_meta("not-a-dict"))
+
+
+class AuditLogViewPermissionTests(TestCase):
+    def test_post_accepts_handover_write_without_audit_read_but_get_remains_forbidden(self):
+        from rest_framework.test import APIClient
+
+        from backend.api.views import AuditLogView
+
+        client = APIClient()
+        url = reverse("audit-log")
+        claims = {
+            "sub": "nurse-audit",
+            "permissions": ["handover:write"],
+            "scope": "handover:write",
+            "roles": ["nurse"],
+        }
+        user = types.SimpleNamespace(
+            is_authenticated=True,
+            sub="nurse-audit",
+            username="nurse-audit",
+            claims=claims,
+        )
+        client.force_authenticate(user=user, token=claims)
+
+        payload = {
+            "type": "patient_edit",
+            "userId": "nurse-audit",
+            "patientKey": build_audit_patient_key("pat-91"),
+            "at": "2026-01-01T10:00:00Z",
+        }
+
+        with patch.object(AuditLogView, "_running_tests", return_value=False):
+            post_response = client.post(url, data=payload, format="json")
+            get_response = client.get(url)
+
+        self.assertEqual(post_response.status_code, 201)
+        self.assertEqual(get_response.status_code, 403)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2470,11 +2470,18 @@ class HandoverEtlReadView(AuthenticatedAPIView):
 
 
 class AuditLogView(AuthenticatedAPIView):
-    permission_classes = [
-        IsAuthenticated,
-        ClinicianAuditPermission,
-        HasAnyScope.required("audit:read", "handover:audit"),
-    ]
+    def get_permissions(self):
+        if self.request.method == "GET":
+            return [
+                IsAuthenticated(),
+                ClinicianAuditPermission(),
+                HasAnyScope.required("audit:read", "handover:audit")(),
+            ]
+        return [
+            IsAuthenticated(),
+            HasAnyRole.required("nurse", "supervisor", "admin")(),
+            HasAnyScope.required("handover:write", "audit:write")(),
+        ]
 
     def get(self, request: HttpRequest) -> Response:
         try:


### PR DESCRIPTION
## Qué cambia
Este PR corrige un seam puntual detectado durante la auditoría hostil final del RC:

- `AuditLogView` ahora separa permisos por método:
  - `GET` sigue restringido a lectura de auditoría (`audit:read` / `handover:audit`) con permiso clínico correspondiente.
  - `POST` acepta escritura clínica autenticada con rol permitido (`nurse`, `supervisor`, `admin`) y scope de escritura (`handover:write` o `audit:write`), sin exigir permisos de lectura de auditoría.
- Se ajustan y amplían los tests para cubrir:
  - el parcheo correcto de permisos en la vista;
  - que `POST` quede permitido con `handover:write`;
  - que `GET` permanezca prohibido sin scope de lectura de auditoría.

## Qué NO cambia
- No cambia el veredicto de la auditoría hostil final del RC.
- No reabre ni cierra blockers estructurales del release candidate.
- No toca frontend, pilot-control, offline queue, FHIR, ICEA ni CI.

## Motivo
La auditoría final detectó una incoherencia concreta en el seam de audit trail: el endpoint de escritura de log clínico quedaba acoplado al permiso de lectura de auditoría. Esta corrección es segura, mínima y acotada.

## Validación
- Tests dirigidos del seam de auditoría en verde.
- Cambio limitado a `backend/api/views.py` y `backend/api/tests/test_audit_log_models.py`.

## Límite honesto
Este PR **no** convierte el RC en “listo”. Solo corrige un bug puntual encontrado durante la verificación final.