### PR TITLE
fix(icea): make bridge age calculation deterministic

### DIFF
--- a/backend/api/icea_payload_mapper.py
+++ b/backend/api/icea_payload_mapper.py
@@ -78,6 +78,16 @@ def build_icea_bridge_payload(
     admin = _admin(observations)
     effective_unit_id = (unit_id or '').strip() or admin.get('unitId') or _unit_from_bundle(bundle, resources, full_urls) or 'unknown'
     window_start, window_end, invalid_shift_window = _shift_window(composition, encounter, admin)
+    age_years = _age(
+        patient.get('birthDate') if isinstance(patient, dict) else None,
+        reference=_clinical_reference_datetime(
+            bundle=bundle,
+            composition=composition,
+            encounter=encounter,
+            window_start=window_start,
+            window_end=window_end,
+        ),
+    )
     has_shift_window = bool(window_start and window_end)
     shift = admin.get('shiftType') or _infer_shift(window_start)
     diagnoses = _diagnoses(conditions)
@@ -114,7 +124,7 @@ def build_icea_bridge_payload(
     completeness_rate = round(len(present) / len(completeness_checks), 4)
 
     missingness_inputs = {
-        'ageYears': _age(patient.get('birthDate') if isinstance(patient, dict) else None) is not None,
+        'ageYears': age_years is not None,
         'diagnoses': len(diagnoses) > 0,
         'vitals': completeness_checks['vitals'],
         'clinicalSummary': bool(closing_summary),
@@ -141,7 +151,7 @@ def build_icea_bridge_payload(
     exposure_share = round(1.0 / signature_count, 4) if signature_count > 0 else None
     observed_contextual_fields = _build_observed_contextual_fields(
         clinical_context=clinical_context,
-        case_mix={'ageYears': _age(patient.get('birthDate') if isinstance(patient, dict) else None), 'diagnoses': diagnoses, 'riskFlags': risk_flags},
+        case_mix={'ageYears': age_years, 'diagnoses': diagnoses, 'riskFlags': risk_flags},
         exposure={
             'documentedMedicationCount': sum(1 for resource in resources if resource.get('resourceType') == 'MedicationStatement'),
             'documentedProcedureCount': sum(1 for resource in resources if resource.get('resourceType') == 'Procedure'),
@@ -200,7 +210,7 @@ def build_icea_bridge_payload(
             },
         },
         'caseMix': {
-            'ageYears': _age(patient.get('birthDate') if isinstance(patient, dict) else None),
+            'ageYears': age_years,
             'sex': _safe(patient.get('gender') if isinstance(patient, dict) else None),
             'diagnoses': diagnoses,
             'riskFlags': risk_flags,
@@ -1088,15 +1098,38 @@ def _dt(value: str | None) -> datetime.datetime | None:
     return parsed.astimezone(datetime.timezone.utc)
 
 
-def _age(birth_date: str | None) -> int | None:
+def _clinical_reference_datetime(
+    *,
+    bundle: dict[str, Any],
+    composition: dict[str, Any] | None,
+    encounter: dict[str, Any] | None,
+    window_start: str | None,
+    window_end: str | None,
+) -> datetime.datetime | None:
+    for candidate in (
+        window_end,
+        window_start,
+        _safe((composition or {}).get('date')),
+        _safe(((encounter or {}).get('period') or {}).get('end')),
+        _safe(((encounter or {}).get('period') or {}).get('start')),
+        _safe((bundle.get('signature') or [{}])[0].get('when')) if isinstance(bundle.get('signature'), list) else None,
+        _safe(bundle.get('timestamp')),
+    ):
+        parsed = _dt(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _age(birth_date: str | None, *, reference: datetime.datetime | None) -> int | None:
     if not birth_date:
         return None
     parsed = _dt(f'{birth_date}T00:00:00Z')
-    if parsed is None:
+    if parsed is None or reference is None:
         return None
-    today = timezone.now().date()
-    years = today.year - parsed.date().year
-    if (today.month, today.day) < (parsed.date().month, parsed.date().day):
+    reference_date = reference.date()
+    years = reference_date.year - parsed.date().year
+    if (reference_date.month, reference_date.day) < (parsed.date().month, parsed.date().day):
         years -= 1
     return years if years >= 0 else None
 

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -272,6 +272,52 @@ class IceaBridgeMapperTests(TestCase):
             payload['contextualSignal']['case_mix_envelope']['pending_hospital_source_fields'],
         )
 
+    def test_mapper_calculates_age_from_clinical_shift_window_not_runner_clock(self):
+        with patch(
+            'backend.api.icea_payload_mapper.timezone.now',
+            return_value=datetime.datetime(2026, 5, 10, 12, 0, tzinfo=datetime.timezone.utc),
+        ):
+            payload = build_icea_bridge_payload(
+                build_bridge_bundle(),
+                request_id='req-bridge-age-window',
+                scoring_mode='immediate_provisional',
+                unit_id='icu-a',
+            )
+
+        self.assertEqual(payload['caseMix']['ageYears'], 37)
+
+    def test_mapper_calculates_age_from_encounter_period_when_shift_window_missing(self):
+        bundle = build_bridge_bundle()
+        bundle['entry'][1]['resource']['period'] = {
+            'start': '2026-03-08T06:00:00Z',
+            'end': '2026-03-08T18:00:00Z',
+        }
+        bundle['entry'][2]['resource'].pop('date', None)
+        bundle['entry'] = [
+            entry
+            for entry in bundle['entry']
+            if not (
+                entry.get('resource', {}).get('resourceType') == 'Observation'
+                and entry['resource'].get('code', {}).get('coding', [{}])[0].get('code') == 'administrative'
+            )
+        ]
+
+        with patch(
+            'backend.api.icea_payload_mapper.timezone.now',
+            return_value=datetime.datetime(2026, 5, 10, 12, 0, tzinfo=datetime.timezone.utc),
+        ):
+            payload = build_icea_bridge_payload(
+                bundle,
+                request_id='req-bridge-age-encounter',
+                scoring_mode='immediate_provisional',
+                unit_id='icu-a',
+            )
+
+        self.assertEqual(payload['context']['grain'], 'shift')
+        self.assertEqual(payload['context']['windowStart'], '2026-03-08T06:00:00Z')
+        self.assertEqual(payload['context']['windowEnd'], '2026-03-08T18:00:00Z')
+        self.assertEqual(payload['caseMix']['ageYears'], 37)
+
     def test_mapper_degrades_without_inventing_missing_fields(self):
         payload = build_icea_bridge_payload(
             build_bridge_bundle(complete=False),


### PR DESCRIPTION
Fixes ICEA bridge ageYears so case-mix age is computed from the clinical reference window instead of the runner wall-clock. Adds regression coverage. No frontend, psychiatry demo, FHIR production mapper, auth, sync, schema or dependency changes.