### PR TITLE
feat: add psychiatry safety runtime overlays

### DIFF
--- a/docs/sjd-psychiatry-demo-scope.md
+++ b/docs/sjd-psychiatry-demo-scope.md
@@ -1,142 +1,62 @@
-# Demo SJD Psiquiatría: contexto, alcance y límites
+# Demo SJD Psiquiatria: alcance prudente
 
-Estado revisado el 2026-05-08.
+Estado revisado el 2026-05-09.
 
 ## Objetivo
 
-Preparar un demo serio y prudente de HANDOVER + ICEA para el Hospital Psiquiátrico San Juan de Dios sin presentar el estado actual del repo como producto final, validado ni production-ready.
+Preparar un demo prudente de HANDOVER + ICEA para salud mental usando el nucleo comun ya existente, sin presentar el repo como solucion cerrada ni abrir formularios paralelos.
 
-Este documento define el alcance de demo para tres contextos objetivo:
+## Seam implementado
 
-- psiquiatría adulto;
-- psiquiatría infanto-adolescente;
-- psicogeriatría / UDCC / deterioro cognitivo-conductual.
+- las unidades `sjd-a`, `sjd-b`, `sjd-infanto` y `udcc-psychogeriatrics` siguen mapeadas al perfil comun `behavioral-health`;
+- el runtime comun de salud mental hace visibles observacion especial, riesgo de caidas, fuga/no retorno, entorno seguro, elementos retirables y continuidad del relevo;
+- la contencion aparece solo como evento trazable con autorizacion, revision, vigencia y reevaluacion;
+- adulto, infanto-adolescente y psicogeriatria/UDCC mantienen un unico core y solo cambian mediante checklist contextual y copy prudente;
+- QR sigue desactivado por defecto en contextos `behavioral-health` / `psych`.
 
-## Estado real del repo tras este PR
+## Variaciones ligeras permitidas
 
-Seams ya existentes y reutilizables:
+### Adulto
 
-- frontend React Native / Expo + TypeScript;
-- backend Django + DRF;
-- formulario único con validación Zod;
-- exportación FHIR transaccional;
-- cola offline / sync / retry ya cableados;
-- control plane prudente por unidad, rol y entorno;
-- bridge ICEA desacoplado y documentado en shadow mode;
-- catálogo de perfiles con `behavioral-health` ya presente como `scaffold`;
-- runtime UPP `behavioral-health` presente en `src/config/profiles/units/index.ts`.
+- observacion especial y acompanamiento;
+- adherencia o rechazo terapeutico;
+- fuga/no retorno;
+- entorno seguro;
+- reevaluacion del siguiente turno.
 
-Seams SJD psiquiatría implementados en este PR:
+### Infanto-adolescente
 
-- especialidad visible `psych` en `src/config/specialties.ts`;
-- unidades `sjd-a`, `sjd-b`, `sjd-infanto` y `udcc-psychogeriatrics` en `src/config/units.ts`;
-- configuración estática de esas unidades en `src/config/unitsConfig.ts`;
-- mapeo de esas unidades al perfil común `behavioral-health`;
-- runtime común de salud mental reforzado con `psychosocial`, `nutrition` y `examenes`;
-- variaciones ligeras por subunidad resueltas solo con checklist contextual, sin formulario paralelo;
-- identificación por QR desactivada por defecto para contextos resueltos como `behavioral-health` / `psych`, incluyendo unidades SJD/UDCC y unidades custom que lleguen por `UNITS_CONFIG`;
-- QR reactivable únicamente mediante `EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN=true`;
-- documentación demo enlazada desde `docs/MVP_DEMO.md`.
+- acompanamiento;
+- comunicacion interna del turno;
+- coordinacion con familia o tutor cuando aplique;
+- continuidad del retorno seguro y del siguiente relevo.
 
-Límites observados tras este PR:
+### Psicogeriatria / UDCC
 
-- no existe todavía un overlay psiquiátrico SJD específico;
-- el runtime `behavioral-health` sigue siendo común y prudente, no una modelización clínica completa por subunidad;
-- las diferencias adulto, infanto-adolescente y psicogeriatría/UDCC siguen limitadas a copy runtime y checklist contextual, sin campos persistidos propios;
-- la evidencia demo actual aún no incluye fixtures sintéticos SJD trazados de punta a punta;
-- no se ha modificado backend, FHIR, ICEA, auth/RBAC ni sync/offline queue;
-- los documentos clínicos locales SJD siguen siendo insumos externos de validación, no evidencia incorporada al repo.
+- riesgo de caidas;
+- deambulacion supervisada;
+- deterioro cognitivo-funcional;
+- dispositivos o tratamientos retirables;
+- ingesta, hidratacion y sueno.
 
-## Guardrails de demo que sí quedan autorizados
+## Limites del demo
 
-- Mantener un único formulario y el pipeline actual UI -> Zod -> FHIR -> queue/sync -> fhir-client -> servidor FHIR/HCE.
-- Resolver variaciones por perfiles, overlays y composición sobre costuras existentes.
-- Mantener ICEA como shadow mode agregado, no nominal ni punitivo.
-- Mantener MPAC como prioridad explicable y revisable.
-- Mantener la decisión clínica final como juicio humano.
-- Usar solo datos sintéticos en fixtures, demo mode y walkthrough.
+- un unico formulario;
+- sin rutas, pantallas ni flujos nuevos;
+- sin campos persistidos nuevos;
+- sin cambios en backend, FHIR, ICEA, auth, auditoria u offline queue;
+- sin instrucciones operativas para contencion.
 
-## Guardrails psiquiátricos específicos para este demo
+## Lectura funcional esperada
 
-- QR no es flujo principal en psiquiatría/salud mental; queda como capacidad opcional o futura, detrás de flag, desactivada por defecto en el recorrido psiquiátrico.
-- La identificación principal del demo debe apoyarse en censo/listado de unidad, búsqueda manual, ubicación funcional, cama/planta o identificador institucional, no en QR.
-- La app no debe exponer información a familiares; solo registrar coordinación interna cuando proceda.
-- La contención mecánica no debe describirse con instrucciones operativas detalladas; el demo solo puede mostrar estado, autorización, revisiones, trazabilidad y referencia a protocolo local.
-- No deben mostrarse rankings de “peligrosidad”.
-- Las prioridades visibles deben expresarse como continuidad, observación, riesgo de omisión, cambio respecto a basal o necesidad de coordinación.
-- No deben generarse recomendaciones clínicas autónomas; solo checklist, recordatorios, síntesis SBAR y continuidad de turno.
+El demo debe permitir que el equipo:
 
-## Insumos institucionales y confidencialidad
-
-Este repositorio no incorpora, enumera ni reproduce documentación interna de instituciones sanitarias. Cualquier documento local, protocolo, cronograma, pauta operativa o material institucional que pudiera orientar una demo debe tratarse como insumo confidencial externo, sujeto a autorización formal, anonimización/saneamiento y revisión institucional antes de cualquier uso.
-
-Para efectos del demo, solo se permite usar datos sintéticos y descripciones funcionales genéricas. No deben incluirse nombres de documentos internos, extractos, capturas, adjuntos ni contenido operativo local en el repositorio, PRs, issues, documentación pública o materiales de presentación.
-
-## Lectura clínica objetivo del demo
-
-El recorrido demo debe demostrar que HANDOVER ayuda a:
-
-- leer parte diario y solape;
-- preparar cambio de turno;
-- revisar pacientes por unidad/planta;
-- registrar observación especial;
-- registrar riesgos de caídas, fuga/no retorno, conducta, adherencia, sueño, hidratación, alimentación y deterioro funcional;
-- revisar medicación y tratamientos pendientes;
-- registrar contención solo como evento trazable y protocolizado;
-- generar un SBAR psiquiátrico prudente;
-- preparar continuidad para el turno siguiente;
-- alimentar ICEA shadow agregado sin score individual visible.
-
-## Mapa de ramas del trabajo
-
-Orden previsto de implementación, manteniendo un objetivo por rama:
-
-1. `docs/sjd-psychiatry-context-and-demo-scope`
-2. `feat/psychiatry-identity-without-qr`
-3. `feat/sjd-psychiatry-unit-profiles`
-4. `feat/sjd-psychiatry-section-fields`
-5. `feat/sjd-safety-overlays-falls-fuga-restraint`
-6. `feat/psychogeriatrics-udcc-functional-overlay`
-7. `feat/psychiatry-mpac-explainable-priorities`
-8. `feat/psychiatry-fhir-and-icea-shadow`
-9. `feat/sjd-psychiatry-demo-mode`
-10. `test/docs-psychiatry-demo-hardening`
-
-## Alcance real de este PR
-
-Este PR implementa el seam inicial SJD psiquiatría de forma acotada:
-
-- documenta alcance, límites y guardrails del demo;
-- añade `psych` como especialidad visible;
-- añade unidades SJD/UDCC al catálogo operativo;
-- mapea esas unidades al perfil común `behavioral-health`;
-- refuerza el runtime mínimo de salud mental;
-- hace visibles secciones ya existentes para continuidad, ingesta/hidratacion y pendientes del turno;
-- diferencia de forma ligera infanto-adolescente y psicogeriatría/UDCC mediante checklist contextual ya soportado por el repo;
-- desactiva QR por defecto en contexto psiquiátrico/salud mental, incluso cuando ese contexto se resuelve por `UNITS_CONFIG` y no solo por IDs SJD hardcodeados;
-- mantiene QR como capacidad futura reactivable solo mediante `EXPO_PUBLIC_ENABLE_QR_PATIENT_SCAN=true`;
-- añade pruebas mínimas del seam.
-
-Este PR no cambia:
-
-- contratos Zod clínicos principales;
-- exportación FHIR;
-- payloads o vistas ICEA;
-- backend;
-- auth/RBAC;
-- sync/offline queue;
-- dependencias;
-- demo fixtures sintéticos de punta a punta.
-
-## Riesgos residuales abiertos tras este PR
-
-- sin unidades y especialidades SJD visibles en runtime, el demo sigue apoyado en costuras genéricas;
-- sin una costura adicional de schema/UI persistida, el runtime psiquiátrico sigue dependiendo de copy contextual y checklist para parte de la variación ligera por subunidad;
-- sin fixtures y demo mode SJD, la narrativa clínica todavía no queda trazada de punta a punta;
-- los documentos clínicos SJD siguen siendo una dependencia externa hasta que exista una vía institucional de incorporación o validación fuera de PHI.
+- revise parte diario y continuidad del relevo;
+- haga visible observacion especial y entorno seguro;
+- registre caidas, fuga/no retorno y elementos retirables como riesgos de seguridad;
+- deje trazable una medida excepcional sin describir pasos tecnicos;
+- cierre pendientes no omitibles para el siguiente turno.
 
 ## Veredicto documental
 
-Listo como documento de alcance y control de cambios para abrir las ramas funcionales siguientes.
-
-No debe usarse como evidencia de que el demo psiquiátrico ya está implementado.
+Listo como alcance generico del demo psiquiatrico con un unico runtime `behavioral-health` y variaciones ligeras por checklist contextual.

--- a/src/config/profiles/units/index.ts
+++ b/src/config/profiles/units/index.ts
@@ -115,17 +115,17 @@ export const UNIT_PROFILE_CHECKLIST_ITEMS: Partial<
     {
       key: 'patientIdentityConfirmed',
       label: 'Paciente, ubicacion funcional y referente del turno confirmados',
-      helper: 'Prioriza censo, cama/planta o identificador institucional sin depender del QR.',
+      helper: 'Prioriza censo, cama/planta o identificador del centro sin depender del QR.',
     },
     {
       key: 'allergiesReviewed',
-      label: 'Alertas conductuales, observacion especial y riesgos inmediatos revisados',
-      helper: 'Aclara si hubo cambio respecto al basal, pendiente critico o necesidad de acompanamiento intensivo.',
+      label: 'Observacion especial, riesgo de caidas y fuga/no retorno revisados',
+      helper: 'Aclara cambio respecto al basal, necesidad de acompanamiento y siguiente reevaluacion prioritaria.',
     },
     {
       key: 'linesAndDevicesChecked',
-      label: 'Pertenencias, entorno seguro y restricciones activas verificadas',
-      helper: 'Solo registra estado y trazabilidad; no sustituye protocolos locales de seguridad.',
+      label: 'Entorno seguro, elementos retirables y tratamientos o dispositivos verificados',
+      helper: 'Deja visible lo que requiere resguardo o puede retirarse, con estado y trazabilidad para el relevo.',
     },
     {
       key: 'medicationPlanReviewed',
@@ -134,8 +134,9 @@ export const UNIT_PROFILE_CHECKLIST_ITEMS: Partial<
     },
     {
       key: 'safetyMeasuresApplied',
-      label: 'Plan de observacion, continuidad y coordinacion interna aplicado',
-      helper: 'Expresa prioridades de cuidado y continuidad, no etiquetas punitivas ni rankings de peligrosidad.',
+      label: 'Continuidad, reevaluacion y evento de contencion trazables',
+      helper:
+        'Si existe una medida excepcional, registra solo autorizacion, revision, vigencia y proxima reevaluacion dentro del marco asistencial vigente.',
     },
     {
       key: 'questionsAnswered',
@@ -316,10 +317,11 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     requiredExtraFields: [
       'Estado basal y cambio observado',
       'Observacion especial o acompanamiento',
+      'Riesgo de caidas y necesidad de deambulacion supervisada cuando aplique',
       'Riesgo de fuga o no retorno',
-      'Riesgo conductual expresado de forma no estigmatizante',
+      'Entorno seguro y elementos que deban resguardarse',
       'Adherencia o rechazo terapeutico',
-      'Coordinacion interna pendiente',
+      'Coordinacion interna pendiente y reevaluacion del siguiente turno',
     ],
     optionalExtraFields: [
       'Sueno e ingesta/hidratacion',
@@ -327,19 +329,24 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
       'Coordinacion con familia, tutor o cuidadores cuando aplique',
       'Deterioro funcional o cognitivo-conductual cuando aplique',
       'Dispositivos o tratamientos que el paciente pueda retirarse',
+      'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
     ],
     focusAreas: [
-      'Observacion especial, continuidad y seguridad relacional',
+      'Observacion especial, entorno seguro y seguridad relacional',
+      'Caidas, fuga/no retorno y elementos retirables que requieren continuidad',
       'Cambio respecto al basal, adherencia terapeutica y riesgo de omision del turno siguiente',
       'Ingesta, hidratacion, sueno y coordinacion interna pendiente',
     ],
     explanations: [
       'Refuerza salud mental con secciones y copy del runtime ya existentes, sin abrir un formulario paralelo ni convertir QR en flujo principal.',
+      'Mantiene un unico nucleo behavioral-health y deja las variaciones por subunidad limitadas a checklist contextual y copy prudente.',
     ],
     scales: ['EVA', 'Observacion conductual estructurada cuando aplique'],
     sentinelEvents: [
+      'Caida',
       'Descompensacion conductual',
       'Fuga o no retorno',
+      'Retiro no planificado de dispositivo o tratamiento',
       'Rechazo terapeutico con riesgo de omision',
       'Cambio relevante respecto al basal',
     ],
@@ -348,7 +355,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
         {
           id: 'psych-observation',
           type: 'other',
-          description: 'Actualizar observacion especial, acompanamiento, gatillos y siguiente reevaluacion del turno',
+          description: 'Actualizar observacion especial, acompanamiento, riesgo de caidas y siguiente reevaluacion del turno',
         },
         {
           id: 'psych-adherence',
@@ -356,9 +363,19 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
           description: 'Cerrar adherencia o rechazo terapeutico y pendientes de medicacion o tratamiento no omitibles',
         },
         {
+          id: 'psych-safe-environment',
+          type: 'other',
+          description: 'Verificar entorno seguro, riesgo de fuga/no retorno y elementos, dispositivos o tratamientos retirables',
+        },
+        {
           id: 'psych-intake-sleep',
           type: 'other',
           description: 'Registrar sueno, ingesta, hidratacion y cambios respecto al basal relevantes para continuidad',
+        },
+        {
+          id: 'psych-restraint-trace',
+          type: 'other',
+          description: 'Registrar evento de contencion solo con autorizacion, vigencia, revision y siguiente reevaluacion',
         },
         {
           id: 'psych-continuity',
@@ -368,8 +385,9 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
       ],
     },
     visibleOutputs: [
-      'Plan de observacion y continuidad',
+      'Plan de observacion, entorno seguro y continuidad',
       'Pendientes de medicacion, tratamiento y coordinacion visibles para el siguiente turno',
+      'Evento de contencion trazable sin instrucciones operativas',
       'Continuidad de turno sin etiquetas estigmatizantes',
     ],
   }),

--- a/src/config/unitsConfig.ts
+++ b/src/config/unitsConfig.ts
@@ -82,13 +82,13 @@ const BEHAVIORAL_HEALTH_CHILD_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] =
   },
   {
     key: 'allergiesReviewed',
-    label: 'Observacion especial, entorno seguro y acompanamiento revisados',
-    helper: 'Asegura continuidad del acompanamiento y cambios respecto al basal sin exponer informacion externa.',
+    label: 'Observacion especial, acompanamiento y entorno seguro revisados',
+    helper: 'Asegura continuidad del acompanamiento, cambios respecto al basal y avisos internos del turno.',
   },
   {
     key: 'linesAndDevicesChecked',
-    label: 'Pertenencias, dispositivos retirables y entorno revisados',
-    helper: 'Deja visible solo lo necesario para continuidad y seguridad del relevo.',
+    label: 'Pertenencias, dispositivos retirables y riesgo de fuga/no retorno revisados',
+    helper: 'Deja visible solo lo necesario para continuidad, retorno seguro y coordinacion del relevo.',
   },
   {
     key: 'medicationPlanReviewed',
@@ -97,8 +97,8 @@ const BEHAVIORAL_HEALTH_CHILD_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] =
   },
   {
     key: 'safetyMeasuresApplied',
-    label: 'Coordinacion con familia o tutor y avisos internos revisados',
-    helper: 'Registra continuidad de comunicacion solo como dato interno del relevo.',
+    label: 'Coordinacion interna y con familia o tutor cuando aplique revisadas',
+    helper: 'Registra continuidad de comunicacion solo como coordinacion del relevo y siguiente reevaluacion.',
   },
   {
     key: 'questionsAnswered',
@@ -130,8 +130,8 @@ const BEHAVIORAL_HEALTH_UDCC_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] = 
   },
   {
     key: 'safetyMeasuresApplied',
-    label: 'Continuidad con cuidadores, supervision y entorno seguro aplicada',
-    helper: 'Aclara acompanamiento, movilidad y medidas de seguridad no farmacologicas del turno.',
+    label: 'Continuidad con cuidadores, supervision, entorno seguro y reevaluacion aplicada',
+    helper: 'Aclara acompanamiento, movilidad y continuidad del siguiente turno sin abrir un overlay paralelo.',
   },
   {
     key: 'questionsAnswered',

--- a/src/lib/__tests__/profile-runtime.spec.ts
+++ b/src/lib/__tests__/profile-runtime.spec.ts
@@ -282,6 +282,7 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.context.catalogUnitProfileId).toBe('behavioral-health');
     expect(runtime.context.unitProfileId).toBe('behavioral-health');
     expect(runtime.context.specialtyId).toBe('psych');
+    expect(runtime.context.specialtyOverlayIds).toEqual([]);
     expect(runtime.pack.id).toBe('behavioral-health');
     expect(runtime.basePack.id).toBe('behavioral-health');
     expect(runtime.sectionVisibility.psychosocial).toBe(true);
@@ -291,11 +292,21 @@ describe('resolveHandoverProfileRuntime', () => {
       expect.arrayContaining([
         'Estado basal y cambio observado',
         'Observacion especial o acompanamiento',
+        'Riesgo de caidas y necesidad de deambulacion supervisada cuando aplique',
         'Riesgo de fuga o no retorno',
+        'Entorno seguro y elementos que deban resguardarse',
+        'Coordinacion interna pendiente y reevaluacion del siguiente turno',
       ]),
     );
-    expect(runtime.visibleOutputs).toContain('Plan de observacion y continuidad');
+    expect(runtime.optionalExtraFields).toContain(
+      'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
+    );
+    expect(runtime.visibleOutputs).toContain('Plan de observacion, entorno seguro y continuidad');
+    expect(runtime.visibleOutputs).toContain('Evento de contencion trazable sin instrucciones operativas');
     expect(runtime.checklistItems[0]?.label).toContain('ubicacion funcional');
+    expect(runtime.checklistItems[1]?.label).toContain('caidas');
+    expect(runtime.checklistItems[2]?.label).toContain('elementos retirables');
+    expect(runtime.checklistItems[4]?.label).toContain('contencion');
   });
 
   it('keeps child-adolescent psychiatry on the shared behavioral-health core while projecting a unit-specific checklist', async () => {
@@ -309,16 +320,19 @@ describe('resolveHandoverProfileRuntime', () => {
 
     expect(runtime.context.catalogUnitProfileId).toBe('behavioral-health');
     expect(runtime.context.unitProfileId).toBe('behavioral-health');
+    expect(runtime.context.specialtyOverlayIds).toEqual([]);
     expect(runtime.pack.id).toBe('behavioral-health');
     expect(runtime.basePack.id).toBe('behavioral-health');
     expect(runtime.activeOverlays).toEqual([]);
     expect(runtime.optionalExtraFields).toEqual(
       expect.arrayContaining([
+        'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
         'Responsable o referente de comunicacion interna',
         'Coordinacion con familia, tutor o cuidadores cuando aplique',
       ]),
     );
     expect(runtime.checklistItems[0]?.label).toBe('Paciente, ubicacion funcional y referente interno confirmados');
+    expect(runtime.checklistItems[2]?.label).toContain('fuga/no retorno');
     expect(runtime.checklistItems[4]?.label).toContain('familia o tutor');
   });
 
@@ -333,9 +347,15 @@ describe('resolveHandoverProfileRuntime', () => {
 
     expect(runtime.context.catalogUnitProfileId).toBe('behavioral-health');
     expect(runtime.context.unitProfileId).toBe('behavioral-health');
+    expect(runtime.context.specialtyOverlayIds).toEqual([]);
     expect(runtime.pack.id).toBe('behavioral-health');
     expect(runtime.basePack.id).toBe('behavioral-health');
     expect(runtime.activeOverlays).toEqual([]);
+    expect(runtime.requiredExtraFields).toEqual(
+      expect.arrayContaining([
+        'Riesgo de caidas y necesidad de deambulacion supervisada cuando aplique',
+      ]),
+    );
     expect(runtime.optionalExtraFields).toEqual(
       expect.arrayContaining([
         'Deterioro funcional o cognitivo-conductual cuando aplique',
@@ -345,6 +365,7 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.checklistItems[0]?.label).toBe(
       'Paciente, ubicacion funcional y basal cognitivo-funcional confirmados',
     );
+    expect(runtime.checklistItems[1]?.label).toContain('riesgo de caidas');
     expect(runtime.checklistItems[2]?.label).toContain('deambulacion supervisada');
   });
 


### PR DESCRIPTION
## Summary
- Adds a minimal mental-health safety runtime seam for the SJD psychiatry demo.
- Keeps all SJD/psychiatry units on the shared behavioral-health core.
- Represents falls, no-return/elopement risk, safe environment, removable devices/treatments, continuity and restraint traceability through runtime/checklist copy only.
- Keeps restraint as a traceable event only: authorization, review, validity and reassessment. No operational instructions are added.
- Removes sensitive institutional-document references from the demo scope document.

## Scope
Touched only:
- docs/sjd-psychiatry-demo-scope.md
- src/config/profiles/units/index.ts
- src/config/unitsConfig.ts
- src/lib/__tests__/profile-runtime.spec.ts

Not touched:
- backend
- FHIR
- ICEA
- auth/RBAC
- audit
- sync/offline queue
- Zod/schema
- QR logic
- package.json
- pnpm-lock.yaml

## Validation
- git diff -- package.json pnpm-lock.yaml
- pnpm -w typecheck
- pnpm -w lint:ci
- pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts
- pnpm exec vitest run src/config/profiles/__tests__/catalog.spec.ts
- pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts
- confidentiality grep over docs src .github

## Risk
Low to moderate. This is runtime/checklist-only. It does not create persisted clinical fields or a separate restraint model. A future structured restraint/event schema would require separate review of UI, Zod, FHIR, audit and backend contracts.