### PR TITLE
feat(demo): add synthetic SJD psychiatry demo mode

### DIFF
--- a/docs/sjd-psychiatry-demo-scope.md
+++ b/docs/sjd-psychiatry-demo-scope.md
@@ -14,6 +14,13 @@ Preparar un demo prudente de HANDOVER + ICEA para salud mental usando el nucleo 
 - adulto, infanto-adolescente y psicogeriatria/UDCC mantienen un unico core y solo cambian mediante checklist contextual y copy prudente;
 - QR sigue desactivado por defecto en contextos `behavioral-health` / `psych`.
 
+## Infraestructura de demo reutilizada
+
+- `src/demo/fixtures.ts` concentra el dataset sintetico del modo demo;
+- `src/demo/mock-api.ts` responde a `/api/patients`, `Patient/{id}`, `Encounter?...` y `AllergyIntolerance?...` sin tocar backend real;
+- `docs/MVP_DEMO.md` sigue siendo el walkthrough generico; este documento fija el seam psiquiatrico SJD hoy soportado;
+- no se conectan materiales locales ni artefactos operativos del centro.
+
 ## Variaciones ligeras permitidas
 
 ### Adulto
@@ -41,6 +48,38 @@ Preparar un demo prudente de HANDOVER + ICEA para salud mental usando el nucleo 
 - dispositivos o tratamientos retirables;
 - ingesta, hidratacion y sueno;
 - adherencia terapeutica y reevaluacion del siguiente turno.
+
+## Recorridos sinteticos soportados hoy
+
+### 1) Adulto salud mental
+
+- fixture demo: `demo-psych-adult-001` en `sjd-a`;
+- presentacion: continuidad del relevo, observacion especial, riesgo de caidas y fuga/no retorno, entorno seguro y elementos retirables resguardados;
+- no omitir: adherencia o rechazo terapeutico, medicacion del siguiente turno y reevaluacion prioritaria;
+- cierre esperado: pendientes claros para el siguiente relevo sin lenguaje punitivo ni ranking de peligrosidad.
+
+### 2) Infanto-adolescente
+
+- fixture demo: `demo-psych-child-001` en `sjd-infanto`;
+- presentacion: acompanamiento, entorno seguro, elementos retirables antes de cambio de actividad, retorno seguro y coordinacion con tutor cuando aplique;
+- no omitir: rechazo terapeutico parcial, continuidad del acompanamiento y cierre del siguiente turno;
+- cierre esperado: continuidad relacional y de supervision sin crear formulario paralelo ni instruccion operativa de contencion.
+
+### 3) Psicogeriatria / UDCC
+
+- fixture demo: `demo-psych-udcc-001` en `udcc-psychogeriatrics`;
+- presentacion: basal cognitivo-funcional, deambulacion supervisada, riesgo de caidas, hidratacion/sueno, adherencia terapeutica y audifono removible resguardado;
+- no omitir: supervision requerida, cambio respecto al basal y pendientes del turno siguiente;
+- cierre esperado: continuidad funcional y seguridad del entorno sin score psiquiatrico ni IA clinica cerrada.
+
+## Walkthrough recomendado
+
+1. Abrir `demo mode` y filtrar, si hace falta, por `sjd-a`, `sjd-infanto` o `udcc-psychogeriatrics`.
+2. Mostrar que el listado y el detalle siguen viniendo del seam demo aislado, con datos sinteticos y sin backend operativo.
+3. En cada recorrido, enfatizar continuidad del relevo, observacion especial o supervision, adherencia/rechazo, entorno seguro, elementos retirables y reevaluacion del siguiente turno.
+4. Si se menciona contencion, dejarla solo como evento trazable con autorizacion, revision, vigencia y reevaluacion, sin describir pasos operativos.
+5. Presentar MPAC solo como prioridades explicables de continuidad subordinadas al juicio enfermero.
+6. Cerrar recordando que HANDOVER se muestra aqui como piloto/demo profesional, no como producto production-ready ni clinicamente validado.
 
 ## Limites del demo
 

--- a/src/demo/fixtures.ts
+++ b/src/demo/fixtures.ts
@@ -1,8 +1,8 @@
-import { PATIENTS_MOCK } from '@/src/data/mockPatients';
 import { UNITS } from '@/src/config/units';
 import { buildDemoAdminDashboardSummary } from '@/src/mock/admin/dashboard-fixture';
 import type { PatientSummary } from '@/src/lib/fhir-client';
 import type { HandoverSession } from '@/src/security/auth-types';
+import type { PatientListItem } from '@/src/types/patientList';
 
 // BEGIN HANDOVER: DEMO_MODE
 export const DEMO_USER_ID = 'demo@nurseos.app';
@@ -18,81 +18,233 @@ export const DEMO_SESSION_TEMPLATE: HandoverSession = {
   mode: 'demo',
 };
 
-export const DEMO_PATIENT_SUMMARY: PatientSummary = {
-  id: PATIENTS_MOCK[0]?.id ?? 'pat-demo',
-  name: PATIENTS_MOCK[0]?.name ?? 'Paciente Demo',
-  gender: 'female',
-  age: 68,
-  bed: 'ICU-A1',
-  mrn: 'MRN-DEMO-001',
-  allergies: ['Penicilina'],
+type DemoPatientFixture = {
+  patient: PatientListItem;
+  summary: PatientSummary;
+  birthDate: string;
+  gender: 'female' | 'male';
+  encounterId: string;
+  locationId: string;
 };
 
-export const DEMO_FHIR_PATIENT = {
-  resourceType: 'Patient',
-  id: PATIENTS_MOCK[0]?.id ?? 'pat-demo',
-  birthDate: '1956-04-11',
-  name: [
-    {
-      given: ['Paciente'],
-      family: 'Demo',
-      text: 'Paciente Demo',
+const DEMO_PATIENT_FIXTURES: readonly DemoPatientFixture[] = [
+  {
+    patient: {
+      id: 'demo-psych-adult-001',
+      name: 'Caso sintetico adulto',
+      unitId: 'sjd-a',
+      bedLabel: 'SJD-A-01',
+      vitals: { rr: 18, spo2: 97, tempC: 36.8, sbp: 118, hr: 84, o2: false, avpu: 'A' },
+      risks: { fall: true },
+      pendingTasks: [
+        {
+          id: 'task-demo-psych-adult-obs',
+          title: 'Reevaluar observacion especial, entorno seguro y riesgo de fuga/no retorno',
+          critical: true,
+          priority: 'critical',
+          category: 'reevaluation',
+        },
+        {
+          id: 'task-demo-psych-adult-med',
+          title: 'Cerrar adherencia terapeutica y medicacion no omitible del siguiente turno',
+          urgent: true,
+          priority: 'urgent',
+          category: 'critical-task',
+        },
+      ],
     },
-  ],
-  identifier: [
-    { system: 'https://demo.hospital/bed', type: { text: 'Cama' }, value: 'A1' },
-    { system: 'https://demo.hospital/mrn', type: { text: 'MRN' }, value: 'MRN-DEMO-001' },
-  ],
-};
+    summary: {
+      id: 'demo-psych-adult-001',
+      name: 'Caso sintetico adulto',
+      gender: 'female',
+      age: 42,
+      bed: 'SJD-A-01',
+      mrn: 'MRN-DEMO-PSY-001',
+      allergies: ['Alergia sintetica documentada'],
+    },
+    birthDate: '1984-03-18',
+    gender: 'female',
+    encounterId: 'enc-demo-psych-adult-001',
+    locationId: 'loc-demo-psych-adult-001',
+  },
+  {
+    patient: {
+      id: 'demo-psych-child-001',
+      name: 'Caso sintetico infanto',
+      unitId: 'sjd-infanto',
+      bedLabel: 'INF-02',
+      vitals: { rr: 19, spo2: 98, tempC: 36.7, sbp: 109, hr: 88, o2: false, avpu: 'A' },
+      pendingTasks: [
+        {
+          id: 'task-demo-psych-child-safe',
+          title: 'Verificar acompanamiento, entorno seguro y elementos retirables antes del cambio de actividad',
+          urgent: true,
+          priority: 'urgent',
+          category: 'reevaluation',
+        },
+        {
+          id: 'task-demo-psych-child-followup',
+          title: 'Cerrar rechazo terapeutico parcial, retorno seguro y coordinacion con tutor del siguiente turno',
+          critical: true,
+          priority: 'critical',
+          category: 'critical-task',
+        },
+      ],
+    },
+    summary: {
+      id: 'demo-psych-child-001',
+      name: 'Caso sintetico infanto',
+      gender: 'male',
+      age: 15,
+      bed: 'INF-02',
+      mrn: 'MRN-DEMO-PSY-002',
+      allergies: ['Sin alergias sinteticas activas'],
+    },
+    birthDate: '2010-11-02',
+    gender: 'male',
+    encounterId: 'enc-demo-psych-child-001',
+    locationId: 'loc-demo-psych-child-001',
+  },
+  {
+    patient: {
+      id: 'demo-psych-udcc-001',
+      name: 'Caso sintetico psicogeriatria',
+      unitId: 'udcc-psychogeriatrics',
+      bedLabel: 'UDCC-03',
+      vitals: { rr: 17, spo2: 96, tempC: 36.5, sbp: 124, hr: 79, o2: false, avpu: 'A' },
+      devices: [{ id: 'dev-demo-udcc-walker', label: 'Andador supervisado', category: 'support' }],
+      risks: { fall: true },
+      pendingTasks: [
+        {
+          id: 'task-demo-psych-udcc-gait',
+          title: 'Reevaluar deambulacion supervisada, riesgo de caidas y continuidad del turno siguiente',
+          critical: true,
+          priority: 'critical',
+          category: 'reevaluation',
+        },
+        {
+          id: 'task-demo-psych-udcc-hydration',
+          title: 'Cerrar hidratacion, adherencia terapeutica y resguardo de audifono removible',
+          urgent: true,
+          priority: 'urgent',
+          category: 'critical-task',
+        },
+      ],
+    },
+    summary: {
+      id: 'demo-psych-udcc-001',
+      name: 'Caso sintetico psicogeriatria',
+      gender: 'female',
+      age: 82,
+      bed: 'UDCC-03',
+      mrn: 'MRN-DEMO-PSY-003',
+      allergies: ['Alergia sintetica a antiinflamatorio'],
+    },
+    birthDate: '1943-07-09',
+    gender: 'female',
+    encounterId: 'enc-demo-psych-udcc-001',
+    locationId: 'loc-demo-psych-udcc-001',
+  },
+] as const;
 
-export const DEMO_FHIR_ENCOUNTER_BUNDLE = {
-  resourceType: 'Bundle',
-  type: 'searchset',
-  entry: [
-    {
-      resource: {
-        resourceType: 'Encounter',
-        id: 'encounter-demo',
-        location: [
-          {
-            location: {
-              reference: 'Location/location-demo',
-              display: 'Cama A1',
-            },
+const DEMO_PATIENT_FIXTURES_BY_ID = Object.fromEntries(
+  DEMO_PATIENT_FIXTURES.map((fixture) => [fixture.patient.id, fixture]),
+) as Record<string, DemoPatientFixture>;
+
+const getDefaultDemoPatientFixture = (): DemoPatientFixture => DEMO_PATIENT_FIXTURES[0];
+
+export const DEMO_PATIENT_SUMMARY: PatientSummary = getDefaultDemoPatientFixture().summary;
+
+export const DEMO_PATIENTS: PatientListItem[] = DEMO_PATIENT_FIXTURES.map((fixture) => fixture.patient);
+
+export function getDemoPatientFixture(patientId?: string | null): DemoPatientFixture {
+  if (patientId && DEMO_PATIENT_FIXTURES_BY_ID[patientId]) {
+    return DEMO_PATIENT_FIXTURES_BY_ID[patientId];
+  }
+  return getDefaultDemoPatientFixture();
+}
+
+export function getDemoFhirPatient(patientId?: string | null) {
+  const fixture = getDemoPatientFixture(patientId);
+  const nameWords = fixture.summary.name.split(' ').filter(Boolean);
+  return {
+    resourceType: 'Patient',
+    id: fixture.summary.id,
+    gender: fixture.gender,
+    birthDate: fixture.birthDate,
+    name: [
+      {
+        given: nameWords.slice(0, -1),
+        family: nameWords.at(-1) ?? fixture.summary.name,
+        text: fixture.summary.name,
+      },
+    ],
+    identifier: [
+      { system: 'https://demo.hospital/bed', type: { text: 'Cama' }, value: fixture.summary.bed },
+      { system: 'https://demo.hospital/mrn', type: { text: 'MRN' }, value: fixture.summary.mrn },
+    ],
+  };
+}
+
+export function getDemoEncounterBundle(patientId?: string | null) {
+  const fixture = getDemoPatientFixture(patientId);
+  return {
+    resourceType: 'Bundle',
+    type: 'searchset',
+    entry: [
+      {
+        resource: {
+          resourceType: 'Encounter',
+          id: fixture.encounterId,
+          subject: {
+            reference: `Patient/${fixture.summary.id}`,
           },
-        ],
-      },
-    },
-    {
-      resource: {
-        resourceType: 'Location',
-        id: 'location-demo',
-        identifier: [{ system: 'https://demo.hospital/bed', type: { text: 'Cama' }, value: 'A1' }],
-      },
-    },
-  ],
-};
-
-export const DEMO_FHIR_ALLERGY_BUNDLE = {
-  resourceType: 'Bundle',
-  type: 'searchset',
-  entry: [
-    {
-      resource: {
-        resourceType: 'AllergyIntolerance',
-        id: 'allergy-demo',
-        code: {
-          text: 'Penicilina',
-          coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', display: 'Penicilina' }],
+          location: [
+            {
+              location: {
+                reference: `Location/${fixture.locationId}`,
+                display: fixture.summary.bed,
+              },
+            },
+          ],
         },
       },
-    },
-  ],
-};
+      {
+        resource: {
+          resourceType: 'Location',
+          id: fixture.locationId,
+          identifier: [{ system: 'https://demo.hospital/bed', type: { text: 'Cama' }, value: fixture.summary.bed }],
+        },
+      },
+    ],
+  };
+}
+
+export function getDemoAllergyBundle(patientId?: string | null) {
+  const fixture = getDemoPatientFixture(patientId);
+  return {
+    resourceType: 'Bundle',
+    type: 'searchset',
+    entry: (fixture.summary.allergies ?? []).map((allergy, index) => ({
+      resource: {
+        resourceType: 'AllergyIntolerance',
+        id: `allergy-demo-${fixture.summary.id}-${index + 1}`,
+        code: {
+          text: allergy,
+          coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', display: allergy }],
+        },
+      },
+    })),
+  };
+}
+
+export const DEMO_FHIR_PATIENT = getDemoFhirPatient();
+
+export const DEMO_FHIR_ENCOUNTER_BUNDLE = getDemoEncounterBundle();
+
+export const DEMO_FHIR_ALLERGY_BUNDLE = getDemoAllergyBundle();
 
 export const DEMO_ADMIN_DASHBOARD = buildDemoAdminDashboardSummary();
-
-export const DEMO_PATIENTS = PATIENTS_MOCK;
 
 export function ensureDemoSessionTemplate(): HandoverSession {
   return {

--- a/src/demo/mock-api.ts
+++ b/src/demo/mock-api.ts
@@ -1,4 +1,10 @@
-import { DEMO_ADMIN_DASHBOARD, DEMO_FHIR_ALLERGY_BUNDLE, DEMO_FHIR_ENCOUNTER_BUNDLE, DEMO_FHIR_PATIENT, DEMO_PATIENTS } from './fixtures';
+import {
+  DEMO_ADMIN_DASHBOARD,
+  DEMO_PATIENTS,
+  getDemoAllergyBundle,
+  getDemoEncounterBundle,
+  getDemoFhirPatient,
+} from './fixtures';
 
 // BEGIN HANDOVER: DEMO_MODE
 function normalizeUrl(input: RequestInfo | URL): string | null {
@@ -15,9 +21,30 @@ function jsonResponse(payload: unknown, status = 200): Response {
   });
 }
 
+function parseUrl(url: string): URL {
+  return new URL(url, 'https://demo.local');
+}
+
+function readDemoPatientId(parsed: URL): string | null {
+  const patientPathMatch = parsed.pathname.match(/\/Patient\/([^/?#]+)/i);
+  if (patientPathMatch?.[1]) {
+    return decodeURIComponent(patientPathMatch[1]);
+  }
+
+  const subject = parsed.searchParams.get('subject') ?? parsed.searchParams.get('patient');
+  if (!subject) return null;
+  const subjectMatch = subject.match(/Patient\/(.+)$/i);
+  if (subjectMatch?.[1]) {
+    return decodeURIComponent(subjectMatch[1]);
+  }
+  return decodeURIComponent(subject);
+}
+
 export async function buildDemoResponse(input: RequestInfo | URL, _init?: RequestInit): Promise<Response | null> {
   const url = normalizeUrl(input);
   if (!url) return null;
+  const parsed = parseUrl(url);
+  const patientId = readDemoPatientId(parsed);
 
   if (url.includes('/api/ping')) {
     return jsonResponse({ ok: true, mode: 'demo' });
@@ -58,18 +85,20 @@ export async function buildDemoResponse(input: RequestInfo | URL, _init?: Reques
     });
   }
 
-  if (/\/Patient\//i.test(url)) {
-    return jsonResponse(DEMO_FHIR_PATIENT);
+  if (/\/Patient\//i.test(parsed.pathname)) {
+    return jsonResponse(getDemoFhirPatient(patientId));
   }
-  if (url.includes('Encounter?')) {
-    return jsonResponse(DEMO_FHIR_ENCOUNTER_BUNDLE);
+  if (parsed.pathname.includes('Encounter')) {
+    return jsonResponse(getDemoEncounterBundle(patientId));
   }
-  if (url.includes('AllergyIntolerance?')) {
-    return jsonResponse(DEMO_FHIR_ALLERGY_BUNDLE);
+  if (parsed.pathname.includes('AllergyIntolerance')) {
+    return jsonResponse(getDemoAllergyBundle(patientId));
   }
 
-  if (url.includes('/patients') || url.includes('/Patient')) {
-    return jsonResponse(DEMO_PATIENTS);
+  if (parsed.pathname.includes('/patients')) {
+    const requestedUnit = parsed.searchParams.get('unit');
+    const patients = requestedUnit ? DEMO_PATIENTS.filter((patient) => patient.unitId === requestedUnit) : DEMO_PATIENTS;
+    return jsonResponse(patients);
   }
 
   return null;

--- a/src/lib/__tests__/demo-mode.spec.ts
+++ b/src/lib/__tests__/demo-mode.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { apiGet } from '@/src/lib/api';
 import { fetchWithRetry } from '@/src/lib/net';
+import { buildDemoResponse } from '@/src/demo/mock-api';
 
 // IMPORTANTE:
 // apiGet ahora llama ensureFreshAccessToken() antes de hacer requests.
@@ -28,5 +29,50 @@ describe('Demo mode network interception', () => {
   it('intercepta apiGet y devuelve datos mock', async () => {
     const data = await apiGet('/api/ping');
     expect(data).toMatchObject({ mode: 'demo' });
+  });
+
+  it('expone los tres recorridos psiquiatricos sinteticos solo en demo mode', async () => {
+    const response = await buildDemoResponse('https://demo.hospital/api/patients');
+    const body = await response?.json();
+
+    expect(body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'demo-psych-adult-001', unitId: 'sjd-a' }),
+        expect.objectContaining({ id: 'demo-psych-child-001', unitId: 'sjd-infanto' }),
+        expect.objectContaining({ id: 'demo-psych-udcc-001', unitId: 'udcc-psychogeriatrics' }),
+      ]),
+    );
+    expect(body).toHaveLength(3);
+  });
+
+  it('resuelve el detalle FHIR demo por patientId sin mezclar los casos sinteticos', async () => {
+    const patientResponse = await buildDemoResponse('https://demo.hospital/fhir/Patient/demo-psych-child-001');
+    const encounterResponse = await buildDemoResponse(
+      'https://demo.hospital/fhir/Encounter?subject=Patient/demo-psych-udcc-001&_include=Encounter:location',
+    );
+
+    const patientBody = await patientResponse?.json();
+    const encounterBody = await encounterResponse?.json();
+
+    expect(patientBody).toMatchObject({
+      id: 'demo-psych-child-001',
+      name: [expect.objectContaining({ text: 'Caso sintetico infanto' })],
+    });
+    expect(encounterBody).toMatchObject({
+      entry: [
+        expect.objectContaining({
+          resource: expect.objectContaining({
+            resourceType: 'Encounter',
+            subject: expect.objectContaining({ reference: 'Patient/demo-psych-udcc-001' }),
+          }),
+        }),
+        expect.objectContaining({
+          resource: expect.objectContaining({
+            resourceType: 'Location',
+            identifier: [expect.objectContaining({ value: 'UDCC-03' })],
+          }),
+        }),
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a synthetic SJD psychiatry demo-mode dataset for adult psychiatry, child-adolescent psychiatry and psychogeriatrics/UDCC.
- Reuses the existing demo fixtures and mock API seam.
- Keeps all data synthetic and isolated to demo mode.
- Resolves demo Patient, Encounter and AllergyIntolerance responses by patientId.
- Adds unit filtering for /api/patients in demo mode.
- Documents the supported synthetic walkthrough.

## Scope

Touched only:

- docs/sjd-psychiatry-demo-scope.md
- src/demo/fixtures.ts
- src/demo/mock-api.ts
- src/lib/__tests__/demo-mode.spec.ts

Not touched:

- backend
- production FHIR mapper
- ICEA bridge/outbox
- auth/RBAC
- audit
- sync/offline queue
- Zod/schema
- package.json
- pnpm-lock.yaml

## Validation

- git diff -- package.json pnpm-lock.yaml
- pnpm -w typecheck
- pnpm -w lint:ci
- pnpm exec vitest run src/lib/__tests__/demo-mode.spec.ts
- pnpm -w validate:fhir
- confidentiality grep over docs src .github

## Risk

Low to moderate. This changes demo-mode fixtures and mock API behavior only. It does not change production clinical contracts, backend, FHIR mapping, ICEA, auth, audit, sync or persisted schema.

## Clinical / confidentiality guardrail

All cases are synthetic. The demo must not use PHI, internal institutional documents, screenshots, local protocols or operational artifacts. HANDOVER remains a pilot/demo workflow, not production-ready clinical validation.