### PR TITLE
fix(psych): address psychiatry review followups

### DIFF
--- a/src/config/profiles/units/index.ts
+++ b/src/config/profiles/units/index.ts
@@ -317,7 +317,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     requiredExtraFields: [
       'Estado basal y cambio observado',
       'Observacion especial, acompanamiento o nivel de supervision requerido',
-      'Riesgo de caidas, movilidad segura y necesidad de deambulacion supervisada cuando aplique',
+      'Riesgo de seguridad fisica y apoyo para movilidad o traslados cuando aplique',
       'Riesgo de fuga o no retorno',
       'Entorno seguro y elementos que deban resguardarse',
       'Adherencia o rechazo terapeutico',
@@ -325,18 +325,18 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
     ],
     optionalExtraFields: [
       'Sueno e ingesta/hidratacion',
-      'Continencia, piel o ayudas funcionales cuando condicionen la continuidad del turno',
+      'Necesidades fisicas o de autocuidado que condicionen la continuidad del turno',
       'Responsable o referente de comunicacion interna y relacion terapeutica relevante',
       'Coordinacion con familia, tutor o cuidadores cuando aplique',
-      'Deterioro funcional o cognitivo-conductual cuando aplique',
+      'Cambios cognitivo-conductuales o funcionales que condicionen la continuidad del turno',
       'Dispositivos o tratamientos que el paciente pueda retirarse',
       'Evento de contencion trazable: autorizacion, revision, vigencia y reevaluacion',
     ],
     focusAreas: [
       'Observacion especial, entorno seguro y seguridad relacional',
-      'Caidas, fuga/no retorno, movilidad segura y elementos retirables que requieren continuidad',
+      'Seguridad fisica, fuga/no retorno y elementos retirables que requieren continuidad',
       'Cambio respecto al basal, adherencia terapeutica y riesgo de omision del turno siguiente',
-      'Ingesta, hidratacion, sueno, supervision funcional y coordinacion interna pendiente',
+      'Ingesta, hidratacion, sueno, acompanamiento requerido y coordinacion interna pendiente',
     ],
     explanations: [
       'Refuerza salud mental con secciones y copy del runtime ya existentes, sin abrir un formulario paralelo ni convertir QR en flujo principal.',
@@ -358,7 +358,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
         {
           id: 'psych-observation',
           type: 'other',
-          description: 'Actualizar observacion especial, acompanamiento, riesgo de caidas y siguiente reevaluacion del turno',
+          description: 'Actualizar observacion especial, acompanamiento, seguridad fisica y siguiente reevaluacion del turno',
         },
         {
           id: 'psych-adherence',
@@ -373,7 +373,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
         {
           id: 'psych-intake-sleep',
           type: 'other',
-          description: 'Registrar sueno, ingesta, hidratacion y continencia o piel cuando condicionen la continuidad',
+          description: 'Registrar sueno, ingesta, hidratacion y necesidades fisicas o de autocuidado cuando condicionen la continuidad',
         },
         {
           id: 'psych-restraint-trace',
@@ -383,7 +383,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
         {
           id: 'psych-continuity',
           type: 'other',
-          description: 'Resumir basal funcional, supervision requerida, coordinacion interna y avisos para el siguiente relevo',
+          description: 'Resumir estado basal, acompanamiento requerido, coordinacion interna y avisos para el siguiente relevo',
         },
       ],
     },
@@ -396,7 +396,7 @@ export const UNIT_PROFILE_RUNTIME_PACKS: Readonly<Record<UnitProfileId, UnitProf
       'Seguridad del entorno y resguardo de elementos retirables visibles',
       'Adherencia o rechazo terapeutico con continuidad del plan',
       'Fuga o no retorno y supervision requerida visibles',
-      'Caidas o movilidad supervisada explicitadas cuando apliquen',
+      'Seguridad fisica y apoyo para movilidad explicitados cuando apliquen',
       'Dispositivos o tratamientos retirables con trazabilidad para el relevo',
       'Observacion especial o acompanamiento explicitados',
       'Evento de contencion trazable sin instrucciones operativas',

--- a/src/lib/__tests__/profile-runtime.spec.ts
+++ b/src/lib/__tests__/profile-runtime.spec.ts
@@ -15,6 +15,33 @@ vi.mock('@/src/config/flags', () => ({
   isOn: (name: string) => isOn(name),
 }));
 
+const readBehavioralHealthPackSurfaces = (
+  runtime: Pick<
+    Awaited<ReturnType<(typeof import('../profile-runtime'))['resolveHandoverProfileRuntime']>>,
+    'requiredExtraFields' | 'optionalExtraFields' | 'focusAreas' | 'visibleOutputs' | 'treatmentQuickPicks'
+  >,
+) => [
+  ...runtime.requiredExtraFields,
+  ...runtime.optionalExtraFields,
+  ...runtime.focusAreas,
+  ...runtime.visibleOutputs,
+  ...runtime.treatmentQuickPicks.map((quickPick) => quickPick.description),
+].join(' | ');
+
+const expectNoUdccSpecificPackCopy = (
+  runtime: Pick<
+    Awaited<ReturnType<(typeof import('../profile-runtime'))['resolveHandoverProfileRuntime']>>,
+    'requiredExtraFields' | 'optionalExtraFields' | 'focusAreas' | 'visibleOutputs' | 'treatmentQuickPicks'
+  >,
+) => {
+  const surfaces = readBehavioralHealthPackSurfaces(runtime);
+
+  expect(surfaces).not.toContain('basal cognitivo-funcional');
+  expect(surfaces).not.toContain('deambulacion supervisada');
+  expect(surfaces).not.toContain('continencia');
+  expect(surfaces).not.toContain('piel');
+};
+
 describe('resolveHandoverProfileRuntime', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -292,7 +319,7 @@ describe('resolveHandoverProfileRuntime', () => {
       expect.arrayContaining([
         'Estado basal y cambio observado',
         'Observacion especial, acompanamiento o nivel de supervision requerido',
-        'Riesgo de caidas, movilidad segura y necesidad de deambulacion supervisada cuando aplique',
+        'Riesgo de seguridad fisica y apoyo para movilidad o traslados cuando aplique',
         'Riesgo de fuga o no retorno',
         'Entorno seguro y elementos que deban resguardarse',
         'Coordinacion interna pendiente y reevaluacion del siguiente turno',
@@ -315,10 +342,11 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.visibleOutputs).toContain('Seguridad del entorno y resguardo de elementos retirables visibles');
     expect(runtime.visibleOutputs).toContain('Adherencia o rechazo terapeutico con continuidad del plan');
     expect(runtime.visibleOutputs).toContain('Fuga o no retorno y supervision requerida visibles');
-    expect(runtime.visibleOutputs).toContain('Caidas o movilidad supervisada explicitadas cuando apliquen');
+    expect(runtime.visibleOutputs).toContain('Seguridad fisica y apoyo para movilidad explicitados cuando apliquen');
     expect(runtime.visibleOutputs).toContain('Dispositivos o tratamientos retirables con trazabilidad para el relevo');
     expect(runtime.visibleOutputs).toContain('Observacion especial o acompanamiento explicitados');
     expect(runtime.visibleOutputs).toContain('Evento de contencion trazable sin instrucciones operativas');
+    expectNoUdccSpecificPackCopy(runtime);
     expect(runtime.checklistItems[0]?.label).toContain('ubicacion funcional');
     expect(runtime.checklistItems[1]?.label).toContain('caidas');
     expect(runtime.checklistItems[2]?.label).toContain('elementos retirables');
@@ -349,6 +377,7 @@ describe('resolveHandoverProfileRuntime', () => {
         'Coordinacion con familia, tutor o cuidadores cuando aplique',
       ]),
     );
+    expectNoUdccSpecificPackCopy(runtime);
     expect(runtime.checklistItems[0]?.label).toBe('Paciente, ubicacion funcional y referente interno confirmados');
     expect(runtime.checklistItems[2]?.label).toContain('fuga/no retorno');
     expect(runtime.checklistItems[4]?.label).toContain('familia o tutor');
@@ -374,24 +403,25 @@ describe('resolveHandoverProfileRuntime', () => {
     expect(runtime.requiredExtraFields).toEqual(
       expect.arrayContaining([
         'Observacion especial, acompanamiento o nivel de supervision requerido',
-        'Riesgo de caidas, movilidad segura y necesidad de deambulacion supervisada cuando aplique',
+        'Riesgo de seguridad fisica y apoyo para movilidad o traslados cuando aplique',
       ]),
     );
     expect(runtime.optionalExtraFields).toEqual(
       expect.arrayContaining([
-        'Continencia, piel o ayudas funcionales cuando condicionen la continuidad del turno',
-        'Deterioro funcional o cognitivo-conductual cuando aplique',
+        'Necesidades fisicas o de autocuidado que condicionen la continuidad del turno',
+        'Cambios cognitivo-conductuales o funcionales que condicionen la continuidad del turno',
         'Dispositivos o tratamientos que el paciente pueda retirarse',
       ]),
     );
     expect(runtime.focusAreas).toEqual(
       expect.arrayContaining([
-        'Caidas, fuga/no retorno, movilidad segura y elementos retirables que requieren continuidad',
-        'Ingesta, hidratacion, sueno, supervision funcional y coordinacion interna pendiente',
+        'Seguridad fisica, fuga/no retorno y elementos retirables que requieren continuidad',
+        'Ingesta, hidratacion, sueno, acompanamiento requerido y coordinacion interna pendiente',
       ]),
     );
     expect(runtime.visibleOutputs).toContain('Coordinacion interna pendiente y referente del relevo explicitados');
-    expect(runtime.visibleOutputs).toContain('Caidas o movilidad supervisada explicitadas cuando apliquen');
+    expect(runtime.visibleOutputs).toContain('Seguridad fisica y apoyo para movilidad explicitados cuando apliquen');
+    expectNoUdccSpecificPackCopy(runtime);
     expect(runtime.checklistItems[0]?.label).toBe(
       'Paciente, ubicacion funcional, basal cognitivo-funcional y supervision requerida confirmados',
     );

--- a/tests/fhir-composition.spec.ts
+++ b/tests/fhir-composition.spec.ts
@@ -6,6 +6,8 @@ import { buildHandoverBundle } from '@/src/lib/fhir-map';
 import { FHIR_CODES, FHIR_EXTENSION_URLS } from '@/src/lib/codes';
 import { PROFILE_REGRESSION_SCENARIOS } from './fixtures/fhir/profileRegressionScenarios';
 
+type SubmissionInput = Parameters<typeof import('@/src/screens/handover/submission').buildHandoverInputPayload>[0];
+
 const originalEnv = { ...process.env };
 
 vi.mock('expo-constants', () => ({
@@ -26,6 +28,172 @@ const readNestedExtension = (extension: { extension?: Array<{ url: string; value
 
 const readFixtureBundle = (fixtureFile: string) =>
   JSON.parse(readFileSync(new URL(`./fixtures/fhir/${fixtureFile}`, import.meta.url), 'utf8'));
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const expectRecord = (value: unknown, label: string): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+};
+
+const expectString = (value: unknown, label: string): string => {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string`);
+  }
+  return value;
+};
+
+const expectBoolean = (value: unknown, label: string): boolean => {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
+};
+
+const expectNumber = (value: unknown, label: string): number => {
+  if (typeof value !== 'number') {
+    throw new Error(`${label} must be a number`);
+  }
+  return value;
+};
+
+const readOptionalString = (record: Record<string, unknown>, key: string): string | undefined => {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+};
+
+const readOptionalNumber = (record: Record<string, unknown>, key: string): number | undefined => {
+  const value = record[key];
+  return typeof value === 'number' ? value : undefined;
+};
+
+const readOptionalBoolean = (record: Record<string, unknown>, key: string): boolean | undefined => {
+  const value = record[key];
+  return typeof value === 'boolean' ? value : undefined;
+};
+
+const readStringArray = (value: unknown, label: string): string[] => {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${label} must be a string array`);
+  }
+  return value;
+};
+
+const readScenarioValues = (values: Record<string, unknown>) => {
+  const administrativeData = expectRecord(values.administrativeData, 'administrativeData');
+  const bedsideChecklist = expectRecord(values.bedsideChecklist, 'bedsideChecklist');
+  const author = isRecord(values.author) ? values.author : undefined;
+  const vitals = isRecord(values.vitals) ? values.vitals : undefined;
+  const psychosocial = isRecord(values.psychosocial) ? values.psychosocial : undefined;
+  const treatments = Array.isArray(values.treatments) ? values.treatments : undefined;
+  const outcomes = Array.isArray(values.outcomes) ? values.outcomes : undefined;
+  const pendingTasks = Array.isArray(values.pendingTasks) ? values.pendingTasks : undefined;
+
+  return {
+    patientId: expectString(values.patientId, 'patientId'),
+    encounterId: readOptionalString(values, 'encounterId'),
+    author: author
+      ? {
+          id: expectString(author.id, 'author.id'),
+          display: expectString(author.display, 'author.display'),
+        }
+      : undefined,
+    bedsideChecklist: {
+      patientIdentityConfirmed: expectBoolean(
+        bedsideChecklist.patientIdentityConfirmed,
+        'bedsideChecklist.patientIdentityConfirmed',
+      ),
+      allergiesReviewed: expectBoolean(bedsideChecklist.allergiesReviewed, 'bedsideChecklist.allergiesReviewed'),
+      linesAndDevicesChecked: expectBoolean(
+        bedsideChecklist.linesAndDevicesChecked,
+        'bedsideChecklist.linesAndDevicesChecked',
+      ),
+      medicationPlanReviewed: expectBoolean(
+        bedsideChecklist.medicationPlanReviewed,
+        'bedsideChecklist.medicationPlanReviewed',
+      ),
+      safetyMeasuresApplied: expectBoolean(
+        bedsideChecklist.safetyMeasuresApplied,
+        'bedsideChecklist.safetyMeasuresApplied',
+      ),
+      questionsAnswered: expectBoolean(bedsideChecklist.questionsAnswered, 'bedsideChecklist.questionsAnswered'),
+      bedsideNotes: readOptionalString(bedsideChecklist, 'bedsideNotes'),
+    },
+    administrativeData: {
+      unit: expectString(administrativeData.unit, 'administrativeData.unit'),
+      census: expectNumber(administrativeData.census, 'administrativeData.census'),
+      staffIn: readStringArray(administrativeData.staffIn, 'administrativeData.staffIn'),
+      staffOut: readStringArray(administrativeData.staffOut, 'administrativeData.staffOut'),
+      shiftStart: expectString(administrativeData.shiftStart, 'administrativeData.shiftStart'),
+      shiftEnd: expectString(administrativeData.shiftEnd, 'administrativeData.shiftEnd'),
+      shiftType: expectString(administrativeData.shiftType, 'administrativeData.shiftType'),
+      generalNotes: readOptionalString(administrativeData, 'generalNotes'),
+      incidents: Array.isArray(administrativeData.incidents)
+        ? readStringArray(administrativeData.incidents, 'administrativeData.incidents')
+        : undefined,
+    },
+    vitals: vitals
+      ? {
+          hr: readOptionalNumber(vitals, 'hr'),
+          rr: readOptionalNumber(vitals, 'rr'),
+          tempC: readOptionalNumber(vitals, 'tempC'),
+          spo2: readOptionalNumber(vitals, 'spo2'),
+          sbp: readOptionalNumber(vitals, 'sbp'),
+          dbp: readOptionalNumber(vitals, 'dbp'),
+          glucoseMgDl: readOptionalNumber(vitals, 'glucoseMgDl'),
+          glucoseMmolL: readOptionalNumber(vitals, 'glucoseMmolL'),
+          avpu:
+            vitals.avpu === 'A' || vitals.avpu === 'C' || vitals.avpu === 'V' || vitals.avpu === 'P' || vitals.avpu === 'U'
+              ? vitals.avpu
+              : undefined,
+          recordedAt: readOptionalString(vitals, 'recordedAt'),
+          issuedAt: readOptionalString(vitals, 'issuedAt'),
+        }
+      : undefined,
+    psychosocial: psychosocial
+      ? {
+          emotionalStatus: readOptionalString(psychosocial, 'emotionalStatus'),
+          familyVisits: readOptionalBoolean(psychosocial, 'familyVisits'),
+          familyNotes: readOptionalString(psychosocial, 'familyNotes'),
+        }
+      : undefined,
+    treatments: treatments?.map((item, index) => {
+      const treatment = expectRecord(item, `treatments[${index}]`);
+      return {
+        id: expectString(treatment.id, `treatments[${index}].id`),
+        type: expectString(treatment.type, `treatments[${index}].type`),
+        description: expectString(treatment.description, `treatments[${index}].description`),
+        scheduledAt: readOptionalString(treatment, 'scheduledAt'),
+        done: readOptionalBoolean(treatment, 'done'),
+      };
+    }),
+    outcomes: outcomes?.map((item, index) => {
+      const outcome = expectRecord(item, `outcomes[${index}]`);
+      return {
+        nocCode: expectString(outcome.nocCode, `outcomes[${index}].nocCode`),
+        nocDisplay: expectString(outcome.nocDisplay, `outcomes[${index}].nocDisplay`),
+        baseline: expectNumber(outcome.baseline, `outcomes[${index}].baseline`),
+        target: expectNumber(outcome.target, `outcomes[${index}].target`),
+        current: readOptionalNumber(outcome, 'current'),
+      };
+    }),
+    pendingTasks: pendingTasks?.map((item, index) => {
+      const task = expectRecord(item, `pendingTasks[${index}]`);
+      return {
+        id: expectString(task.id, `pendingTasks[${index}].id`),
+        category: expectString(task.category, `pendingTasks[${index}].category`),
+        title: expectString(task.title, `pendingTasks[${index}].title`),
+        status: expectString(task.status, `pendingTasks[${index}].status`),
+        priority: expectString(task.priority, `pendingTasks[${index}].priority`),
+        dueBy: readOptionalString(task, 'dueBy'),
+      };
+    }),
+    closingSummary: readOptionalString(values, 'closingSummary'),
+  } satisfies SubmissionInput;
+};
 
 async function buildScenarioBundle(
   fixtureFile: string,
@@ -65,11 +233,7 @@ async function buildScenarioBundle(
     specialtyId: scenario.specialtyId,
   });
 
-  const payload = buildHandoverInputPayload(
-    scenario.values as any,
-    {},
-    buildProfileTraceInput(runtime),
-  );
+  const payload = buildHandoverInputPayload(readScenarioValues(scenario.values), {}, buildProfileTraceInput(runtime));
 
   return {
     bundle: buildScenarioHandoverBundle(payload, { now: () => scenario.now }),
@@ -284,47 +448,44 @@ describe('FHIR Composition', () => {
     const { buildHandoverBundle: buildBehavioralHealthBundle } = await import('@/src/lib/fhir-map');
 
     const runtime = resolveHandoverProfileRuntime({ unitId: 'sjd-a', specialtyId: 'psych' });
-    const payload = buildHandoverInputPayload(
-      {
-        patientId: 'pat-psych-1',
-        encounterId: 'enc-psych-1',
-        author: { id: 'nurse-psych-1', display: 'Nurse Psych One' },
-        bedsideChecklist: {
-          patientIdentityConfirmed: true,
-          allergiesReviewed: true,
-          linesAndDevicesChecked: true,
-          medicationPlanReviewed: true,
-          safetyMeasuresApplied: true,
-          questionsAnswered: true,
+    const behavioralHealthValues = {
+      patientId: 'pat-psych-1',
+      encounterId: 'enc-psych-1',
+      author: { id: 'nurse-psych-1', display: 'Nurse Psych One' },
+      bedsideChecklist: {
+        patientIdentityConfirmed: true,
+        allergiesReviewed: true,
+        linesAndDevicesChecked: true,
+        medicationPlanReviewed: true,
+        safetyMeasuresApplied: true,
+        questionsAnswered: true,
+      },
+      administrativeData: {
+        unit: 'Psiquiatria adulto',
+        census: 14,
+        staffIn: ['Nurse In'],
+        staffOut: ['Nurse Out'],
+        shiftStart: '2025-10-20T08:00:00Z',
+        shiftEnd: '2025-10-20T16:00:00Z',
+        shiftType: 'Mañana',
+      },
+      psychosocial: {
+        emotionalStatus: 'Ansiedad contenida y colaboracion parcial',
+        familyVisits: true,
+        familyNotes: 'Acompanamiento sintetico coordinado para continuidad del relevo.',
+      },
+      pendingTasks: [
+        {
+          id: 'task-psych-1',
+          category: 'critical-task',
+          title: 'Reevaluar observacion especial y continuidad terapeutica',
+          status: 'pending',
+          priority: 'critical',
+          dueBy: '2025-10-20T16:15:00Z',
         },
-        administrativeData: {
-          unit: 'Psiquiatria adulto',
-          census: 14,
-          staffIn: ['Nurse In'],
-          staffOut: ['Nurse Out'],
-          shiftStart: '2025-10-20T08:00:00Z',
-          shiftEnd: '2025-10-20T16:00:00Z',
-          shiftType: 'Mañana',
-        },
-        psychosocial: {
-          emotionalStatus: 'Ansiedad contenida y colaboracion parcial',
-          familyVisits: true,
-          familyNotes: 'Acompanamiento sintetico coordinado para continuidad del relevo.',
-        },
-        pendingTasks: [
-          {
-            id: 'task-psych-1',
-            category: 'critical-task',
-            title: 'Reevaluar observacion especial y continuidad terapeutica',
-            status: 'pending',
-            priority: 'critical',
-            dueBy: '2025-10-20T16:15:00Z',
-          },
-        ],
-      } as any,
-      {},
-      buildProfileTraceInput(runtime),
-    );
+      ],
+    } satisfies SubmissionInput;
+    const payload = buildHandoverInputPayload(behavioralHealthValues, {}, buildProfileTraceInput(runtime));
     const bundle = buildBehavioralHealthBundle(payload, { now: () => '2025-10-20T16:05:00Z' });
 
     expect(runtime.context.unitProfileId).toBe('behavioral-health');
@@ -396,4 +557,3 @@ describe('FHIR Composition', () => {
     },
   );
 });
-


### PR DESCRIPTION
## Summary

- Addresses P2 review followups from the psychiatry demo sequence.
- Keeps UDCC-specific copy out of the shared behavioral-health runtime pack.
- Preserves UDCC-specific continuity wording only through the unit-scoped checklist path.
- Removes forced s any casting from the FHIR regression fixture and uses a typed submission input.

## Scope

Touched only:

- src/config/profiles/units/index.ts
- src/lib/__tests__/profile-runtime.spec.ts
- tests/fhir-composition.spec.ts

Not touched:

- backend
- production FHIR mapper
- ICEA bridge/outbox
- auth/RBAC
- audit
- sync/offline queue
- Zod/schema
- package.json
- pnpm-lock.yaml
- src/config/unitsConfig.ts
- docs

## Validation

- git diff -- package.json pnpm-lock.yaml
- pnpm -w typecheck
- pnpm -w lint:ci
- pnpm -w validate:fhir
- pnpm exec vitest run src/lib/__tests__/profile-runtime.spec.ts
- pnpm exec vitest run tests/fhir-composition.spec.ts
- pnpm exec vitest run src/config/__tests__/patientIdentification.spec.ts
- confidentiality grep over docs src .github

## Risk

Low to moderate.

The runtime copy cleanup is low risk. The FHIR regression fixture is now more strictly typed, which is desirable, but the test file changed more than the production code. No production FHIR mapping, backend, ICEA, schema or dependency surface was changed.