### PR TITLE
hardening(fhir): tighten default validation posture

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 # Deployment mode: development | demo | test | pilot | production
 HANDOVER_DEPLOYMENT_MODE=production
+HANDOVER_FHIR_VALIDATION_MODE=local
 # Read-only pilot rollout control plane. Keep aligned with frontend runtime config when the app needs to hide/show surfaces.
 # HANDOVER_PILOT_CONTROL_JSON={"pilotMode":"pilot","rolloutStatus":"pause","enabledUnits":["icu-a"],"allowedRoles":["nurse","supervisor","admin"],"environmentScope":["pilot"],"explicitShadowModeForIcea":true,"features":{"icea_bridge":{"mode":"shadow","enabledUnits":["icu-a"]},"icea_patient_risk":{"mode":"disabled"},"governed_nnn":{"mode":"pilot","enabledUnits":["icu-a"]},"admin_analytics":{"mode":"shadow","allowedRoles":["supervisor","admin"]}}}
 HANDOVER_PRIVATE_KEY_PATH=/secure/path/handover-private.pem

--- a/backend/api/tests/test_security_hardening.py
+++ b/backend/api/tests/test_security_hardening.py
@@ -19,6 +19,7 @@ class SecurityHardeningSettingsTests(TestCase):
         env["SECRET_KEY"] = "test-secret"
         env["DJANGO_DEBUG"] = "false"
         env["HANDOVER_SIGNATURE_DISABLED"] = "false"
+        env["HANDOVER_FHIR_VALIDATION_MODE"] = "local"
         env["HANDOVER_PRIVATE_KEY_PATH"] = "C:/keys/private.pem"
         env["HANDOVER_PUBLIC_KEY_PATH"] = "C:/keys/public.pem"
         env.pop("PYTEST_CURRENT_TEST", None)
@@ -128,6 +129,18 @@ class SecurityHardeningSettingsTests(TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("HANDOVER_SIGNATURE_DISABLED cannot be enabled in pilot/production", result.stderr)
+
+    def test_pilot_requires_explicit_fhir_validation_mode(self):
+        result = self._run_settings_import({
+            "HANDOVER_ALLOWED_ORIGINS": "https://app.handover.test",
+            "HANDOVER_DEPLOYMENT_MODE": "pilot",
+            "HANDOVER_FHIR_VALIDATION_MODE": "",
+            "AUTH0_ISSUER_BASE_URL": "https://issuer.example",
+            "AUTH0_AUDIENCE": "handover-api",
+        })
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("HANDOVER_FHIR_VALIDATION_MODE must be set explicitly in pilot/production", result.stderr)
 
     def test_pilot_requires_signature_key_paths(self):
         result = self._run_settings_import({

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -676,7 +676,8 @@ class FHIRJSONRenderer(JSONRenderer):
 # =========================
 
 FHIR_BASE = os.environ.get("FHIR_BASE") or os.environ.get("FHIR_BASE_URL") or "http://localhost:8080/fhir"
-HANDOVER_FHIR_VALIDATION_MODE = os.getenv("HANDOVER_FHIR_VALIDATION_MODE", "off").lower().strip()
+# Default to local minimal validation; strict environments must still declare the mode explicitly at startup.
+HANDOVER_FHIR_VALIDATION_MODE = os.getenv("HANDOVER_FHIR_VALIDATION_MODE", "local").lower().strip()
 HANDOVER_VALIDATE_STRICT = os.getenv("HANDOVER_VALIDATE_STRICT", "false").lower().strip()
 HANDOVER_REQUIRE_RBAC_ON_FHIR = os.getenv("HANDOVER_REQUIRE_RBAC_ON_FHIR", "true").lower().strip()
 OIDC_TOKEN_URL = os.getenv("OIDC_TOKEN_URL", "")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -87,11 +87,18 @@ HANDOVER_TEST_AUTH_BYPASS_ALLOWED = RUNNING_TESTS
 HANDOVER_PRIVATE_KEY_PATH = os.getenv("HANDOVER_PRIVATE_KEY_PATH")
 HANDOVER_PUBLIC_KEY_PATH = os.getenv("HANDOVER_PUBLIC_KEY_PATH")
 HANDOVER_SIGNATURE_DISABLED = os.getenv("HANDOVER_SIGNATURE_DISABLED", "false").lower() == "true"
+RAW_HANDOVER_FHIR_VALIDATION_MODE = (os.getenv("HANDOVER_FHIR_VALIDATION_MODE") or "").strip().lower()
 
 if HANDOVER_STRICT_SECURITY_MODE and HANDOVER_SIGNATURE_DISABLED:
     _record_startup_validation_error(
         "HANDOVER_SIGNATURE_DISABLED cannot be enabled in pilot/production. "
         "Use HANDOVER_DEPLOYMENT_MODE=development|demo|test for controlled insecure runs."
+    )
+
+if HANDOVER_STRICT_SECURITY_MODE and not RAW_HANDOVER_FHIR_VALIDATION_MODE:
+    _record_startup_validation_error(
+        "HANDOVER_FHIR_VALIDATION_MODE must be set explicitly in pilot/production. "
+        "Use local, remote or strict; do not rely on an implicit fallback."
     )
 
 if HANDOVER_STRICT_SECURITY_MODE and (


### PR DESCRIPTION
# Summary
- 

# Scope
- 

# How to test
```
# Pilot-grade quality gates
pnpm -w quality:pilot

# Focused reruns when needed
pnpm -w test:pilot:coverage
pnpm -w test:smoke:forms
pnpm -w gate:any-sensitive
pnpm -w validate:fhir:fixture
```

# Coverage
- Note: pilot-grade coverage runs through `vitest.pilot.config.ts`.
- Note: If coverage fails due to registry access for `@vitest/coverage-v8`, note it here.

# PHI/Security
- [ ] No PHI in logs/snapshots
- [ ] No PHI in fixtures/test data
- [ ] No PHI in screenshots

# Reviewer checklist
- [ ] Scope matches summary and is limited to intended changes
- [ ] Tests/commands in this PR are documented and results reported
- [ ] Coverage expectations and gaps are clearly stated
- [ ] No PHI or sensitive data introduced

