### PR TITLE
fix: disable QR for resolved psychiatry contexts

### DIFF
--- a/docs/sjd-psychiatry-demo-scope.md
+++ b/docs/sjd-psychiatry-demo-scope.md
@@ -33,8 +33,8 @@ Seams SJD psiquiatría implementados en este PR:
 - configuración estática de esas unidades en `src/config/unitsConfig.ts`;
 - mapeo de esas unidades al perfil común `behavioral-health`;
 - checklist y runtime mínimo reforzado para salud mental;
-- identificación por QR desactivada por defecto para `behavioral-health`, `psych` y las unidades SJD/UDCC;
-- QR reactivable únicamente mediante flag explícito;
+- identificación por QR desactivada por defecto para contextos resueltos como `behavioral-health` / `psych`, incluyendo unidades SJD/UDCC y unidades custom que lleguen por `UNITS_CONFIG`;
+- QR reactivable únicamente mediante `EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN=true`;
 - documentación demo enlazada desde `docs/MVP_DEMO.md`.
 
 Límites observados tras este PR:
@@ -57,30 +57,19 @@ Límites observados tras este PR:
 
 ## Guardrails psiquiátricos específicos para este demo
 
-- QR queda como capacidad opcional o futura, detrás de flag, desactivada por defecto en el recorrido psiquiátrico.
-- La identificación principal del demo debe apoyarse en censo/listado de unidad, búsqueda manual, ubicación funcional, cama/planta o identificador institucional.
+- QR no es flujo principal en psiquiatría/salud mental; queda como capacidad opcional o futura, detrás de flag, desactivada por defecto en el recorrido psiquiátrico.
+- La identificación principal del demo debe apoyarse en censo/listado de unidad, búsqueda manual, ubicación funcional, cama/planta o identificador institucional, no en QR.
 - La app no debe exponer información a familiares; solo registrar coordinación interna cuando proceda.
 - La contención mecánica no debe describirse con instrucciones operativas detalladas; el demo solo puede mostrar estado, autorización, revisiones, trazabilidad y referencia a protocolo local.
 - No deben mostrarse rankings de “peligrosidad”.
 - Las prioridades visibles deben expresarse como continuidad, observación, riesgo de omisión, cambio respecto a basal o necesidad de coordinación.
 - No deben generarse recomendaciones clínicas autónomas; solo checklist, recordatorios, síntesis SBAR y continuidad de turno.
 
-## Fuentes clínicas externas esperadas para el demo
+## Insumos institucionales y confidencialidad
 
-Este repo no contiene con nombres verificables los documentos locales SJD listados en el encargo. Por tanto, deben tratarse como insumos externos de validación clínica/operativa y no como archivos ya incorporados al workspace.
+Este repositorio no incorpora, enumera ni reproduce documentación interna de instituciones sanitarias. Cualquier documento local, protocolo, cronograma, pauta operativa o material institucional que pudiera orientar una demo debe tratarse como insumo confidencial externo, sujeto a autorización formal, anonimización/saneamiento y revisión institucional antes de cualquier uso.
 
-Fuentes a mapear fuera del repo o a incorporar después de saneamiento institucional:
-
-- Actividades mañana SJD A y SJD B.
-- Actividades tarde SJD A y SJD B.
-- Actividades turno noche.
-- CRONO DUE A 2025.
-- Procedimiento/protocolo de contención mecánica.
-- Protocolo de prevención de caídas.
-- Protocolo de fugas.
-- UDCC cronograma mañana y tarde.
-- Valoración funcional.
-- Protocolo de fallecimiento solo como referencia futura, fuera del objetivo inicial de demo.
+Para efectos del demo, solo se permite usar datos sintéticos y descripciones funcionales genéricas. No deben incluirse nombres de documentos internos, extractos, capturas, adjuntos ni contenido operativo local en el repositorio, PRs, issues, documentación pública o materiales de presentación.
 
 ## Lectura clínica objetivo del demo
 
@@ -121,8 +110,8 @@ Este PR implementa el seam inicial SJD psiquiatría de forma acotada:
 - añade unidades SJD/UDCC al catálogo operativo;
 - mapea esas unidades al perfil común `behavioral-health`;
 - refuerza el runtime mínimo de salud mental;
-- desactiva QR por defecto en contexto psiquiátrico/salud mental;
-- mantiene QR como capacidad futura reactivable por flag explícito;
+- desactiva QR por defecto en contexto psiquiátrico/salud mental, incluso cuando ese contexto se resuelve por `UNITS_CONFIG` y no solo por IDs SJD hardcodeados;
+- mantiene QR como capacidad futura reactivable solo mediante `EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN=true`;
 - añade pruebas mínimas del seam.
 
 Este PR no cambia:

--- a/src/config/__tests__/patientIdentification.spec.ts
+++ b/src/config/__tests__/patientIdentification.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('patientIdentification', () => {
   const originalQrFlag = process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+  const originalUnitsConfig = process.env.UNITS_CONFIG;
 
   afterEach(() => {
     vi.resetModules();
@@ -9,6 +10,12 @@ describe('patientIdentification', () => {
       process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN = originalQrFlag;
     } else {
       delete process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+    }
+
+    if (typeof originalUnitsConfig === 'string') {
+      process.env.UNITS_CONFIG = originalUnitsConfig;
+    } else {
+      delete process.env.UNITS_CONFIG;
     }
   });
 
@@ -38,5 +45,43 @@ describe('patientIdentification', () => {
     expect(isQrPatientScanEnabled({ specialtyId: 'behavioral-health' })).toBe(true);
     expect(isQrPatientScanEnabled({ specialtyId: 'psych' })).toBe(true);
     expect(isQrPatientScanEnabled({ unitId: 'sjd-a' })).toBe(true);
+  });
+
+  it('disables QR by default for a custom psych unit resolved from UNITS_CONFIG', async () => {
+    delete process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN;
+    process.env.UNITS_CONFIG = JSON.stringify({
+      units: [
+        {
+          id: 'custom-psych-unit',
+          name: 'Unidad Salud Mental Custom',
+          specialty: 'psych',
+          profileId: 'behavioral-health',
+          features: { enablePsychosocialExtra: true },
+        },
+      ],
+    });
+
+    const { isQrPatientScanEnabled } = await import('@/src/config/patientIdentification');
+
+    expect(isQrPatientScanEnabled({ unitId: 'custom-psych-unit' })).toBe(false);
+  });
+
+  it('allows an explicit QR flag for a custom psych unit resolved from UNITS_CONFIG', async () => {
+    process.env.EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN = 'true';
+    process.env.UNITS_CONFIG = JSON.stringify({
+      units: [
+        {
+          id: 'custom-psych-unit',
+          name: 'Unidad Salud Mental Custom',
+          specialty: 'psych',
+          profileId: 'behavioral-health',
+          features: { enablePsychosocialExtra: true },
+        },
+      ],
+    });
+
+    const { isQrPatientScanEnabled } = await import('@/src/config/patientIdentification');
+
+    expect(isQrPatientScanEnabled({ unitId: 'custom-psych-unit' })).toBe(true);
   });
 });

--- a/src/config/patientIdentification.ts
+++ b/src/config/patientIdentification.ts
@@ -20,6 +20,31 @@ const QR_DISABLED_UNIT_IDS = new Set([
   'udcc-psychogeriatrics',
 ]);
 
+function isBehavioralHealthQrDisabledContext(
+  context: PatientIdentificationContext,
+  profileContext: ReturnType<typeof resolveProfileContext>,
+): boolean {
+  const normalizedUnitId = normalizeContextId(context.unitId);
+  if (normalizedUnitId && QR_DISABLED_UNIT_IDS.has(normalizedUnitId)) {
+    return true;
+  }
+
+  const normalizedSpecialtyId = normalizeContextId(context.specialtyId);
+  if (normalizedSpecialtyId && QR_DISABLED_SPECIALTY_IDS.has(normalizedSpecialtyId)) {
+    return true;
+  }
+
+  const normalizedResolvedSpecialtyId = normalizeContextId(profileContext.specialtyId);
+  if (normalizedResolvedSpecialtyId && QR_DISABLED_SPECIALTY_IDS.has(normalizedResolvedSpecialtyId)) {
+    return true;
+  }
+
+  return (
+    normalizeContextId(profileContext.unitProfileId) === 'behavioral-health' ||
+    normalizeContextId(profileContext.catalogUnitProfileId) === 'behavioral-health'
+  );
+}
+
 function normalizeContextId(value?: string | null): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim().toLowerCase();
@@ -52,22 +77,12 @@ export function isQrPatientScanEnabled(context: PatientIdentificationContext = {
     return truthy(explicitFlag);
   }
 
-  const normalizedUnitId = normalizeContextId(context.unitId);
-  if (normalizedUnitId && QR_DISABLED_UNIT_IDS.has(normalizedUnitId)) {
-    return false;
-  }
-
-  const normalizedSpecialtyId = normalizeContextId(context.specialtyId);
-  if (normalizedSpecialtyId && QR_DISABLED_SPECIALTY_IDS.has(normalizedSpecialtyId)) {
-    return false;
-  }
-
   const profileContext = resolveProfileContext({
     unitId: context.unitId,
     specialtyId: context.specialtyId,
   });
 
-  return normalizeContextId(profileContext.unitProfileId) !== 'behavioral-health';
+  return !isBehavioralHealthQrDisabledContext(context, profileContext);
 }
 
 export function getPatientIdentificationHint(context: PatientIdentificationContext = {}): string {


### PR DESCRIPTION
## Summary
- Closes the P2 Codex finding from PR #788.
- Keeps QR disabled by default for resolved psychiatry / behavioral-health contexts.
- Preserves explicit QR reactivation through feature flag.

## Scope
Touched only:
- src/config/patientIdentification.ts
- src/config/__tests__/patientIdentification.spec.ts

Not touched:
- dependencies
- backend
- FHIR
- ICEA
- auth/RBAC
- sync/offline queue
- HandoverForm
- PatientSection
- units/specialties/profile runtime
- documentation

## Validation
- pnpm -w typecheck
- pnpm -w lint:ci
- pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts
- pnpm exec vitest run src/config/profiles/__tests__/catalog.spec.ts
- pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts

## Risk
Low. This only tightens QR default gating for resolved psychiatry/behavioral-health contexts and preserves explicit opt-in by flag.