### PR TITLE
hardening(audit): make AuditEvent append-only

### DIFF
--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -23,5 +23,13 @@ class AuditEvent(models.Model):
     class Meta:
         ordering = ["-timestamp"]
 
+    def save(self, *args, **kwargs):
+        if not self._state.adding:
+            raise ValueError("AuditEvent is append-only and cannot be updated once persisted.")
+        return super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        raise ValueError("AuditEvent is append-only and cannot be deleted from the model layer.")
+
     def __str__(self) -> str:  # pragma: no cover - representation helper
         return f"AuditEvent(event_type={self.event_type}, status={self.status})"

--- a/backend/audit/tests/test_audit_immutability.py
+++ b/backend/audit/tests/test_audit_immutability.py
@@ -1,0 +1,41 @@
+import pytest
+
+from backend.audit.models import AuditEvent
+
+
+@pytest.mark.django_db
+def test_audit_event_allows_initial_create():
+    event = AuditEvent.objects.create(
+        event_type="security_check",
+        action="create",
+        status="success",
+    )
+
+    assert event.pk is not None
+    assert AuditEvent.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_audit_event_rejects_update_after_persist():
+    event = AuditEvent.objects.create(
+        event_type="security_check",
+        action="create",
+        status="success",
+    )
+
+    event.status = "fail"
+
+    with pytest.raises(ValueError, match="append-only"):
+        event.save()
+
+
+@pytest.mark.django_db
+def test_audit_event_rejects_delete_from_model_layer():
+    event = AuditEvent.objects.create(
+        event_type="security_check",
+        action="create",
+        status="success",
+    )
+
+    with pytest.raises(ValueError, match="append-only"):
+        event.delete()


### PR DESCRIPTION
# Summary
- 

# Scope
- 

# How to test
```
# Pilot-grade quality gates
pnpm -w quality:pilot

# Focused reruns when needed
pnpm -w test:pilot:coverage
pnpm -w test:smoke:forms
pnpm -w gate:any-sensitive
pnpm -w validate:fhir:fixture
```

# Coverage
- Note: pilot-grade coverage runs through `vitest.pilot.config.ts`.
- Note: If coverage fails due to registry access for `@vitest/coverage-v8`, note it here.

# PHI/Security
- [ ] No PHI in logs/snapshots
- [ ] No PHI in fixtures/test data
- [ ] No PHI in screenshots

# Reviewer checklist
- [ ] Scope matches summary and is limited to intended changes
- [ ] Tests/commands in this PR are documented and results reported
- [ ] Coverage expectations and gaps are clearly stated
- [ ] No PHI or sensitive data introduced

