### PR TITLE
feat: add SJD psychiatry unit profile demo seam

### DIFF
--- a/docs/MVP_DEMO.md
+++ b/docs/MVP_DEMO.md
@@ -1,5 +1,7 @@
 # MVP Demo / Piloto (5–7 min)
 
+> Para el trabajo específico del demo psiquiátrico del Hospital Psiquiátrico San Juan de Dios, usa además [`docs/sjd-psychiatry-demo-scope.md`](./sjd-psychiatry-demo-scope.md). Ese documento fija alcance, límites y guardrails del seam SJD; este archivo sigue describiendo el walkthrough genérico hoy soportado por el repo.
+
 > **Objetivo**: demostrar flujo clínico SBAR, offline queue, auditoría y FHIR con datos sintéticos.
 
 ## Requisitos

--- a/docs/sjd-psychiatry-demo-scope.md
+++ b/docs/sjd-psychiatry-demo-scope.md
@@ -1,0 +1,150 @@
+# Demo SJD Psiquiatría: contexto, alcance y límites
+
+Estado revisado el 2026-05-08.
+
+## Objetivo
+
+Preparar un demo serio y prudente de HANDOVER + ICEA para el Hospital Psiquiátrico San Juan de Dios sin presentar el estado actual del repo como producto final, validado ni production-ready.
+
+Este documento define el alcance de demo para tres contextos objetivo:
+
+- psiquiatría adulto;
+- psiquiatría infanto-adolescente;
+- psicogeriatría / UDCC / deterioro cognitivo-conductual.
+
+## Estado real del repo tras este PR
+
+Seams ya existentes y reutilizables:
+
+- frontend React Native / Expo + TypeScript;
+- backend Django + DRF;
+- formulario único con validación Zod;
+- exportación FHIR transaccional;
+- cola offline / sync / retry ya cableados;
+- control plane prudente por unidad, rol y entorno;
+- bridge ICEA desacoplado y documentado en shadow mode;
+- catálogo de perfiles con `behavioral-health` ya presente como `scaffold`;
+- runtime UPP `behavioral-health` presente en `src/config/profiles/units/index.ts`.
+
+Seams SJD psiquiatría implementados en este PR:
+
+- especialidad visible `psych` en `src/config/specialties.ts`;
+- unidades `sjd-a`, `sjd-b`, `sjd-infanto` y `udcc-psychogeriatrics` en `src/config/units.ts`;
+- configuración estática de esas unidades en `src/config/unitsConfig.ts`;
+- mapeo de esas unidades al perfil común `behavioral-health`;
+- checklist y runtime mínimo reforzado para salud mental;
+- identificación por QR desactivada por defecto para `behavioral-health`, `psych` y las unidades SJD/UDCC;
+- QR reactivable únicamente mediante flag explícito;
+- documentación demo enlazada desde `docs/MVP_DEMO.md`.
+
+Límites observados tras este PR:
+
+- no existe todavía un overlay psiquiátrico SJD específico;
+- el runtime `behavioral-health` sigue siendo común y prudente, no una modelización clínica completa por subunidad;
+- adulto, infanto-adolescente y psicogeriatría/UDCC todavía no tienen campos diferenciales completos;
+- la evidencia demo actual aún no incluye fixtures sintéticos SJD trazados de punta a punta;
+- no se ha modificado backend, FHIR, ICEA, auth/RBAC ni sync/offline queue;
+- los documentos clínicos locales SJD siguen siendo insumos externos de validación, no evidencia incorporada al repo.
+
+## Guardrails de demo que sí quedan autorizados
+
+- Mantener un único formulario y el pipeline actual UI -> Zod -> FHIR -> queue/sync -> fhir-client -> servidor FHIR/HCE.
+- Resolver variaciones por perfiles, overlays y composición sobre costuras existentes.
+- Mantener ICEA como shadow mode agregado, no nominal ni punitivo.
+- Mantener MPAC como prioridad explicable y revisable.
+- Mantener la decisión clínica final como juicio humano.
+- Usar solo datos sintéticos en fixtures, demo mode y walkthrough.
+
+## Guardrails psiquiátricos específicos para este demo
+
+- QR queda como capacidad opcional o futura, detrás de flag, desactivada por defecto en el recorrido psiquiátrico.
+- La identificación principal del demo debe apoyarse en censo/listado de unidad, búsqueda manual, ubicación funcional, cama/planta o identificador institucional.
+- La app no debe exponer información a familiares; solo registrar coordinación interna cuando proceda.
+- La contención mecánica no debe describirse con instrucciones operativas detalladas; el demo solo puede mostrar estado, autorización, revisiones, trazabilidad y referencia a protocolo local.
+- No deben mostrarse rankings de “peligrosidad”.
+- Las prioridades visibles deben expresarse como continuidad, observación, riesgo de omisión, cambio respecto a basal o necesidad de coordinación.
+- No deben generarse recomendaciones clínicas autónomas; solo checklist, recordatorios, síntesis SBAR y continuidad de turno.
+
+## Fuentes clínicas externas esperadas para el demo
+
+Este repo no contiene con nombres verificables los documentos locales SJD listados en el encargo. Por tanto, deben tratarse como insumos externos de validación clínica/operativa y no como archivos ya incorporados al workspace.
+
+Fuentes a mapear fuera del repo o a incorporar después de saneamiento institucional:
+
+- Actividades mañana SJD A y SJD B.
+- Actividades tarde SJD A y SJD B.
+- Actividades turno noche.
+- CRONO DUE A 2025.
+- Procedimiento/protocolo de contención mecánica.
+- Protocolo de prevención de caídas.
+- Protocolo de fugas.
+- UDCC cronograma mañana y tarde.
+- Valoración funcional.
+- Protocolo de fallecimiento solo como referencia futura, fuera del objetivo inicial de demo.
+
+## Lectura clínica objetivo del demo
+
+El recorrido demo debe demostrar que HANDOVER ayuda a:
+
+- leer parte diario y solape;
+- preparar cambio de turno;
+- revisar pacientes por unidad/planta;
+- registrar observación especial;
+- registrar riesgos de caídas, fuga/no retorno, conducta, adherencia, sueño, hidratación, alimentación y deterioro funcional;
+- revisar medicación y tratamientos pendientes;
+- registrar contención solo como evento trazable y protocolizado;
+- generar un SBAR psiquiátrico prudente;
+- preparar continuidad para el turno siguiente;
+- alimentar ICEA shadow agregado sin score individual visible.
+
+## Mapa de ramas del trabajo
+
+Orden previsto de implementación, manteniendo un objetivo por rama:
+
+1. `docs/sjd-psychiatry-context-and-demo-scope`
+2. `feat/psychiatry-identity-without-qr`
+3. `feat/sjd-psychiatry-unit-profiles`
+4. `feat/sjd-psychiatry-section-fields`
+5. `feat/sjd-safety-overlays-falls-fuga-restraint`
+6. `feat/psychogeriatrics-udcc-functional-overlay`
+7. `feat/psychiatry-mpac-explainable-priorities`
+8. `feat/psychiatry-fhir-and-icea-shadow`
+9. `feat/sjd-psychiatry-demo-mode`
+10. `test/docs-psychiatry-demo-hardening`
+
+## Alcance real de este PR
+
+Este PR implementa el seam inicial SJD psiquiatría de forma acotada:
+
+- documenta alcance, límites y guardrails del demo;
+- añade `psych` como especialidad visible;
+- añade unidades SJD/UDCC al catálogo operativo;
+- mapea esas unidades al perfil común `behavioral-health`;
+- refuerza el runtime mínimo de salud mental;
+- desactiva QR por defecto en contexto psiquiátrico/salud mental;
+- mantiene QR como capacidad futura reactivable por flag explícito;
+- añade pruebas mínimas del seam.
+
+Este PR no cambia:
+
+- contratos Zod clínicos principales;
+- exportación FHIR;
+- payloads o vistas ICEA;
+- backend;
+- auth/RBAC;
+- sync/offline queue;
+- dependencias;
+- demo fixtures sintéticos de punta a punta.
+
+## Riesgos residuales abiertos tras este PR
+
+- sin unidades y especialidades SJD visibles en runtime, el demo sigue apoyado en costuras genéricas;
+- sin campos psiquiátricos mínimos adicionales, el runtime `behavioral-health` actual es insuficiente para adulto, infanto-adolescente y psicogeriatría;
+- sin fixtures y demo mode SJD, la narrativa clínica todavía no queda trazada de punta a punta;
+- los documentos clínicos SJD siguen siendo una dependencia externa hasta que exista una vía institucional de incorporación o validación fuera de PHI.
+
+## Veredicto documental
+
+Listo como documento de alcance y control de cambios para abrir las ramas funcionales siguientes.
+
+No debe usarse como evidencia de que el demo psiquiátrico ya está implementado.

--- a/src/components/handover/PatientSection.tsx
+++ b/src/components/handover/PatientSection.tsx
@@ -6,9 +6,16 @@ import { type HandoverValues as HandoverFormValues } from '@/src/validation/sche
 export type PatientSectionProps = {
   styles: Record<string, TextStyle | ViewStyle>;
   onScanPress: () => void;
+  qrPatientScanEnabled: boolean;
+  patientIdentificationHint: string;
 };
 
-export const PatientSection: React.FC<PatientSectionProps> = ({ styles, onScanPress }) => {
+export const PatientSection: React.FC<PatientSectionProps> = ({
+  styles,
+  onScanPress,
+  qrPatientScanEnabled,
+  patientIdentificationHint,
+}) => {
   const {
     control,
     formState: { errors },
@@ -27,7 +34,7 @@ export const PatientSection: React.FC<PatientSectionProps> = ({ styles, onScanPr
               <TextInput
                 style={styles.input}
                 testID="handover-patient-id"
-                placeholder="Paciente"
+                placeholder="Paciente o identificador institucional"
                 onBlur={onBlur}
                 value={value ?? ''}
                 onChangeText={onChange}
@@ -35,9 +42,14 @@ export const PatientSection: React.FC<PatientSectionProps> = ({ styles, onScanPr
             )}
           />
         </View>
-        <View style={styles.spacer} />
-        <Button title="Escanear" onPress={onScanPress} testID="handover-scan-qr" />
+        {qrPatientScanEnabled ? (
+          <>
+            <View style={styles.spacer} />
+            <Button title="Escanear QR" onPress={onScanPress} testID="handover-scan-qr" />
+          </>
+        ) : null}
       </View>
+      <Text style={styles.helperText}>{patientIdentificationHint}</Text>
       {patientError ? <Text style={styles.error}>{patientError}</Text> : null}
     </View>
   );

--- a/src/config/__tests__/patientIdentification.spec.ts
+++ b/src/config/__tests__/patientIdentification.spec.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('patientIdentification', () => {
+  const originalQrFlag = process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+
+  afterEach(() => {
+    vi.resetModules();
+    if (typeof originalQrFlag === 'string') {
+      process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN = originalQrFlag;
+    } else {
+      delete process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+    }
+  });
+
+  it('keeps QR enabled by default outside behavioral health contexts', async () => {
+    delete process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+    const { isQrPatientScanEnabled } = await import('@/src/config/patientIdentification');
+
+    expect(isQrPatientScanEnabled({ unitId: 'icu-a' })).toBe(true);
+  });
+
+  it('disables QR by default for behavioral health contexts', async () => {
+    delete process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+    const { isQrPatientScanEnabled } = await import('@/src/config/patientIdentification');
+
+    expect(isQrPatientScanEnabled({ specialtyId: 'behavioral-health' })).toBe(false);
+    expect(isQrPatientScanEnabled({ specialtyId: ' psych ' })).toBe(false);
+    expect(isQrPatientScanEnabled({ unitId: 'sjd-a' })).toBe(false);
+    expect(isQrPatientScanEnabled({ unitId: 'sjd-b' })).toBe(false);
+    expect(isQrPatientScanEnabled({ unitId: 'sjd-infanto' })).toBe(false);
+    expect(isQrPatientScanEnabled({ unitId: 'udcc-psychogeriatrics' })).toBe(false);
+  });
+
+  it('allows an explicit feature flag to re-enable QR when needed', async () => {
+    process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN = 'true';
+    const { isQrPatientScanEnabled } = await import('@/src/config/patientIdentification');
+
+    expect(isQrPatientScanEnabled({ specialtyId: 'behavioral-health' })).toBe(true);
+    expect(isQrPatientScanEnabled({ specialtyId: 'psych' })).toBe(true);
+    expect(isQrPatientScanEnabled({ unitId: 'sjd-a' })).toBe(true);
+  });
+});

--- a/src/config/patientIdentification.ts
+++ b/src/config/patientIdentification.ts
@@ -1,0 +1,79 @@
+import { getAppConfigExtra } from './app-config';
+import { resolveProfileContext } from './profiles';
+
+type BooleanLike = boolean | number | string | null | undefined;
+
+export interface PatientIdentificationContext {
+  unitId?: string | null;
+  specialtyId?: string | null;
+}
+
+const extra = getAppConfigExtra();
+const QR_DISABLED_SPECIALTY_IDS = new Set([
+  'behavioral-health',
+  'psych',
+]);
+const QR_DISABLED_UNIT_IDS = new Set([
+  'sjd-a',
+  'sjd-b',
+  'sjd-infanto',
+  'udcc-psychogeriatrics',
+]);
+
+function normalizeContextId(value?: string | null): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function truthy(value: BooleanLike): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value === 1;
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(normalized);
+}
+
+function hasExplicitQrFlag(value: BooleanLike): boolean {
+  if (typeof value === 'boolean' || typeof value === 'number') return true;
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function getExplicitQrPatientScanFlag(): BooleanLike {
+  return (
+    (extra as { FEATURES?: { handover?: { enableQrPatientScan?: BooleanLike } } })?.FEATURES?.handover
+      ?.enableQrPatientScan ??
+    process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN
+  );
+}
+
+export function isQrPatientScanEnabled(context: PatientIdentificationContext = {}): boolean {
+  const explicitFlag = getExplicitQrPatientScanFlag();
+  if (hasExplicitQrFlag(explicitFlag)) {
+    return truthy(explicitFlag);
+  }
+
+  const normalizedUnitId = normalizeContextId(context.unitId);
+  if (normalizedUnitId && QR_DISABLED_UNIT_IDS.has(normalizedUnitId)) {
+    return false;
+  }
+
+  const normalizedSpecialtyId = normalizeContextId(context.specialtyId);
+  if (normalizedSpecialtyId && QR_DISABLED_SPECIALTY_IDS.has(normalizedSpecialtyId)) {
+    return false;
+  }
+
+  const profileContext = resolveProfileContext({
+    unitId: context.unitId,
+    specialtyId: context.specialtyId,
+  });
+
+  return normalizeContextId(profileContext.unitProfileId) !== 'behavioral-health';
+}
+
+export function getPatientIdentificationHint(context: PatientIdentificationContext = {}): string {
+  if (isQrPatientScanEnabled(context)) {
+    return 'Usa el listado o la busqueda manual como flujo principal. El QR queda como apoyo opcional.';
+  }
+
+  return 'Usa el listado, la busqueda manual o el identificador institucional. El QR queda desactivado en este contexto.';
+}

--- a/src/config/profiles/__tests__/catalog.spec.ts
+++ b/src/config/profiles/__tests__/catalog.spec.ts
@@ -205,7 +205,7 @@ describe('profile master catalog', () => {
   });
 
   it('keeps operational specialties limited to the visible subset while pilot-ready and registry-only stages stay explicit', () => {
-    expect(SPECIALTIES.map((specialty) => specialty.id)).toEqual(['icu', 'ed', 'onc', 'neph', 'ped', 'ob', 'neuroicu', 'cvicu']);
+    expect(SPECIALTIES.map((specialty) => specialty.id)).toEqual(['icu', 'ed', 'onc', 'neph', 'ped', 'ob', 'neuroicu', 'cvicu', 'psych']);
     expect(WAVE_1_UNIT_PROFILE_IDS).toEqual([
       'emergency',
       'general-inpatient',
@@ -261,5 +261,7 @@ describe('profile master catalog', () => {
     expect(matchLocationToUnit('Paciente trasladado a UCI Adulto Ala A')).toBe('icu-a');
     expect(matchLocationToUnit('Pendiente en resucitacion de urgencias')).toBe('ed-obs');
     expect(matchLocationToUnit('Control post hemodialisis')).toBe('neph-hd');
+    expect(matchLocationToUnit('Observacion especial en Psiquiatria adulto SJD A')).toBe('sjd-a');
+    expect(matchLocationToUnit('Revisar continuidad en UDCC')).toBe('udcc-psychogeriatrics');
   });
 });

--- a/src/config/profiles/units/index.ts
+++ b/src/config/profiles/units/index.ts
@@ -111,6 +111,38 @@ export const UNIT_PROFILE_CHECKLIST_ITEMS: Partial<
       helper: 'Aclara dudas del relevo sobre microvigilancia, avisos y la siguiente reevaluación no delegable.',
     },
   ],
+  'behavioral-health': [
+    {
+      key: 'patientIdentityConfirmed',
+      label: 'Paciente, ubicacion funcional y referente del turno confirmados',
+      helper: 'Prioriza censo, cama/planta o identificador institucional sin depender del QR.',
+    },
+    {
+      key: 'allergiesReviewed',
+      label: 'Alertas conductuales, observacion especial y riesgos inmediatos revisados',
+      helper: 'Aclara si hubo cambio respecto al basal, pendiente critico o necesidad de acompanamiento intensivo.',
+    },
+    {
+      key: 'linesAndDevicesChecked',
+      label: 'Pertenencias, entorno seguro y restricciones activas verificadas',
+      helper: 'Solo registra estado y trazabilidad; no sustituye protocolos locales de seguridad.',
+    },
+    {
+      key: 'medicationPlanReviewed',
+      label: 'Adherencia, medicacion pendiente y tratamientos no omitibles revisados',
+      helper: 'Haz visible rechazo terapeutico, ventanas horarias y necesidad de seguimiento del siguiente turno.',
+    },
+    {
+      key: 'safetyMeasuresApplied',
+      label: 'Plan de observacion, continuidad y coordinacion interna aplicado',
+      helper: 'Expresa prioridades de cuidado y continuidad, no etiquetas punitivas ni rankings de peligrosidad.',
+    },
+    {
+      key: 'questionsAnswered',
+      label: 'Preguntas del equipo entrante resueltas',
+      helper: 'Aclara gatillos de reevaluacion, avisos al equipo y coordinaciones pendientes del turno siguiente.',
+    },
+  ],
 };
 
 export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProfileRuntimePack & { id: UnitProfileId }>> = {
@@ -281,11 +313,20 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     id: 'behavioral-health',
     label: 'Salud mental',
     enabledSections: ['psychosocial'],
-    requiredExtraFields: ['Riesgo conductual', 'Plan de observacion'],
-    optionalExtraFields: ['Alianza terapeutica', 'Factores desencadenantes'],
-    scales: ['EVA'],
-    sentinelEvents: ['Riesgo auto o heteroagresivo', 'Descompensacion conductual'],
-    visibleOutputs: ['Plan de observacion y seguridad'],
+    requiredExtraFields: ['Riesgo conductual', 'Plan de observacion', 'Cambio respecto al basal'],
+    optionalExtraFields: ['Alianza terapeutica', 'Factores desencadenantes', 'Coordinacion interna o familiar relevante'],
+    focusAreas: ['Observacion especial, continuidad y seguridad relacional', 'Adherencia, sueno, ingesta y cambio conductual respecto al basal'],
+    explanations: ['Hace visible observacion, continuidad y riesgo de omision en salud mental sin abrir un formulario paralelo ni convertir QR en flujo principal.'],
+    scales: ['EVA', 'Escala conductual local', 'Riesgo suicida institucional'],
+    sentinelEvents: ['Riesgo auto o heteroagresivo', 'Descompensacion conductual', 'Fuga o no retorno', 'Rechazo terapeutico'],
+    quickPicks: {
+      treatments: [
+        { id: 'psych-observation', type: 'other', description: 'Actualizar observacion especial, gatillos y siguiente reevaluacion del turno' },
+        { id: 'psych-adherence', type: 'education', description: 'Cerrar adherencia, rechazo terapeutico y pendientes de medicacion o acompanamiento' },
+        { id: 'psych-continuity', type: 'other', description: 'Resumir continuidad, coordinaciones internas y cambios respecto al basal' },
+      ],
+    },
+    visibleOutputs: ['Plan de observacion y seguridad', 'Continuidad de turno sin etiquetas estigmatizantes'],
   }),
   'home-care': createPack({
     id: 'home-care',

--- a/src/config/specialties.ts
+++ b/src/config/specialties.ts
@@ -74,6 +74,13 @@ export const SPECIALTIES: Specialty[] = [
     defaultUnitProfileId: 'specialized-critical-care',
     overlayId: 'cardio',
   },
+  {
+    id: 'psych',
+    name: 'Psiquiatria y salud mental',
+    aliases: ['salud-mental', 'psiquiatria', 'psiquiatria-adulto', 'psiquiatria-infanto-adolescente', 'udcc'],
+    readiness: 'scaffold',
+    defaultUnitProfileId: 'behavioral-health',
+  },
 ];
 
 export const SPECIALTIES_BY_ID: Record<string, Specialty> = SPECIALTIES.reduce(

--- a/src/config/units.ts
+++ b/src/config/units.ts
@@ -79,6 +79,34 @@ export const UNITS: Unit[] = [
     profileId: 'specialized-critical-care',
     aliases: ['cardio-icu', 'cvicu', 'hemodinamia-1'],
   },
+  {
+    id: 'sjd-a',
+    name: 'Psiquiatria adulto · SJD A',
+    specialtyId: 'psych',
+    profileId: 'behavioral-health',
+    aliases: ['san-juan-de-dios-a', 'psiquiatria-adulto-a', 'sjd-adulto-a'],
+  },
+  {
+    id: 'sjd-b',
+    name: 'Psiquiatria adulto · SJD B',
+    specialtyId: 'psych',
+    profileId: 'behavioral-health',
+    aliases: ['san-juan-de-dios-b', 'psiquiatria-adulto-b', 'sjd-adulto-b'],
+  },
+  {
+    id: 'sjd-infanto',
+    name: 'Psiquiatria infanto-adolescente',
+    specialtyId: 'psych',
+    profileId: 'behavioral-health',
+    aliases: ['infanto-adolescente', 'psiquiatria-infanto', 'salud-mental-infanto'],
+  },
+  {
+    id: 'udcc-psychogeriatrics',
+    name: 'Psicogeriatria / UDCC',
+    specialtyId: 'psych',
+    profileId: 'behavioral-health',
+    aliases: ['udcc', 'psicogeriatria', 'deterioro-cognitivo-conductual'],
+  },
 ];
 
 export const UNITS_BY_SPECIALTY: Record<string, string[]> = UNITS.reduce((acc, unit) => {

--- a/src/config/unitsConfig.ts
+++ b/src/config/unitsConfig.ts
@@ -100,6 +100,34 @@ const STATIC_UNITS_CONFIG: HandoverUnitConfig[] = [
     specialtyOverlayIds: ['pedsSubspecialties'],
     features: { ...BASE_FEATURES, enablePediatricScales: true },
   },
+  {
+    id: 'sjd-a',
+    name: 'Psiquiatria adulto · SJD A',
+    specialty: 'psych',
+    profileId: 'behavioral-health',
+    features: { ...BASE_FEATURES, enablePsychosocialExtra: true },
+  },
+  {
+    id: 'sjd-b',
+    name: 'Psiquiatria adulto · SJD B',
+    specialty: 'psych',
+    profileId: 'behavioral-health',
+    features: { ...BASE_FEATURES, enablePsychosocialExtra: true },
+  },
+  {
+    id: 'sjd-infanto',
+    name: 'Psiquiatria infanto-adolescente',
+    specialty: 'psych',
+    profileId: 'behavioral-health',
+    features: { ...BASE_FEATURES, enablePsychosocialExtra: true },
+  },
+  {
+    id: 'udcc-psychogeriatrics',
+    name: 'Psicogeriatria / UDCC',
+    specialty: 'psych',
+    profileId: 'behavioral-health',
+    features: { ...BASE_FEATURES, enablePsychosocialExtra: true },
+  },
 ] as const;
 
 const STATIC_UNITS_CONFIG_BY_ID = STATIC_UNITS_CONFIG.reduce(

--- a/src/lib/__tests__/profile-runtime.spec.ts
+++ b/src/lib/__tests__/profile-runtime.spec.ts
@@ -259,6 +259,39 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(emergency.checklistItems.at(-1)?.label).toBe('Preguntas del equipo entrante resueltas');
   });
 
+  it('resolves SJD psychiatry units onto the shared behavioral-health runtime without opening a parallel form', async () => {
+    process.env.UNITS_CONFIG = JSON.stringify({
+      units: [
+        {
+          id: 'sjd-a',
+          name: 'Psiquiatria adulto · SJD A',
+          specialty: 'psych',
+          profileId: 'behavioral-health',
+          features: { enablePsychosocialExtra: true },
+        },
+      ],
+    });
+    process.env.EXPO_PUBLIC_HANDOVER_PROFILE_ACTIVATION_JSON = JSON.stringify({
+      unitProfiles: ['behavioral-health'],
+    });
+
+    const { resolveHandoverProfileRuntime } = await import('../profile-runtime');
+
+    const runtime = resolveHandoverProfileRuntime({ unitId: 'sjd-a', specialtyId: 'psych' });
+
+    expect(runtime.context.catalogUnitProfileId).toBe('behavioral-health');
+    expect(runtime.context.unitProfileId).toBe('behavioral-health');
+    expect(runtime.context.specialtyId).toBe('psych');
+    expect(runtime.pack.id).toBe('behavioral-health');
+    expect(runtime.basePack.id).toBe('behavioral-health');
+    expect(runtime.sectionVisibility.psychosocial).toBe(true);
+    expect(runtime.requiredExtraFields).toEqual(
+      expect.arrayContaining(['Riesgo conductual', 'Plan de observacion', 'Cambio respecto al basal']),
+    );
+    expect(runtime.visibleOutputs).toContain('Plan de observacion y seguridad');
+    expect(runtime.checklistItems[0]?.label).toContain('ubicacion funcional');
+  });
+
   it('keeps hidden sections monotonic across compatible overlay merges while preserving trace order', async () => {
     process.env.EXPO_PUBLIC_HANDOVER_PROFILE_ACTIVATION_JSON = JSON.stringify({
       unitProfiles: ['emergency'],

--- a/src/screens/HandoverForm.tsx
+++ b/src/screens/HandoverForm.tsx
@@ -22,6 +22,7 @@ import * as Speech from 'expo-speech';
 import { getRecordingPermissionsAsync, requestRecordingPermissionsAsync } from 'expo-audio';
 
 import { isOn } from '@/src/config/flags';
+import { getPatientIdentificationHint, isQrPatientScanEnabled } from '@/src/config/patientIdentification';
 import { isPilotFeatureEnabled, usePilotControlContext } from '@/src/config/pilotControl';
 import { getHandoverVisibleSections } from '@/src/screens/handover/visibility';
 import { HANDOVER_SECTIONS_INFO, resolveHandoverProfileRuntime } from '@/src/lib/profile-runtime';
@@ -660,6 +661,22 @@ export default function HandoverForm({ navigation, route }: Props) {
   const showLegacyNursingDiagnosisText = profileRuntime.fieldVisibility['legacy-nursing-diagnosis-text'];
   const showNicCodingHint = profileRuntime.fieldVisibility['nic-coding-hint'];
   const showHandoverTimingHint = profileRuntime.fieldVisibility['handover-timing-hint'];
+  const qrPatientScanEnabled = useMemo(
+    () =>
+      isQrPatientScanEnabled({
+        unitId: effectivePilotUnitId,
+        specialtyId,
+      }),
+    [effectivePilotUnitId, specialtyId],
+  );
+  const patientIdentificationHint = useMemo(
+    () =>
+      getPatientIdentificationHint({
+        unitId: effectivePilotUnitId,
+        specialtyId,
+      }),
+    [effectivePilotUnitId, specialtyId],
+  );
 
   useEffect(() => {
     if (!features.showHandoverTimingMetrics || timingInitializedRef.current) return;
@@ -1695,6 +1712,11 @@ export default function HandoverForm({ navigation, route }: Props) {
   }, [form, patientIdValue, session]);
 
   const onScanPress = () => {
+    if (!qrPatientScanEnabled) {
+      Alert.alert(t('handover.scannerUnavailableTitle'), patientIdentificationHint);
+      return;
+    }
+
     const routeNames = navigation.getState?.().routeNames ?? [];
     if (routeNames.includes('QRScan')) {
       const trimmedPatientId =
@@ -1704,6 +1726,8 @@ export default function HandoverForm({ navigation, route }: Props) {
       navigation.navigate('QRScan', {
         returnTo: 'HandoverForm',
         patientIdParam: trimmedPatientId,
+        unitIdParam: effectivePilotUnitId ?? undefined,
+        specialtyId,
       });
     } else {
       Alert.alert(t('handover.scannerUnavailableTitle'), t('handover.scannerUnavailableMessage'));
@@ -2288,6 +2312,8 @@ export default function HandoverForm({ navigation, route }: Props) {
             onLayout={handleSectionLayout}
             onToggle={toggleSection}
             onScanPress={onScanPress}
+            qrPatientScanEnabled={qrPatientScanEnabled}
+            patientIdentificationHint={patientIdentificationHint}
             parseNumericInput={parseNumericInput}
             dictationState={{
               activeDictationField,

--- a/src/screens/handover/HandoverContextSections.tsx
+++ b/src/screens/handover/HandoverContextSections.tsx
@@ -17,6 +17,8 @@ type Props = {
   onLayout: (key: ContextSectionKey) => (event: LayoutChangeEvent) => void;
   onToggle: (key: ContextSectionKey) => void;
   onScanPress: () => void;
+  qrPatientScanEnabled: boolean;
+  patientIdentificationHint: string;
   parseNumericInput: AdministrativeSectionProps['parseNumericInput'];
   dictationState: AdministrativeSectionProps['dictationState'];
   DictationMicButton: AdministrativeSectionProps['DictationMicButton'];
@@ -29,6 +31,8 @@ export function HandoverContextSections({
   onLayout,
   onToggle,
   onScanPress,
+  qrPatientScanEnabled,
+  patientIdentificationHint,
   parseNumericInput,
   dictationState,
   DictationMicButton,
@@ -59,7 +63,12 @@ export function HandoverContextSections({
           isCollapsed={collapsedSections.paciente}
           onToggle={() => onToggle('paciente')}
         >
-          <PatientSection styles={styles} onScanPress={onScanPress} />
+          <PatientSection
+            styles={styles}
+            onScanPress={onScanPress}
+            qrPatientScanEnabled={qrPatientScanEnabled}
+            patientIdentificationHint={patientIdentificationHint}
+          />
         </CollapsibleSection>
       </View>
     </>


### PR DESCRIPTION
## Resumen

Añade el seam inicial para demo psiquiátrico SJD sin crear formularios paralelos ni tocar backend/FHIR/ICEA.

## Cambios principales

- Añade documento de alcance y guardrails para demo SJD psiquiatría.
- Añade especialidad visible `psych`.
- Añade unidades SJD:
  - `sjd-a`
  - `sjd-b`
  - `sjd-infanto`
  - `udcc-psychogeriatrics`
- Mapea esas unidades al runtime compartido `behavioral-health`.
- Refuerza el runtime de salud mental como perfil común, no como app paralela.
- Desactiva QR por defecto en contextos psiquiátricos/salud mental, con reactivación explícita por flag.
- Ajusta `PatientSection` y `HandoverContextSections` para ocultar el botón QR cuando corresponde.
- Añade tests de identificación, catálogo y resolución runtime.

## Guardrails respetados

- No se toca backend.
- No se toca FHIR.
- No se toca ICEA.
- No se toca auth/RBAC.
- No se toca sync/offline queue.
- No se modifican dependencias.
- No se crean formularios independientes por unidad.
- Se mantiene un núcleo común de relevo con perfiles configurables.

## Validación ejecutada

- `pnpm -w typecheck`
- `pnpm -w lint:ci`
- `pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts`
- `pnpm exec vitest run src/config/profiles/__tests__/catalog.spec.ts`
- `pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts`

## Limitaciones

Este PR no completa el demo psiquiátrico. Solo deja el seam inicial de unidades/perfil/QR y documentación de alcance. Quedan pendientes los campos clínicos específicos, overlays de seguridad, fixtures sintéticos SJD, recorrido demo end-to-end y validación clínica local.