### PR TITLE
feat: add psychiatry section runtime fields

### DIFF
--- a/docs/sjd-psychiatry-demo-scope.md
+++ b/docs/sjd-psychiatry-demo-scope.md
@@ -32,7 +32,8 @@ Seams SJD psiquiatría implementados en este PR:
 - unidades `sjd-a`, `sjd-b`, `sjd-infanto` y `udcc-psychogeriatrics` en `src/config/units.ts`;
 - configuración estática de esas unidades en `src/config/unitsConfig.ts`;
 - mapeo de esas unidades al perfil común `behavioral-health`;
-- checklist y runtime mínimo reforzado para salud mental;
+- runtime común de salud mental reforzado con `psychosocial`, `nutrition` y `examenes`;
+- variaciones ligeras por subunidad resueltas solo con checklist contextual, sin formulario paralelo;
 - identificación por QR desactivada por defecto para contextos resueltos como `behavioral-health` / `psych`, incluyendo unidades SJD/UDCC y unidades custom que lleguen por `UNITS_CONFIG`;
 - QR reactivable únicamente mediante `EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN=true`;
 - documentación demo enlazada desde `docs/MVP_DEMO.md`.
@@ -41,7 +42,7 @@ Límites observados tras este PR:
 
 - no existe todavía un overlay psiquiátrico SJD específico;
 - el runtime `behavioral-health` sigue siendo común y prudente, no una modelización clínica completa por subunidad;
-- adulto, infanto-adolescente y psicogeriatría/UDCC todavía no tienen campos diferenciales completos;
+- las diferencias adulto, infanto-adolescente y psicogeriatría/UDCC siguen limitadas a copy runtime y checklist contextual, sin campos persistidos propios;
 - la evidencia demo actual aún no incluye fixtures sintéticos SJD trazados de punta a punta;
 - no se ha modificado backend, FHIR, ICEA, auth/RBAC ni sync/offline queue;
 - los documentos clínicos locales SJD siguen siendo insumos externos de validación, no evidencia incorporada al repo.
@@ -110,6 +111,8 @@ Este PR implementa el seam inicial SJD psiquiatría de forma acotada:
 - añade unidades SJD/UDCC al catálogo operativo;
 - mapea esas unidades al perfil común `behavioral-health`;
 - refuerza el runtime mínimo de salud mental;
+- hace visibles secciones ya existentes para continuidad, ingesta/hidratacion y pendientes del turno;
+- diferencia de forma ligera infanto-adolescente y psicogeriatría/UDCC mediante checklist contextual ya soportado por el repo;
 - desactiva QR por defecto en contexto psiquiátrico/salud mental, incluso cuando ese contexto se resuelve por `UNITS_CONFIG` y no solo por IDs SJD hardcodeados;
 - mantiene QR como capacidad futura reactivable solo mediante `EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN=true`;
 - añade pruebas mínimas del seam.
@@ -128,7 +131,7 @@ Este PR no cambia:
 ## Riesgos residuales abiertos tras este PR
 
 - sin unidades y especialidades SJD visibles en runtime, el demo sigue apoyado en costuras genéricas;
-- sin campos psiquiátricos mínimos adicionales, el runtime `behavioral-health` actual es insuficiente para adulto, infanto-adolescente y psicogeriatría;
+- sin una costura adicional de schema/UI persistida, el runtime psiquiátrico sigue dependiendo de copy contextual y checklist para parte de la variación ligera por subunidad;
 - sin fixtures y demo mode SJD, la narrativa clínica todavía no queda trazada de punta a punta;
 - los documentos clínicos SJD siguen siendo una dependencia externa hasta que exista una vía institucional de incorporación o validación fuera de PHI.
 

--- a/src/config/profiles/units/index.ts
+++ b/src/config/profiles/units/index.ts
@@ -312,21 +312,66 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
   'behavioral-health': createPack({
     id: 'behavioral-health',
     label: 'Salud mental',
-    enabledSections: ['psychosocial'],
-    requiredExtraFields: ['Riesgo conductual', 'Plan de observacion', 'Cambio respecto al basal'],
-    optionalExtraFields: ['Alianza terapeutica', 'Factores desencadenantes', 'Coordinacion interna o familiar relevante'],
-    focusAreas: ['Observacion especial, continuidad y seguridad relacional', 'Adherencia, sueno, ingesta y cambio conductual respecto al basal'],
-    explanations: ['Hace visible observacion, continuidad y riesgo de omision en salud mental sin abrir un formulario paralelo ni convertir QR en flujo principal.'],
-    scales: ['EVA', 'Escala conductual local', 'Riesgo suicida institucional'],
-    sentinelEvents: ['Riesgo auto o heteroagresivo', 'Descompensacion conductual', 'Fuga o no retorno', 'Rechazo terapeutico'],
+    enabledSections: ['psychosocial', 'nutrition', 'examenes'],
+    requiredExtraFields: [
+      'Estado basal y cambio observado',
+      'Observacion especial o acompanamiento',
+      'Riesgo de fuga o no retorno',
+      'Riesgo conductual expresado de forma no estigmatizante',
+      'Adherencia o rechazo terapeutico',
+      'Coordinacion interna pendiente',
+    ],
+    optionalExtraFields: [
+      'Sueno e ingesta/hidratacion',
+      'Responsable o referente de comunicacion interna',
+      'Coordinacion con familia, tutor o cuidadores cuando aplique',
+      'Deterioro funcional o cognitivo-conductual cuando aplique',
+      'Dispositivos o tratamientos que el paciente pueda retirarse',
+    ],
+    focusAreas: [
+      'Observacion especial, continuidad y seguridad relacional',
+      'Cambio respecto al basal, adherencia terapeutica y riesgo de omision del turno siguiente',
+      'Ingesta, hidratacion, sueno y coordinacion interna pendiente',
+    ],
+    explanations: [
+      'Refuerza salud mental con secciones y copy del runtime ya existentes, sin abrir un formulario paralelo ni convertir QR en flujo principal.',
+    ],
+    scales: ['EVA', 'Observacion conductual estructurada cuando aplique'],
+    sentinelEvents: [
+      'Descompensacion conductual',
+      'Fuga o no retorno',
+      'Rechazo terapeutico con riesgo de omision',
+      'Cambio relevante respecto al basal',
+    ],
     quickPicks: {
       treatments: [
-        { id: 'psych-observation', type: 'other', description: 'Actualizar observacion especial, gatillos y siguiente reevaluacion del turno' },
-        { id: 'psych-adherence', type: 'education', description: 'Cerrar adherencia, rechazo terapeutico y pendientes de medicacion o acompanamiento' },
-        { id: 'psych-continuity', type: 'other', description: 'Resumir continuidad, coordinaciones internas y cambios respecto al basal' },
+        {
+          id: 'psych-observation',
+          type: 'other',
+          description: 'Actualizar observacion especial, acompanamiento, gatillos y siguiente reevaluacion del turno',
+        },
+        {
+          id: 'psych-adherence',
+          type: 'education',
+          description: 'Cerrar adherencia o rechazo terapeutico y pendientes de medicacion o tratamiento no omitibles',
+        },
+        {
+          id: 'psych-intake-sleep',
+          type: 'other',
+          description: 'Registrar sueno, ingesta, hidratacion y cambios respecto al basal relevantes para continuidad',
+        },
+        {
+          id: 'psych-continuity',
+          type: 'other',
+          description: 'Resumir coordinacion interna, continuidad del turno y avisos para el siguiente relevo',
+        },
       ],
     },
-    visibleOutputs: ['Plan de observacion y seguridad', 'Continuidad de turno sin etiquetas estigmatizantes'],
+    visibleOutputs: [
+      'Plan de observacion y continuidad',
+      'Pendientes de medicacion, tratamiento y coordinacion visibles para el siguiente turno',
+      'Continuidad de turno sin etiquetas estigmatizantes',
+    ],
   }),
   'home-care': createPack({
     id: 'home-care',

--- a/src/config/unitsConfig.ts
+++ b/src/config/unitsConfig.ts
@@ -74,6 +74,72 @@ const BASE_FEATURES: UnitFeatureFlags = {
   hideLegacyFields: isOn('HIDE_LEGACY_FIELDS'),
 };
 
+const BEHAVIORAL_HEALTH_CHILD_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] = [
+  {
+    key: 'patientIdentityConfirmed',
+    label: 'Paciente, ubicacion funcional y referente interno confirmados',
+    helper: 'Prioriza censo/listado, ubicacion y quien centraliza la comunicacion del turno.',
+  },
+  {
+    key: 'allergiesReviewed',
+    label: 'Observacion especial, entorno seguro y acompanamiento revisados',
+    helper: 'Asegura continuidad del acompanamiento y cambios respecto al basal sin exponer informacion externa.',
+  },
+  {
+    key: 'linesAndDevicesChecked',
+    label: 'Pertenencias, dispositivos retirables y entorno revisados',
+    helper: 'Deja visible solo lo necesario para continuidad y seguridad del relevo.',
+  },
+  {
+    key: 'medicationPlanReviewed',
+    label: 'Adherencia, medicacion pendiente y actividad terapeutica revisadas',
+    helper: 'Incluye rechazos, acompanamiento y continuidad generica del plan del turno.',
+  },
+  {
+    key: 'safetyMeasuresApplied',
+    label: 'Coordinacion con familia o tutor y avisos internos revisados',
+    helper: 'Registra continuidad de comunicacion solo como dato interno del relevo.',
+  },
+  {
+    key: 'questionsAnswered',
+    label: 'Preguntas del equipo entrante resueltas',
+    helper: 'Aclara acompanamiento, continuidad y coordinaciones del siguiente turno.',
+  },
+];
+
+const BEHAVIORAL_HEALTH_UDCC_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] = [
+  {
+    key: 'patientIdentityConfirmed',
+    label: 'Paciente, ubicacion funcional y basal cognitivo-funcional confirmados',
+    helper: 'Prioriza censo/listado, ubicacion y referencia breve del estado habitual.',
+  },
+  {
+    key: 'allergiesReviewed',
+    label: 'Cambio respecto al basal, observacion y riesgo de caidas revisados',
+    helper: 'Haz visible deterioro funcional o cognitivo-conductual y necesidad de supervision.',
+  },
+  {
+    key: 'linesAndDevicesChecked',
+    label: 'Dispositivos, tratamientos retirables y deambulacion supervisada verificados',
+    helper: 'Confirma lo que puede retirarse el paciente y las medidas de acompanamiento activas.',
+  },
+  {
+    key: 'medicationPlanReviewed',
+    label: 'Ingesta, hidratacion, sueno y medicacion pendiente revisados',
+    helper: 'Expresa lo no omitible para el siguiente turno con continuidad longitudinal.',
+  },
+  {
+    key: 'safetyMeasuresApplied',
+    label: 'Continuidad con cuidadores, supervision y entorno seguro aplicada',
+    helper: 'Aclara acompanamiento, movilidad y medidas de seguridad no farmacologicas del turno.',
+  },
+  {
+    key: 'questionsAnswered',
+    label: 'Preguntas del equipo entrante resueltas',
+    helper: 'Resume continuidad funcional, cognitiva y pendientes del relevo siguiente.',
+  },
+];
+
 /** Configuración estática por defecto. */
 const STATIC_UNITS_CONFIG: HandoverUnitConfig[] = [
   {
@@ -119,14 +185,22 @@ const STATIC_UNITS_CONFIG: HandoverUnitConfig[] = [
     name: 'Psiquiatria infanto-adolescente',
     specialty: 'psych',
     profileId: 'behavioral-health',
-    features: { ...BASE_FEATURES, enablePsychosocialExtra: true },
+    features: {
+      ...BASE_FEATURES,
+      enablePsychosocialExtra: true,
+      checklistItems: [...BEHAVIORAL_HEALTH_CHILD_CHECKLIST_ITEMS],
+    },
   },
   {
     id: 'udcc-psychogeriatrics',
     name: 'Psicogeriatria / UDCC',
     specialty: 'psych',
     profileId: 'behavioral-health',
-    features: { ...BASE_FEATURES, enablePsychosocialExtra: true },
+    features: {
+      ...BASE_FEATURES,
+      enablePsychosocialExtra: true,
+      checklistItems: [...BEHAVIORAL_HEALTH_UDCC_CHECKLIST_ITEMS],
+    },
   },
 ] as const;
 
@@ -312,4 +386,3 @@ export function getDefaultUnitConfig(units?: readonly HandoverUnitConfig[]): Han
 }
 
 // END HANDOVER D4 – MultiUnitConfig
-

--- a/src/lib/__tests__/profile-runtime.spec.ts
+++ b/src/lib/__tests__/profile-runtime.spec.ts
@@ -285,11 +285,67 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.pack.id).toBe('behavioral-health');
     expect(runtime.basePack.id).toBe('behavioral-health');
     expect(runtime.sectionVisibility.psychosocial).toBe(true);
+    expect(runtime.sectionVisibility.nutrition).toBe(true);
+    expect(runtime.sectionVisibility.examenes).toBe(true);
     expect(runtime.requiredExtraFields).toEqual(
-      expect.arrayContaining(['Riesgo conductual', 'Plan de observacion', 'Cambio respecto al basal']),
+      expect.arrayContaining([
+        'Estado basal y cambio observado',
+        'Observacion especial o acompanamiento',
+        'Riesgo de fuga o no retorno',
+      ]),
     );
-    expect(runtime.visibleOutputs).toContain('Plan de observacion y seguridad');
+    expect(runtime.visibleOutputs).toContain('Plan de observacion y continuidad');
     expect(runtime.checklistItems[0]?.label).toContain('ubicacion funcional');
+  });
+
+  it('keeps child-adolescent psychiatry on the shared behavioral-health core while projecting a unit-specific checklist', async () => {
+    process.env.EXPO_PUBLIC_HANDOVER_PROFILE_ACTIVATION_JSON = JSON.stringify({
+      unitProfiles: ['behavioral-health'],
+    });
+
+    const { resolveHandoverProfileRuntime } = await import('../profile-runtime');
+
+    const runtime = resolveHandoverProfileRuntime({ unitId: 'sjd-infanto', specialtyId: 'psych' });
+
+    expect(runtime.context.catalogUnitProfileId).toBe('behavioral-health');
+    expect(runtime.context.unitProfileId).toBe('behavioral-health');
+    expect(runtime.pack.id).toBe('behavioral-health');
+    expect(runtime.basePack.id).toBe('behavioral-health');
+    expect(runtime.activeOverlays).toEqual([]);
+    expect(runtime.optionalExtraFields).toEqual(
+      expect.arrayContaining([
+        'Responsable o referente de comunicacion interna',
+        'Coordinacion con familia, tutor o cuidadores cuando aplique',
+      ]),
+    );
+    expect(runtime.checklistItems[0]?.label).toBe('Paciente, ubicacion funcional y referente interno confirmados');
+    expect(runtime.checklistItems[4]?.label).toContain('familia o tutor');
+  });
+
+  it('keeps psychogeriatrics on the shared behavioral-health core while projecting a unit-specific checklist', async () => {
+    process.env.EXPO_PUBLIC_HANDOVER_PROFILE_ACTIVATION_JSON = JSON.stringify({
+      unitProfiles: ['behavioral-health'],
+    });
+
+    const { resolveHandoverProfileRuntime } = await import('../profile-runtime');
+
+    const runtime = resolveHandoverProfileRuntime({ unitId: 'udcc-psychogeriatrics', specialtyId: 'psych' });
+
+    expect(runtime.context.catalogUnitProfileId).toBe('behavioral-health');
+    expect(runtime.context.unitProfileId).toBe('behavioral-health');
+    expect(runtime.pack.id).toBe('behavioral-health');
+    expect(runtime.basePack.id).toBe('behavioral-health');
+    expect(runtime.activeOverlays).toEqual([]);
+    expect(runtime.optionalExtraFields).toEqual(
+      expect.arrayContaining([
+        'Deterioro funcional o cognitivo-conductual cuando aplique',
+        'Dispositivos o tratamientos que el paciente pueda retirarse',
+      ]),
+    );
+    expect(runtime.checklistItems[0]?.label).toBe(
+      'Paciente, ubicacion funcional y basal cognitivo-funcional confirmados',
+    );
+    expect(runtime.checklistItems[2]?.label).toContain('deambulacion supervisada');
   });
 
   it('keeps hidden sections monotonic across compatible overlay merges while preserving trace order', async () => {


### PR DESCRIPTION
## Summary
- Reinforces the shared behavioral-health runtime for psychiatry demo continuity.
- Reuses existing HANDOVER sections instead of creating a parallel form.
- Adds light contextual checklist variation for child-adolescent psychiatry and psychogeriatrics/UDCC.
- Keeps QR behavior unchanged: disabled by default for resolved behavioral-health / psych contexts.

## Scope
Touched only:
- docs/sjd-psychiatry-demo-scope.md
- src/config/profiles/units/index.ts
- src/config/unitsConfig.ts
- src/lib/__tests__/profile-runtime.spec.ts

Not touched:
- dependencies
- backend
- FHIR
- ICEA
- auth/RBAC
- sync/offline queue
- Zod schema
- PatientSection
- HandoverForm

## Validation
- git diff -- package.json pnpm-lock.yaml: no changes
- pnpm -w typecheck: passed
- pnpm -w lint:ci: passed
- pnpm exec vitest run src/config/profiles/__tests__/catalog.spec.ts: passed, 6/6
- pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts: passed, 21/21
- pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts: passed, 5/5
- confidentiality grep over docs/src/.github: no matches for internal document names

## Risk
Low. This is runtime/copy/checklist hardening only. It does not add persisted psychiatric fields, FHIR mappings or backend contracts.

## Verdict
Ready with reservations: subunit variation remains intentionally lightweight until a future schema/UI/FHIR seam is designed.