### PR TITLE
hardening(fhir): reject invalid strict validation modes

### DIFF
--- a/backend/api/tests/test_security_hardening.py
+++ b/backend/api/tests/test_security_hardening.py
@@ -142,6 +142,44 @@ class SecurityHardeningSettingsTests(TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("HANDOVER_FHIR_VALIDATION_MODE must be set explicitly in pilot/production", result.stderr)
 
+    def test_pilot_rejects_fhir_validation_mode_off(self):
+        result = self._run_settings_import({
+            "HANDOVER_ALLOWED_ORIGINS": "https://app.handover.test",
+            "HANDOVER_DEPLOYMENT_MODE": "pilot",
+            "HANDOVER_FHIR_VALIDATION_MODE": "off",
+            "AUTH0_ISSUER_BASE_URL": "https://issuer.example",
+            "AUTH0_AUDIENCE": "handover-api",
+        })
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Invalid HANDOVER_FHIR_VALIDATION_MODE for pilot/production: 'off'", result.stderr)
+        self.assertIn("Allowed values: local, remote, strict", result.stderr)
+        self.assertIn("'off' and any other invalid value are not allowed in strict environments", result.stderr)
+
+    def test_pilot_rejects_invalid_fhir_validation_mode_value(self):
+        result = self._run_settings_import({
+            "HANDOVER_ALLOWED_ORIGINS": "https://app.handover.test",
+            "HANDOVER_DEPLOYMENT_MODE": "pilot",
+            "HANDOVER_FHIR_VALIDATION_MODE": "remtoe",
+            "AUTH0_ISSUER_BASE_URL": "https://issuer.example",
+            "AUTH0_AUDIENCE": "handover-api",
+        })
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Invalid HANDOVER_FHIR_VALIDATION_MODE for pilot/production: 'remtoe'", result.stderr)
+        self.assertIn("Allowed values: local, remote, strict", result.stderr)
+
+    def test_pilot_accepts_valid_fhir_validation_mode(self):
+        result = self._run_settings_import({
+            "HANDOVER_ALLOWED_ORIGINS": "https://app.handover.test",
+            "HANDOVER_DEPLOYMENT_MODE": "pilot",
+            "HANDOVER_FHIR_VALIDATION_MODE": "remote",
+            "AUTH0_ISSUER_BASE_URL": "https://issuer.example",
+            "AUTH0_AUDIENCE": "handover-api",
+        })
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
     def test_pilot_requires_signature_key_paths(self):
         result = self._run_settings_import({
             "HANDOVER_ALLOWED_ORIGINS": "https://app.handover.test",

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -88,6 +88,7 @@ HANDOVER_PRIVATE_KEY_PATH = os.getenv("HANDOVER_PRIVATE_KEY_PATH")
 HANDOVER_PUBLIC_KEY_PATH = os.getenv("HANDOVER_PUBLIC_KEY_PATH")
 HANDOVER_SIGNATURE_DISABLED = os.getenv("HANDOVER_SIGNATURE_DISABLED", "false").lower() == "true"
 RAW_HANDOVER_FHIR_VALIDATION_MODE = (os.getenv("HANDOVER_FHIR_VALIDATION_MODE") or "").strip().lower()
+STRICT_HANDOVER_FHIR_VALIDATION_MODES = {"local", "remote", "strict"}
 
 if HANDOVER_STRICT_SECURITY_MODE and HANDOVER_SIGNATURE_DISABLED:
     _record_startup_validation_error(
@@ -99,6 +100,15 @@ if HANDOVER_STRICT_SECURITY_MODE and not RAW_HANDOVER_FHIR_VALIDATION_MODE:
     _record_startup_validation_error(
         "HANDOVER_FHIR_VALIDATION_MODE must be set explicitly in pilot/production. "
         "Use local, remote or strict; do not rely on an implicit fallback."
+    )
+elif (
+    HANDOVER_STRICT_SECURITY_MODE
+    and RAW_HANDOVER_FHIR_VALIDATION_MODE not in STRICT_HANDOVER_FHIR_VALIDATION_MODES
+):
+    _record_startup_validation_error(
+        "Invalid HANDOVER_FHIR_VALIDATION_MODE for pilot/production: "
+        f"{RAW_HANDOVER_FHIR_VALIDATION_MODE!r}. Allowed values: local, remote, strict. "
+        "'off' and any other invalid value are not allowed in strict environments."
     )
 
 if HANDOVER_STRICT_SECURITY_MODE and (


### PR DESCRIPTION
# Summary
- 

# Scope
- 

# How to test
```
# Pilot-grade quality gates
pnpm -w quality:pilot

# Focused reruns when needed
pnpm -w test:pilot:coverage
pnpm -w test:smoke:forms
pnpm -w gate:any-sensitive
pnpm -w validate:fhir:fixture
```

# Coverage
- Note: pilot-grade coverage runs through `vitest.pilot.config.ts`.
- Note: If coverage fails due to registry access for `@vitest/coverage-v8`, note it here.

# PHI/Security
- [ ] No PHI in logs/snapshots
- [ ] No PHI in fixtures/test data
- [ ] No PHI in screenshots

# Reviewer checklist
- [ ] Scope matches summary and is limited to intended changes
- [ ] Tests/commands in this PR are documented and results reported
- [ ] Coverage expectations and gaps are clearly stated
- [ ] No PHI or sensitive data introduced

