### PR TITLE
feat(psych): add explainable MPAC continuity priorities

### DIFF
--- a/docs/mpac-v1.md
+++ b/docs/mpac-v1.md
@@ -75,6 +75,8 @@ The contextual priority output is surfaced in the existing React Native experien
 - PatientList can auto-sort only when there is actionable contextual signal and otherwise falls back to the received order.
 - Each patient card shows a compact, non-alarmist explanation covering why the patient is elevated, what cannot be omitted, and the active time window when available.
 - SupervisorDashboard reuses the same patient census and MPAC facade to expose a unit-level priority snapshot for supervision.
+- Behavioral-health demos can project explainable continuity priorities through the existing profile runtime copy (`focusAreas`, `explanations`, `visibleOutputs`, checklist labels) without adding a psychiatric scorer, autonomous recommendation engine, or new persisted schema.
+- That projection is editorial and prudential: it must not be presented as clinically validated psychiatric scoring, ranking, or replacement for nurse judgment.
 
 ## Validation
 

--- a/src/config/profiles/units/index.ts
+++ b/src/config/profiles/units/index.ts
@@ -341,6 +341,8 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     explanations: [
       'Refuerza salud mental con secciones y copy del runtime ya existentes, sin abrir un formulario paralelo ni convertir QR en flujo principal.',
       'Mantiene un unico nucleo behavioral-health y deja las variaciones por subunidad limitadas a checklist contextual y copy prudente.',
+      'MPAC para salud mental se proyecta aqui como prioridades explicables de continuidad y seguridad; no sustituye juicio clinico ni activa scoring autonomo.',
+      'No presenta ranking individual ni validacion clinica; ordena de forma prudente lo que el relevo no debe omitir.',
     ],
     scales: ['EVA', 'Observacion conductual estructurada cuando aplique'],
     sentinelEvents: [
@@ -386,11 +388,18 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
       ],
     },
     visibleOutputs: [
-      'Plan de observacion, entorno seguro y continuidad',
-      'Basal funcional y supervision requerida explicitados para el siguiente turno',
-      'Pendientes de medicacion, tratamiento y coordinacion visibles para el siguiente turno',
+      'Continuidad del relevo explicitada para el siguiente turno',
+      'Riesgo de omision en medicacion, tratamiento, vigilancia o coordinacion visible',
+      'Cambio respecto al basal resumido sin etiquetas estigmatizantes',
+      'Necesidad de reevaluacion y siguiente ventana del turno visibles',
+      'Coordinacion interna pendiente y referente del relevo explicitados',
+      'Seguridad del entorno y resguardo de elementos retirables visibles',
+      'Adherencia o rechazo terapeutico con continuidad del plan',
+      'Fuga o no retorno y supervision requerida visibles',
+      'Caidas o movilidad supervisada explicitadas cuando apliquen',
+      'Dispositivos o tratamientos retirables con trazabilidad para el relevo',
+      'Observacion especial o acompanamiento explicitados',
       'Evento de contencion trazable sin instrucciones operativas',
-      'Continuidad de turno sin etiquetas estigmatizantes',
     ],
   }),
   'home-care': createPack({

--- a/src/lib/__tests__/profile-runtime.spec.ts
+++ b/src/lib/__tests__/profile-runtime.spec.ts
@@ -301,8 +301,23 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.optionalExtraFields).toContain(
       'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
     );
-    expect(runtime.visibleOutputs).toContain('Plan de observacion, entorno seguro y continuidad');
-    expect(runtime.visibleOutputs).toContain('Basal funcional y supervision requerida explicitados para el siguiente turno');
+    expect(runtime.explanations).toContain(
+      'MPAC para salud mental se proyecta aqui como prioridades explicables de continuidad y seguridad; no sustituye juicio clinico ni activa scoring autonomo.',
+    );
+    expect(runtime.explanations).toContain(
+      'No presenta ranking individual ni validacion clinica; ordena de forma prudente lo que el relevo no debe omitir.',
+    );
+    expect(runtime.visibleOutputs).toContain('Continuidad del relevo explicitada para el siguiente turno');
+    expect(runtime.visibleOutputs).toContain('Riesgo de omision en medicacion, tratamiento, vigilancia o coordinacion visible');
+    expect(runtime.visibleOutputs).toContain('Cambio respecto al basal resumido sin etiquetas estigmatizantes');
+    expect(runtime.visibleOutputs).toContain('Necesidad de reevaluacion y siguiente ventana del turno visibles');
+    expect(runtime.visibleOutputs).toContain('Coordinacion interna pendiente y referente del relevo explicitados');
+    expect(runtime.visibleOutputs).toContain('Seguridad del entorno y resguardo de elementos retirables visibles');
+    expect(runtime.visibleOutputs).toContain('Adherencia o rechazo terapeutico con continuidad del plan');
+    expect(runtime.visibleOutputs).toContain('Fuga o no retorno y supervision requerida visibles');
+    expect(runtime.visibleOutputs).toContain('Caidas o movilidad supervisada explicitadas cuando apliquen');
+    expect(runtime.visibleOutputs).toContain('Dispositivos o tratamientos retirables con trazabilidad para el relevo');
+    expect(runtime.visibleOutputs).toContain('Observacion especial o acompanamiento explicitados');
     expect(runtime.visibleOutputs).toContain('Evento de contencion trazable sin instrucciones operativas');
     expect(runtime.checklistItems[0]?.label).toContain('ubicacion funcional');
     expect(runtime.checklistItems[1]?.label).toContain('caidas');
@@ -375,7 +390,8 @@ describe('resolveHandoverProfileRuntime', () => {
         'Ingesta, hidratacion, sueno, supervision funcional y coordinacion interna pendiente',
       ]),
     );
-    expect(runtime.visibleOutputs).toContain('Basal funcional y supervision requerida explicitados para el siguiente turno');
+    expect(runtime.visibleOutputs).toContain('Coordinacion interna pendiente y referente del relevo explicitados');
+    expect(runtime.visibleOutputs).toContain('Caidas o movilidad supervisada explicitadas cuando apliquen');
     expect(runtime.checklistItems[0]?.label).toBe(
       'Paciente, ubicacion funcional, basal cognitivo-funcional y supervision requerida confirmados',
     );

--- a/src/screens/handover/HandoverOverview.tsx
+++ b/src/screens/handover/HandoverOverview.tsx
@@ -92,6 +92,8 @@ export function HandoverOverview({
 }: Props) {
   const syncNoticeCopy = resolveSyncNoticeCopy(handoverSyncStatus, handoverSyncError);
   const syncNoticeColors = resolveSyncNoticeColors(handoverSyncStatus, colors);
+  const usesBehavioralHealthRuntime =
+    profileRuntime.basePack.id === 'behavioral-health' || profileRuntime.pack.id === 'behavioral-health';
 
   return (
     <>
@@ -181,9 +183,18 @@ export function HandoverOverview({
           {`Merge aplicado: ${profileRuntime.mergeTrace.map((entry) => entry.label).join(' -> ')}`}
         </Text>
         {profileRuntime.visibleOutputs.length > 0 ? (
-          <Text style={styles.profileCardMeta}>
-            {`Salidas visibles: ${profileRuntime.visibleOutputs.join(' · ')}`}
-          </Text>
+          <View testID="handover-profile-visible-outputs">
+            <Text style={styles.profileCardMeta}>
+              {usesBehavioralHealthRuntime
+                ? 'Prioridades explicables de continuidad (MPAC prudente):'
+                : 'Salidas visibles:'}
+            </Text>
+            {profileRuntime.visibleOutputs.map((output) => (
+              <Text key={output} style={styles.profileCardMeta}>
+                {`- ${output}`}
+              </Text>
+            ))}
+          </View>
         ) : null}
       </View>
     </>

--- a/src/screens/handover/__tests__/HandoverOverview.spec.tsx
+++ b/src/screens/handover/__tests__/HandoverOverview.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { HandoverOverview } from '../HandoverOverview';
+
+const originalEnv = { ...process.env };
+const isOn = vi.fn<(name: string) => boolean>(() => true);
+
+vi.mock('expo-constants', () => ({
+  default: {
+    expoConfig: {
+      extra: {},
+    },
+  },
+}));
+
+vi.mock('@/src/config/flags', () => ({
+  isOn: (name: string) => isOn(name),
+}));
+
+const styles = {
+  syncNotice: {},
+  syncNoticeTitle: {},
+  syncNoticeMessage: {},
+  syncNoticeActions: {},
+  syncNoticeCta: {},
+  e2eControls: {},
+  e2eTitle: {},
+  e2eActions: {},
+  profileCard: {},
+  profileCardTitle: {},
+  profileCardMeta: {},
+};
+
+describe('HandoverOverview', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.EXPO_PUBLIC_HANDOVER_PROFILE_ACTIVATION_JSON;
+    delete process.env.HANDOVER_PROFILE_ACTIVATION_JSON;
+    delete process.env.EXPO_PUBLIC_HANDOVER_UNITS_JSON;
+    delete process.env.HANDOVER_UNITS_JSON;
+    delete process.env.UNITS_CONFIG;
+    isOn.mockReset();
+    isOn.mockReturnValue(true);
+  });
+
+  it('lists explainable behavioral-health priorities without presenting a new scoring workflow', async () => {
+    process.env.UNITS_CONFIG = JSON.stringify({
+      units: [
+        {
+          id: 'sjd-a',
+          name: 'Psiquiatria adulto demo',
+          specialty: 'psych',
+          profileId: 'behavioral-health',
+        },
+      ],
+    });
+    process.env.EXPO_PUBLIC_HANDOVER_PROFILE_ACTIVATION_JSON = JSON.stringify({
+      unitProfiles: ['behavioral-health'],
+    });
+
+    const { resolveHandoverProfileRuntime } = await import('@/src/lib/profile-runtime');
+    const profileRuntime = resolveHandoverProfileRuntime({ unitId: 'sjd-a', specialtyId: 'psych' });
+
+    const screen = render(
+      <HandoverOverview
+        styles={styles}
+        colors={{
+          text: '#111827',
+          primary: '#2563EB',
+          danger: '#DC2626',
+          success: '#059669',
+          warning: '#D97706',
+          info: '#0284C7',
+        }}
+        handoverSyncStatus="idle"
+        handoverSyncError={null}
+        syncSnapshot={{ status: 'idle' }}
+        onRetrySync={() => {}}
+        onOpenLogin={() => {}}
+        onOpenSyncCenter={() => {}}
+        isE2E={false}
+        onSetFinalStatus={() => {}}
+        onAddSignature={() => {}}
+        onCompleteChecklist={() => {}}
+        profileRuntime={profileRuntime}
+        bannerSummary={null}
+        bannerLoading={false}
+        patientSummaryError={null}
+      />,
+    );
+
+    expect(screen.getByText('Prioridades explicables de continuidad (MPAC prudente):')).toBeTruthy();
+    expect(screen.getByText('- Continuidad del relevo explicitada para el siguiente turno')).toBeTruthy();
+    expect(screen.getByText('- Riesgo de omision en medicacion, tratamiento, vigilancia o coordinacion visible')).toBeTruthy();
+    expect(screen.getByText('- Observacion especial o acompanamiento explicitados')).toBeTruthy();
+    expect(screen.getByText('- Evento de contencion trazable sin instrucciones operativas')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds explainable MPAC continuity priorities for behavioral-health / psychiatry demo contexts.
- Projects priorities through existing runtime visibleOutputs and HandoverOverview UI.
- Keeps MPAC prudential, explainable, non-autonomous and non-scoring.
- Does not add psychiatric scoring, ML, ranking, persisted schema, backend or FHIR changes.

## Scope

Touched:
- docs/mpac-v1.md
- src/config/profiles/units/index.ts
- src/lib/__tests__/profile-runtime.spec.ts
- src/screens/handover/HandoverOverview.tsx
- src/screens/handover/__tests__/HandoverOverview.spec.tsx

Not touched:
- backend
- FHIR
- ICEA
- auth/RBAC
- audit
- sync/offline queue
- Zod/schema
- QR logic
- package.json
- pnpm-lock.yaml

## Validation

- git diff -- package.json pnpm-lock.yaml
- pnpm -w typecheck
- pnpm -w lint:ci
- pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts
- pnpm exec vitest run src/screens/handover/__tests__/HandoverOverview.spec.tsx
- pnpm exec vitest run src/config/profiles/__tests__/catalog.spec.ts
- pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts
- confidentiality grep over docs src .github

## Risk

Low to moderate. This is runtime/UI copy only. It does not create persisted clinical fields, a psychiatric scorer, autonomous recommendations, FHIR changes or ICEA runtime changes.

## Clinical guardrail

MPAC is presented as explainable continuity support for nursing handover. It is not a validated psychiatric score, not a danger ranking, not causal attribution and not a replacement for clinical judgment.