### PR TITLE
refactor(auth): formalize ETL client-credentials permission

### DIFF
--- a/backend/api/etl_access.py
+++ b/backend/api/etl_access.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.http import HttpRequest
+
+from backend.security.roles import extract_roles
+from backend.security.scope_permissions import _extract_permissions_from_request
+
+
+ETL_ALLOWED_ROLES = {"service_etl", "admin"}
+ETL_REQUIRED_SCOPES = {"icea:etl:read", "handover:etl:read"}
+
+
+def get_claims_from_request(request: HttpRequest) -> dict[str, Any] | None:
+    """Extrae claims ya validados del request sin acoplarse a views.py."""
+    auth_claims = getattr(request, "auth", None)
+    if isinstance(auth_claims, dict):
+        return auth_claims
+
+    user = getattr(request, "user", None)
+    user_claims = getattr(user, "claims", None)
+    if isinstance(user_claims, dict):
+        return user_claims
+
+    if isinstance(user, dict):
+        return user
+
+    if hasattr(user, "claims") and isinstance(user.claims, dict):
+        return user.claims
+
+    return None
+
+
+def has_bearer_authorization(request: HttpRequest) -> bool:
+    auth_header = str(request.META.get("HTTP_AUTHORIZATION") or "").strip().lower()
+    return auth_header.startswith("bearer ")
+
+
+def has_client_credentials_grant(request: HttpRequest) -> bool:
+    claims = get_claims_from_request(request) or {}
+    grant_type = str((claims.get("gty") if isinstance(claims, dict) else "") or "").strip().lower()
+    return grant_type == "client-credentials"
+
+
+def has_valid_etl_access(request: HttpRequest) -> bool:
+    claims = get_claims_from_request(request) or {}
+    roles = extract_roles(claims) if isinstance(claims, dict) else set()
+    if not (roles & ETL_ALLOWED_ROLES):
+        return False
+
+    scopes = set(_extract_permissions_from_request(request) or [])
+    return bool(scopes & ETL_REQUIRED_SCOPES)

--- a/backend/api/etl_permissions.py
+++ b/backend/api/etl_permissions.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from rest_framework.permissions import BasePermission
+
+from backend.api.etl_access import (
+    has_bearer_authorization,
+    has_client_credentials_grant,
+    has_valid_etl_access,
+)
+from backend.security.auth import AuthRequired
+
+
+class ClientCredentialsEtlPermission(BasePermission):
+    message = "Forbidden"
+    code = "forbidden-scope"
+
+    def has_permission(self, request, view) -> bool:
+        if not has_bearer_authorization(request):
+            raise AuthRequired()
+
+        if not has_client_credentials_grant(request):
+            self.message = "Forbidden"
+            self.code = "forbidden-grant-type"
+            return False
+
+        if not has_valid_etl_access(request):
+            self.message = "Forbidden"
+            self.code = "forbidden-scope"
+            return False
+
+        return True

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -57,6 +57,8 @@ from backend.api.icea_bridge_service import enqueue_icea_bridge_request_for_tran
 from backend.api.icea_pipeline import ensure_pipeline_snapshot_from_bundle
 from backend.api.icea_transaction import persist_handover_bundle_record, persist_successful_transaction_icea_side_effects
 from backend.audit.models import AuditEvent
+from backend.api.etl_access import get_claims_from_request as _get_claims_from_request
+from backend.api.etl_permissions import ClientCredentialsEtlPermission
 from backend.security.permissions import ClinicianAuditPermission, IsAdminOrSupervisor
 from backend.security.permissions_roles import HasAnyRole
 from backend.security.roles import extract_roles
@@ -122,8 +124,6 @@ AuthenticatedApiView = AuthenticatedAPIView
 
 logger = logging.getLogger(__name__)
 
-ETL_ALLOWED_ROLES = {"service_etl", "admin"}
-ETL_REQUIRED_SCOPES = {"icea:etl:read", "handover:etl:read"}
 FHIR_TRANSACTION_ALLOWED_ROLES = ("nurse", "supervisor", "admin")
 FHIR_TRANSACTION_REQUIRED_SCOPES = ("fhir:transaction", "handover:write")
 
@@ -220,16 +220,6 @@ def _resolve_persisted_handover_bundle(record: HandoverBundleRecord) -> dict[str
             extra={"bundle_id": record.bundle_id, "request_id": record.request_id},
         )
         raise
-
-
-def _has_valid_etl_access(request: HttpRequest) -> bool:
-    claims = _get_claims_from_request(request) or {}
-    roles = extract_roles(claims) if isinstance(claims, dict) else set()
-    if not (roles & ETL_ALLOWED_ROLES):
-        return False
-
-    scopes = set(_extract_permissions_from_request(request) or [])
-    return bool(scopes & ETL_REQUIRED_SCOPES)
 
 
 def _claims_text_list(value: Any) -> list[str]:
@@ -538,23 +528,6 @@ def _build_demo_patient_bundle(*, patient_id: str | None = None) -> dict:
         "total": len(entries),
         "entry": entries,
     }
-
-
-def _get_claims_from_request(request: HttpRequest) -> dict | None:
-    """Extrae claims ya validados del request sin depender de helpers externos."""
-    auth_claims = getattr(request, "auth", None)
-    if isinstance(auth_claims, dict):
-        return auth_claims
-
-    user = getattr(request, "user", None)
-    user_claims = getattr(user, "claims", None)
-    if isinstance(user_claims, dict):
-        return user_claims
-
-    if hasattr(user, "claims") and isinstance(user.claims, dict):
-        return user.claims
-
-    return None
 
 
 def _get_authenticated_subject_from_context(request: HttpRequest) -> str | None:
@@ -2401,36 +2374,16 @@ class BundleView(AuthenticatedAPIView):
 
 class HandoverEtlReadView(AuthenticatedAPIView):
     authentication_classes = [Auth0JWTAuthentication]
-    permission_classes = [AllowAny]
+    permission_classes = [ClientCredentialsEtlPermission]
 
     def get_permissions(self):
         return [permission() for permission in self.permission_classes]
 
     def get_authenticators(self):
-        auth_header = (self.request.META.get("HTTP_AUTHORIZATION") or "").strip().lower()
-        if not auth_header.startswith("bearer "):
-            return []
-        return [authenticator() for authenticator in self.authentication_classes]
+        classes = [authenticator for authenticator in self.authentication_classes if authenticator is not None]
+        return [authenticator() for authenticator in classes]
 
     def get(self, request: HttpRequest, bundle_id: str) -> HttpResponse:
-        auth_header = (request.META.get("HTTP_AUTHORIZATION") or "").strip().lower()
-        if not auth_header.startswith("bearer "):
-            return Response(
-                {"detail": "Authentication credentials were not provided.", "code": "auth-required"},
-                status=401,
-            )
-
-        if not getattr(request.user, "is_authenticated", False):
-            return Response({"detail": "Invalid or expired token", "code": "auth-failed"}, status=401)
-
-        claims = _get_claims_from_request(request) or {}
-        grant_type = str((claims.get("gty") if isinstance(claims, dict) else "") or "").strip().lower()
-        if grant_type != "client-credentials":
-            return Response({"detail": "Forbidden", "code": "forbidden-grant-type"}, status=403)
-
-        if not _has_valid_etl_access(request):
-            return Response({"detail": "Forbidden", "code": "forbidden-scope"}, status=403)
-
         record = (
             HandoverBundleRecord.objects.filter(bundle_id=bundle_id)
             .only("id", "bundle_id", "request_id", "bundle_json", "encryption_metadata", "expires_at", "created_at")

--- a/backend/tests/test_etl_permissions.py
+++ b/backend/tests/test_etl_permissions.py
@@ -1,0 +1,77 @@
+import types
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from backend.api.models import HandoverBundleRecord
+
+
+class ClientCredentialsEtlPermissionTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("handover-etl-read", kwargs={"bundle_id": "bundle-etl-permission"})
+        HandoverBundleRecord.objects.create(
+            bundle_id="bundle-etl-permission",
+            patient_id="patient-etl-permission",
+            unit_id="uci-etl",
+            request_id="req-etl-permission",
+            bundle_json={"resourceType": "Bundle", "id": "bundle-etl-permission", "type": "transaction"},
+            expires_at=HandoverBundleRecord.default_expiry(),
+        )
+
+    def _auth(
+        self,
+        *,
+        roles: list[str],
+        scopes: list[str],
+        gty: str = "client-credentials",
+        include_bearer: bool = True,
+    ) -> None:
+        claims = {
+            "sub": "auth0|svc-etl",
+            "roles": roles,
+            "permissions": scopes,
+            "scope": " ".join(scopes),
+            "gty": gty,
+        }
+        user = types.SimpleNamespace(
+            is_authenticated=True,
+            claims=claims,
+            sub="auth0|svc-etl",
+            username="svc-etl",
+        )
+        self.client.force_authenticate(user=user, token=claims)
+        if include_bearer:
+            self.client.credentials(HTTP_AUTHORIZATION="Bearer etl-token-value")
+        else:
+            self.client.credentials()
+
+    def test_etl_permission_denies_when_bearer_missing(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["code"], "auth-required")
+
+    def test_etl_permission_denies_when_grant_type_is_not_client_credentials(self):
+        self._auth(roles=["service_etl"], scopes=["handover:etl:read"], gty="password")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["code"], "forbidden-grant-type")
+
+    def test_etl_permission_denies_when_etl_scope_is_missing(self):
+        self._auth(roles=["service_etl"], scopes=["fhir:transaction"])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["code"], "forbidden-scope")
+
+    def test_etl_permission_allows_client_credentials_with_etl_scope(self):
+        self._auth(roles=["service_etl"], scopes=["handover:etl:read"])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# Summary
- 

# Scope
- 

# How to test
```
# Pilot-grade quality gates
pnpm -w quality:pilot

# Focused reruns when needed
pnpm -w test:pilot:coverage
pnpm -w test:smoke:forms
pnpm -w gate:any-sensitive
pnpm -w validate:fhir:fixture
```

# Coverage
- Note: pilot-grade coverage runs through `vitest.pilot.config.ts`.
- Note: If coverage fails due to registry access for `@vitest/coverage-v8`, note it here.

# PHI/Security
- [ ] No PHI in logs/snapshots
- [ ] No PHI in fixtures/test data
- [ ] No PHI in screenshots

# Reviewer checklist
- [ ] Scope matches summary and is limited to intended changes
- [ ] Tests/commands in this PR are documented and results reported
- [ ] Coverage expectations and gaps are clearly stated
- [ ] No PHI or sensitive data introduced

