### PR TITLE
fix(auth): restore verify_jwt compatibility alias

### DIFF
--- a/backend/api/tests/test_auth.py
+++ b/backend/api/tests/test_auth.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.test import APIClient, APIRequestFactory
 
 from backend.api.views import AuthenticatedAPIView
+from backend.security import auth as auth_module
 from backend.security.auth import Auth0JWTAuthentication, Auth0User, AuthFailed, AuthRequired
 from backend.security.scopes import CLINICAL_SCOPES, FHIR_PROFILES
 
@@ -146,6 +147,15 @@ class AuthEndpointTests(TestCase):
         request = self.factory.get("/api/protected", HTTP_AUTHORIZATION="Bearer local-token")
 
         self.assertIsNone(Auth0JWTAuthentication().authenticate(request))
+
+    def test_verify_jwt_compatibility_alias_fails_closed_by_default(self):
+        with self.assertRaises(NotImplementedError) as exc:
+            auth_module.verify_jwt("compat-token")
+
+        self.assertEqual(
+            str(exc.exception),
+            "backend.security.auth.verify_jwt is a compatibility alias for tests only; real authentication lives in Auth0JWTAuthentication.authenticate().",
+        )
 
     @override_settings(DEBUG=False)
     @patch(

--- a/backend/security/auth.py
+++ b/backend/security/auth.py
@@ -64,6 +64,19 @@ def _get_bearer_token(request) -> str:
     return parts[1]
 
 
+def verify_jwt(token: str) -> Dict[str, Any]:
+    """
+    Alias de compatibilidad para tests/consumidores que monkeypatchan
+    ``backend.security.auth.verify_jwt``.
+
+    No forma parte del flujo real de autenticación. La validación JWT activa
+    sigue en ``Auth0JWTAuthentication.authenticate()``.
+    """
+    raise NotImplementedError(
+        "backend.security.auth.verify_jwt is a compatibility alias for tests only; real authentication lives in Auth0JWTAuthentication.authenticate()."
+    )
+
+
 def _get_jwks() -> Dict[str, Any]:
     global _JWKS_CACHE, _JWKS_CACHE_TS
 


### PR DESCRIPTION
# Summary
- 

# Scope
- 

# How to test
```
# Pilot-grade quality gates
pnpm -w quality:pilot

# Focused reruns when needed
pnpm -w test:pilot:coverage
pnpm -w test:smoke:forms
pnpm -w gate:any-sensitive
pnpm -w validate:fhir:fixture
```

# Coverage
- Note: pilot-grade coverage runs through `vitest.pilot.config.ts`.
- Note: If coverage fails due to registry access for `@vitest/coverage-v8`, note it here.

# PHI/Security
- [ ] No PHI in logs/snapshots
- [ ] No PHI in fixtures/test data
- [ ] No PHI in screenshots

# Reviewer checklist
- [ ] Scope matches summary and is limited to intended changes
- [ ] Tests/commands in this PR are documented and results reported
- [ ] Coverage expectations and gaps are clearly stated
- [ ] No PHI or sensitive data introduced

