### PR TITLE
feat: refine UDCC functional runtime continuity

### DIFF
--- a/docs/sjd-psychiatry-demo-scope.md
+++ b/docs/sjd-psychiatry-demo-scope.md
@@ -33,11 +33,14 @@ Preparar un demo prudente de HANDOVER + ICEA para salud mental usando el nucleo 
 
 ### Psicogeriatria / UDCC
 
+- basal cognitivo-funcional y cambio respecto al basal;
+- supervision requerida y deambulacion supervisada;
 - riesgo de caidas;
-- deambulacion supervisada;
 - deterioro cognitivo-funcional;
+- continencia o piel cuando condicionen la continuidad;
 - dispositivos o tratamientos retirables;
-- ingesta, hidratacion y sueno.
+- ingesta, hidratacion y sueno;
+- adherencia terapeutica y reevaluacion del siguiente turno.
 
 ## Limites del demo
 

--- a/src/config/profiles/units/index.ts
+++ b/src/config/profiles/units/index.ts
@@ -316,8 +316,8 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     enabledSections: ['psychosocial', 'nutrition', 'examenes'],
     requiredExtraFields: [
       'Estado basal y cambio observado',
-      'Observacion especial o acompanamiento',
-      'Riesgo de caidas y necesidad de deambulacion supervisada cuando aplique',
+      'Observacion especial, acompanamiento o nivel de supervision requerido',
+      'Riesgo de caidas, movilidad segura y necesidad de deambulacion supervisada cuando aplique',
       'Riesgo de fuga o no retorno',
       'Entorno seguro y elementos que deban resguardarse',
       'Adherencia o rechazo terapeutico',
@@ -325,7 +325,8 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     ],
     optionalExtraFields: [
       'Sueno e ingesta/hidratacion',
-      'Responsable o referente de comunicacion interna',
+      'Continencia, piel o ayudas funcionales cuando condicionen la continuidad del turno',
+      'Responsable o referente de comunicacion interna y relacion terapeutica relevante',
       'Coordinacion con familia, tutor o cuidadores cuando aplique',
       'Deterioro funcional o cognitivo-conductual cuando aplique',
       'Dispositivos o tratamientos que el paciente pueda retirarse',
@@ -333,9 +334,9 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     ],
     focusAreas: [
       'Observacion especial, entorno seguro y seguridad relacional',
-      'Caidas, fuga/no retorno y elementos retirables que requieren continuidad',
+      'Caidas, fuga/no retorno, movilidad segura y elementos retirables que requieren continuidad',
       'Cambio respecto al basal, adherencia terapeutica y riesgo de omision del turno siguiente',
-      'Ingesta, hidratacion, sueno y coordinacion interna pendiente',
+      'Ingesta, hidratacion, sueno, supervision funcional y coordinacion interna pendiente',
     ],
     explanations: [
       'Refuerza salud mental con secciones y copy del runtime ya existentes, sin abrir un formulario paralelo ni convertir QR en flujo principal.',
@@ -370,7 +371,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
         {
           id: 'psych-intake-sleep',
           type: 'other',
-          description: 'Registrar sueno, ingesta, hidratacion y cambios respecto al basal relevantes para continuidad',
+          description: 'Registrar sueno, ingesta, hidratacion y continencia o piel cuando condicionen la continuidad',
         },
         {
           id: 'psych-restraint-trace',
@@ -380,12 +381,13 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
         {
           id: 'psych-continuity',
           type: 'other',
-          description: 'Resumir coordinacion interna, continuidad del turno y avisos para el siguiente relevo',
+          description: 'Resumir basal funcional, supervision requerida, coordinacion interna y avisos para el siguiente relevo',
         },
       ],
     },
     visibleOutputs: [
       'Plan de observacion, entorno seguro y continuidad',
+      'Basal funcional y supervision requerida explicitados para el siguiente turno',
       'Pendientes de medicacion, tratamiento y coordinacion visibles para el siguiente turno',
       'Evento de contencion trazable sin instrucciones operativas',
       'Continuidad de turno sin etiquetas estigmatizantes',

--- a/src/config/unitsConfig.ts
+++ b/src/config/unitsConfig.ts
@@ -110,28 +110,28 @@ const BEHAVIORAL_HEALTH_CHILD_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] =
 const BEHAVIORAL_HEALTH_UDCC_CHECKLIST_ITEMS: readonly BedsideChecklistItem[] = [
   {
     key: 'patientIdentityConfirmed',
-    label: 'Paciente, ubicacion funcional y basal cognitivo-funcional confirmados',
-    helper: 'Prioriza censo/listado, ubicacion y referencia breve del estado habitual.',
+    label: 'Paciente, ubicacion funcional, basal cognitivo-funcional y supervision requerida confirmados',
+    helper: 'Prioriza censo/listado, ubicacion y referencia breve del estado habitual y del apoyo necesario.',
   },
   {
     key: 'allergiesReviewed',
-    label: 'Cambio respecto al basal, observacion y riesgo de caidas revisados',
-    helper: 'Haz visible deterioro funcional o cognitivo-conductual y necesidad de supervision.',
+    label: 'Cambio respecto al basal, deambulacion supervisada y riesgo de caidas revisados',
+    helper: 'Haz visible deterioro cognitivo-funcional, movilidad y ayudas necesarias del turno.',
   },
   {
     key: 'linesAndDevicesChecked',
-    label: 'Dispositivos, tratamientos retirables y deambulacion supervisada verificados',
-    helper: 'Confirma lo que puede retirarse el paciente y las medidas de acompanamiento activas.',
+    label: 'Entorno seguro, continencia, piel y elementos retirables verificados',
+    helper: 'Confirma dispositivos o tratamientos que pueda retirarse y cualquier continuidad de continencia o integridad cutanea.',
   },
   {
     key: 'medicationPlanReviewed',
-    label: 'Ingesta, hidratacion, sueno y medicacion pendiente revisados',
-    helper: 'Expresa lo no omitible para el siguiente turno con continuidad longitudinal.',
+    label: 'Ingesta, hidratacion, sueno y adherencia terapeutica revisados',
+    helper: 'Incluye medicacion pendiente, rechazos o dificultad para sostener el plan del siguiente turno.',
   },
   {
     key: 'safetyMeasuresApplied',
-    label: 'Continuidad con cuidadores, supervision, entorno seguro y reevaluacion aplicada',
-    helper: 'Aclara acompanamiento, movilidad y continuidad del siguiente turno sin abrir un overlay paralelo.',
+    label: 'Supervision, coordinacion interna y con cuidadores, y reevaluacion revisadas',
+    helper: 'Aclara acompanamiento, comunicacion o relacion relevante, actividad estructurada cuando aplique y continuidad del relevo siguiente.',
   },
   {
     key: 'questionsAnswered',

--- a/src/lib/__tests__/profile-runtime.spec.ts
+++ b/src/lib/__tests__/profile-runtime.spec.ts
@@ -291,8 +291,8 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.requiredExtraFields).toEqual(
       expect.arrayContaining([
         'Estado basal y cambio observado',
-        'Observacion especial o acompanamiento',
-        'Riesgo de caidas y necesidad de deambulacion supervisada cuando aplique',
+        'Observacion especial, acompanamiento o nivel de supervision requerido',
+        'Riesgo de caidas, movilidad segura y necesidad de deambulacion supervisada cuando aplique',
         'Riesgo de fuga o no retorno',
         'Entorno seguro y elementos que deban resguardarse',
         'Coordinacion interna pendiente y reevaluacion del siguiente turno',
@@ -302,11 +302,14 @@ describe('resolveHandoverProfileRuntime', () => {
       'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
     );
     expect(runtime.visibleOutputs).toContain('Plan de observacion, entorno seguro y continuidad');
+    expect(runtime.visibleOutputs).toContain('Basal funcional y supervision requerida explicitados para el siguiente turno');
     expect(runtime.visibleOutputs).toContain('Evento de contencion trazable sin instrucciones operativas');
     expect(runtime.checklistItems[0]?.label).toContain('ubicacion funcional');
     expect(runtime.checklistItems[1]?.label).toContain('caidas');
     expect(runtime.checklistItems[2]?.label).toContain('elementos retirables');
     expect(runtime.checklistItems[4]?.label).toContain('contencion');
+    expect(runtime.checklistItems.some((item) => item.label.includes('basal cognitivo-funcional'))).toBe(false);
+    expect(runtime.checklistItems.some((item) => item.label.includes('deambulacion supervisada'))).toBe(false);
   });
 
   it('keeps child-adolescent psychiatry on the shared behavioral-health core while projecting a unit-specific checklist', async () => {
@@ -327,13 +330,15 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.optionalExtraFields).toEqual(
       expect.arrayContaining([
         'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
-        'Responsable o referente de comunicacion interna',
+        'Responsable o referente de comunicacion interna y relacion terapeutica relevante',
         'Coordinacion con familia, tutor o cuidadores cuando aplique',
       ]),
     );
     expect(runtime.checklistItems[0]?.label).toBe('Paciente, ubicacion funcional y referente interno confirmados');
     expect(runtime.checklistItems[2]?.label).toContain('fuga/no retorno');
     expect(runtime.checklistItems[4]?.label).toContain('familia o tutor');
+    expect(runtime.checklistItems.some((item) => item.label.includes('basal cognitivo-funcional'))).toBe(false);
+    expect(runtime.checklistItems.some((item) => item.label.includes('deambulacion supervisada'))).toBe(false);
   });
 
   it('keeps psychogeriatrics on the shared behavioral-health core while projecting a unit-specific checklist', async () => {
@@ -353,20 +358,35 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.activeOverlays).toEqual([]);
     expect(runtime.requiredExtraFields).toEqual(
       expect.arrayContaining([
-        'Riesgo de caidas y necesidad de deambulacion supervisada cuando aplique',
+        'Observacion especial, acompanamiento o nivel de supervision requerido',
+        'Riesgo de caidas, movilidad segura y necesidad de deambulacion supervisada cuando aplique',
       ]),
     );
     expect(runtime.optionalExtraFields).toEqual(
       expect.arrayContaining([
+        'Continencia, piel o ayudas funcionales cuando condicionen la continuidad del turno',
         'Deterioro funcional o cognitivo-conductual cuando aplique',
         'Dispositivos o tratamientos que el paciente pueda retirarse',
       ]),
     );
-    expect(runtime.checklistItems[0]?.label).toBe(
-      'Paciente, ubicacion funcional y basal cognitivo-funcional confirmados',
+    expect(runtime.focusAreas).toEqual(
+      expect.arrayContaining([
+        'Caidas, fuga/no retorno, movilidad segura y elementos retirables que requieren continuidad',
+        'Ingesta, hidratacion, sueno, supervision funcional y coordinacion interna pendiente',
+      ]),
     );
-    expect(runtime.checklistItems[1]?.label).toContain('riesgo de caidas');
-    expect(runtime.checklistItems[2]?.label).toContain('deambulacion supervisada');
+    expect(runtime.visibleOutputs).toContain('Basal funcional y supervision requerida explicitados para el siguiente turno');
+    expect(runtime.checklistItems[0]?.label).toBe(
+      'Paciente, ubicacion funcional, basal cognitivo-funcional y supervision requerida confirmados',
+    );
+    expect(runtime.checklistItems[1]?.label).toContain('deambulacion supervisada');
+    expect(runtime.checklistItems[2]?.label).toContain('continencia');
+    expect(runtime.checklistItems[3]?.label).toContain('adherencia terapeutica');
+    expect(runtime.checklistItems[4]?.label).toContain('reevaluacion');
+    expect(runtime.treatmentQuickPicks.map((quickPick) => quickPick.id)).toEqual(
+      expect.arrayContaining(['psych-intake-sleep', 'psych-continuity']),
+    );
+    expect(runtime.checklistItems.some((item) => item.label.includes('familia o tutor'))).toBe(false);
   });
 
   it('keeps hidden sections monotonic across compatible overlay merges while preserving trace order', async () => {


### PR DESCRIPTION
## Summary

- Refines the psychogeriatrics / UDCC runtime and checklist within the shared behavioral-health core.
- Makes cognitive-functional baseline, supervision needs, safe mobility, continence/skin continuity, adherence and next-shift reassessment more visible.
- Keeps the change runtime/checklist-only, without new persisted fields or parallel forms.

## Scope

Touched only:

- docs/sjd-psychiatry-demo-scope.md
- src/config/profiles/units/index.ts
- src/config/unitsConfig.ts
- src/lib/__tests__/profile-runtime.spec.ts

Not touched:

- backend
- FHIR
- ICEA
- auth/RBAC
- audit
- sync/offline queue
- Zod/schema
- HandoverForm
- PatientSection
- SafetySection
- package.json
- pnpm-lock.yaml

## Validation

- pnpm -w typecheck
- pnpm -w lint:ci
- pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts
- pnpm exec vitest run src/config/profiles/__tests__/catalog.spec.ts
- pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts
- git diff -- package.json pnpm-lock.yaml
- confidentiality grep over docs src .github

## Risk

Low. This is runtime/checklist/documentation only. It does not introduce persisted clinical fields, new schemas, backend changes, FHIR changes or ICEA changes.

## Limitations

This does not constitute clinical validation. It improves continuity wording and runtime projection for the demo only.