### PR TITLE
fix(icea): enforce HANDOVER bridge feature contract

### DIFF
--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -33,6 +33,8 @@ FEATURE_CONTRACT_VERSION = 'handover-icea-feature-v1'
 FEATURE_SOURCE_REPO = 'Luis195f/HANDOVER'
 NON_SCORING_REMOTE_STATUSES = frozenset({'contract_mismatch', 'insufficient_evidence', 'low_feature_coverage'})
 NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES = frozenset({'contract_mismatch', 'low_feature_coverage'})
+SCORE_SUMMARY_REDACTED_WARNING = 'score_summary_redacted_due_to_non_scoring_status'
+SCORE_SUMMARY_REDACTED_MARKER = {'redacted': True, 'reason': SCORE_SUMMARY_REDACTED_WARNING}
 
 
 @dataclass(frozen=True)
@@ -1171,7 +1173,7 @@ def _apply_remote_payload(
             'insufficient_evidence': normalized['insufficientEvidence'],
             'formula_version': normalized['formulaVersion'],
             'contract_version': normalized['contractVersion'],
-            'score_summary_json': normalized['scoreSummary'],
+            'score_summary_json': normalized['scoreSummaryStorage'],
             'warnings_json': normalized['warnings'],
             'remote_refs_json': normalized['remoteRefs'],
             'last_error': '',
@@ -1233,6 +1235,29 @@ def _mark_failed(
     return IceaBridgeDeliveryResult(delivered=False, status=bridge_request.status, http_status=http_status, detail=bridge_request.last_error)
 
 
+def _numeric_score_value(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _contains_numeric_score_material(value: Any) -> bool:
+    if _numeric_score_value(value):
+        return True
+    if isinstance(value, dict):
+        return any(_contains_numeric_score_material(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_numeric_score_material(item) for item in value)
+    return False
+
+
+def _remote_payload_has_redactable_score_material(payload: dict[str, Any], first_result: dict[str, Any]) -> bool:
+    if _contains_numeric_score_material(payload.get('scoreSummary')):
+        return True
+    for key in ('score', 'raw_score', 'rawScore', 'riskScore', 'value'):
+        if _numeric_score_value(payload.get(key)) or _numeric_score_value(first_result.get(key)):
+            return True
+    return False
+
+
 def _normalize_remote_payload(
     body_json: dict[str, Any] | list[Any] | None,
     *,
@@ -1257,6 +1282,7 @@ def _normalize_remote_payload(
         raw_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES
         or bool(result_statuses & NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES)
     )
+    redacted_score_material = non_scoring_status and _remote_payload_has_redactable_score_material(payload, first_result)
 
     score_summary = None
     if non_scoring_status:
@@ -1318,6 +1344,11 @@ def _normalize_remote_payload(
         warning_code = next((item for item in result_statuses if item in NON_SCORING_REMOTE_STATUSES), raw_status)
         if not any(item.get('code') == warning_code for item in warnings if isinstance(item, dict)):
             warnings.append({'code': warning_code, 'message': f'ICEA+ did not produce an individual score: {warning_code}.'})
+    if redacted_score_material and not any(item.get('code') == SCORE_SUMMARY_REDACTED_WARNING for item in warnings if isinstance(item, dict)):
+        warnings.append({
+            'code': SCORE_SUMMARY_REDACTED_WARNING,
+            'message': 'HANDOVER suppressed numeric score material returned with a non-scoring ICEA+ status.',
+        })
 
     insufficient_evidence = (
         bool(payload.get('insufficientEvidence'))
@@ -1359,6 +1390,7 @@ def _normalize_remote_payload(
         'formulaVersion': formula_version,
         'contractVersion': str(payload.get('contractVersion') or payload.get('contract_version') or bridge_request.contract_version or CONTRACT_VERSION)[:64],
         'scoreSummary': score_summary,
+        'scoreSummaryStorage': dict(SCORE_SUMMARY_REDACTED_MARKER) if redacted_score_material else score_summary,
         'warnings': warnings,
         'remoteRefs': remote_refs,
     }

--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -1176,7 +1176,7 @@ def _apply_remote_payload(
             'score_summary_json': normalized['scoreSummaryStorage'],
             'warnings_json': normalized['warnings'],
             'remote_refs_json': normalized['remoteRefs'],
-            'last_error': '',
+            'last_error': normalized['lastError'],
             'last_http_status': http_status,
             'next_retry_at': None,
             'received_at': received_at,
@@ -1191,7 +1191,7 @@ def _apply_remote_payload(
         delivered=bridge_request.status == IceaBridgeRequest.STATUS_SCORED,
         status=bridge_request.status,
         http_status=http_status,
-        detail='ok',
+        detail=normalized['detail'] or 'ok',
     )
 
 
@@ -1276,11 +1276,27 @@ def _normalize_remote_payload(
         for item in results
         if isinstance(item, dict) and str(item.get('status') or '').strip()
     }
+    ordered_result_statuses = [
+        str(item.get('status') or '').strip().lower()
+        for item in results
+        if isinstance(item, dict) and str(item.get('status') or '').strip()
+    ]
     non_scoring_status = raw_status in NON_SCORING_REMOTE_STATUSES or bool(result_statuses & NON_SCORING_REMOTE_STATUSES)
     insufficient_evidence_status = raw_status == 'insufficient_evidence' or 'insufficient_evidence' in result_statuses
     contract_failure_status = (
         raw_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES
         or bool(result_statuses & NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES)
+    )
+    contract_failure_code = ''
+    if contract_failure_status:
+        contract_failure_code = next(
+            (item for item in ordered_result_statuses if item in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES),
+            raw_status if raw_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES else '',
+        )
+    contract_failure_detail = (
+        f'ICEA+ returned non-scoring contract failure: {contract_failure_code}'
+        if contract_failure_code
+        else ''
     )
     redacted_score_material = non_scoring_status and _remote_payload_has_redactable_score_material(payload, first_result)
 
@@ -1393,6 +1409,8 @@ def _normalize_remote_payload(
         'scoreSummaryStorage': dict(SCORE_SUMMARY_REDACTED_MARKER) if redacted_score_material else score_summary,
         'warnings': warnings,
         'remoteRefs': remote_refs,
+        'lastError': contract_failure_code if status == IceaBridgeRequest.STATUS_FAILED and contract_failure_code else '',
+        'detail': contract_failure_detail if status == IceaBridgeRequest.STATUS_FAILED else '',
     }
 
 

--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -679,7 +679,7 @@ def _timestamp_value(value: Any) -> str:
 
 
 def _bridge_request_timestamp(bridge_request: IceaBridgeRequest) -> str:
-    return _timestamp_value(bridge_request.updated_at) or _timestamp_value(bridge_request.created_at) or timezone.now().isoformat()
+    return _timestamp_value(bridge_request.created_at) or _timestamp_value(bridge_request.updated_at) or timezone.now().isoformat()
 
 
 def _row_warnings_with_legacy_timestamp_fallback(warnings: list[Any], *, used_fallback: bool) -> list[Any]:

--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -679,7 +679,7 @@ def _timestamp_value(value: Any) -> str:
 
 
 def _bridge_request_timestamp(bridge_request: IceaBridgeRequest) -> str:
-    return _timestamp_value(bridge_request.created_at) or _timestamp_value(bridge_request.updated_at) or timezone.now().isoformat()
+    return _timestamp_value(bridge_request.updated_at) or _timestamp_value(bridge_request.created_at) or timezone.now().isoformat()
 
 
 def _row_warnings_with_legacy_timestamp_fallback(warnings: list[Any], *, used_fallback: bool) -> list[Any]:

--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -32,6 +32,7 @@ REMOTE_STATUS_TIMEOUT_ERROR = 'remote_status_timeout'
 FEATURE_CONTRACT_VERSION = 'handover-icea-feature-v1'
 FEATURE_SOURCE_REPO = 'Luis195f/HANDOVER'
 NON_SCORING_REMOTE_STATUSES = frozenset({'contract_mismatch', 'insufficient_evidence', 'low_feature_coverage'})
+NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES = frozenset({'contract_mismatch', 'low_feature_coverage'})
 
 
 @dataclass(frozen=True)
@@ -1200,6 +1201,11 @@ def _normalize_remote_payload(
     raw_status = str(payload.get('status') or payload.get('state') or payload.get('result') or '').strip().lower()
     result_status = str(first_result.get('status') or '').strip().lower()
     non_scoring_status = raw_status in NON_SCORING_REMOTE_STATUSES or result_status in NON_SCORING_REMOTE_STATUSES
+    insufficient_evidence_status = raw_status == 'insufficient_evidence' or result_status == 'insufficient_evidence'
+    contract_failure_status = (
+        raw_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES
+        or result_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES
+    )
 
     score_summary = None
     if non_scoring_status:
@@ -1232,9 +1238,9 @@ def _normalize_remote_payload(
         status = IceaBridgeRequest.STATUS_SCORED
     elif raw_status == 'stale':
         status = IceaBridgeRequest.STATUS_STALE
-    elif non_scoring_status:
+    elif contract_failure_status:
         status = IceaBridgeRequest.STATUS_FAILED
-    elif result_status in {'complete', 'completed', 'provisional', 'insufficient_evidence'}:
+    elif result_status in {'complete', 'completed', 'provisional'} or insufficient_evidence_status:
         status = IceaBridgeRequest.STATUS_SCORED
     elif score_summary is not None:
         status = IceaBridgeRequest.STATUS_SCORED
@@ -1265,8 +1271,7 @@ def _normalize_remote_payload(
     insufficient_evidence = (
         bool(payload.get('insufficientEvidence'))
         or bool(flags.get('insufficient_evidence'))
-        or result_status == 'insufficient_evidence'
-        or non_scoring_status
+        or insufficient_evidence_status
         or any(
             str(item.get('code') or '').strip().lower() == 'insufficient_evidence'
             for item in warnings

--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -670,6 +670,33 @@ def _build_icea_plus_score_request(bridge_request: IceaBridgeRequest, settings: 
     return _validate_icea_plus_score_request_contract(request_payload)
 
 
+def _timestamp_value(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, datetime.datetime):
+        return value.isoformat()
+    return ''
+
+
+def _bridge_request_timestamp(bridge_request: IceaBridgeRequest) -> str:
+    return _timestamp_value(bridge_request.created_at) or _timestamp_value(bridge_request.updated_at) or timezone.now().isoformat()
+
+
+def _row_warnings_with_legacy_timestamp_fallback(warnings: list[Any], *, used_fallback: bool) -> list[Any]:
+    if not used_fallback:
+        return warnings
+    for item in warnings:
+        if isinstance(item, dict) and str(item.get('code') or '').strip() == 'legacy_timestamp_fallback':
+            return warnings
+    return [
+        *warnings,
+        {
+            'code': 'legacy_timestamp_fallback',
+            'message': 'Legacy bridge payload lacked required ICEA timestamps; HANDOVER used the bridge request persistence timestamp.',
+        },
+    ]
+
+
 def _build_icea_plus_score_row(payload: dict[str, Any], *, bridge_request: IceaBridgeRequest) -> dict[str, Any]:
     identity = payload.get('identity') if isinstance(payload.get('identity'), dict) else {}
     context = payload.get('context') if isinstance(payload.get('context'), dict) else {}
@@ -701,8 +728,27 @@ def _build_icea_plus_score_row(payload: dict[str, Any], *, bridge_request: IceaB
     if isinstance(patient_key, str) and patient_key.strip().lower() == 'unknown':
         patient_key = None
 
-    clinical_timestamp = window_end or window_start or context.get('timestamp')
-    recorded_timestamp = (provenance.get('generatedAt') if isinstance(provenance, dict) else None) or context.get('timestamp')
+    bridge_persistence_timestamp = _bridge_request_timestamp(bridge_request)
+    clinical_timestamp = (
+        _timestamp_value(window_end)
+        or _timestamp_value(window_start)
+        or _timestamp_value(context.get('timestamp'))
+        or _timestamp_value(payload.get('clinicalTimestamp'))
+        or _timestamp_value(payload.get('clinical_timestamp'))
+        or _timestamp_value(payload.get('timestamp'))
+        or bridge_persistence_timestamp
+    )
+    recorded_timestamp = (
+        _timestamp_value(context.get('recordedTimestamp'))
+        or _timestamp_value(context.get('timestamp'))
+        or _timestamp_value(provenance.get('generatedAt'))
+        or bridge_persistence_timestamp
+    )
+    used_timestamp_fallback = clinical_timestamp == bridge_persistence_timestamp or recorded_timestamp == bridge_persistence_timestamp
+    row_warnings = _row_warnings_with_legacy_timestamp_fallback(
+        uncertainty.get('warnings') if isinstance(uncertainty.get('warnings'), list) else [],
+        used_fallback=used_timestamp_fallback,
+    )
     feature_values = {
         'age_years': _optional_numeric_value(case_mix.get('ageYears')),
         'diagnosis_count': float(len(diagnoses)),
@@ -745,7 +791,7 @@ def _build_icea_plus_score_row(payload: dict[str, Any], *, bridge_request: IceaB
         'recorded_timestamp': recorded_timestamp,
         'features': features,
         'missingness_flags': missingness_flags,
-        'warnings': uncertainty.get('warnings') if isinstance(uncertainty.get('warnings'), list) else [],
+        'warnings': row_warnings,
         'shadow_mode': True,
         'non_individual_use': True,
         'patient_key': patient_key,
@@ -1200,11 +1246,16 @@ def _normalize_remote_payload(
     first_result = next((item for item in results if isinstance(item, dict)), {})
     raw_status = str(payload.get('status') or payload.get('state') or payload.get('result') or '').strip().lower()
     result_status = str(first_result.get('status') or '').strip().lower()
-    non_scoring_status = raw_status in NON_SCORING_REMOTE_STATUSES or result_status in NON_SCORING_REMOTE_STATUSES
-    insufficient_evidence_status = raw_status == 'insufficient_evidence' or result_status == 'insufficient_evidence'
+    result_statuses = {
+        str(item.get('status') or '').strip().lower()
+        for item in results
+        if isinstance(item, dict) and str(item.get('status') or '').strip()
+    }
+    non_scoring_status = raw_status in NON_SCORING_REMOTE_STATUSES or bool(result_statuses & NON_SCORING_REMOTE_STATUSES)
+    insufficient_evidence_status = raw_status == 'insufficient_evidence' or 'insufficient_evidence' in result_statuses
     contract_failure_status = (
         raw_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES
-        or result_status in NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES
+        or bool(result_statuses & NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES)
     )
 
     score_summary = None
@@ -1230,7 +1281,9 @@ def _normalize_remote_payload(
         }
 
     status = IceaBridgeRequest.STATUS_SENT
-    if raw_status in {'accepted', 'queued'}:
+    if contract_failure_status:
+        status = IceaBridgeRequest.STATUS_FAILED
+    elif raw_status in {'accepted', 'queued'}:
         status = IceaBridgeRequest.STATUS_ACCEPTED
     elif raw_status in {'pending', 'running', 'processing'}:
         status = IceaBridgeRequest.STATUS_PENDING
@@ -1238,8 +1291,6 @@ def _normalize_remote_payload(
         status = IceaBridgeRequest.STATUS_SCORED
     elif raw_status == 'stale':
         status = IceaBridgeRequest.STATUS_STALE
-    elif contract_failure_status:
-        status = IceaBridgeRequest.STATUS_FAILED
     elif result_status in {'complete', 'completed', 'provisional'} or insufficient_evidence_status:
         status = IceaBridgeRequest.STATUS_SCORED
     elif score_summary is not None:
@@ -1264,7 +1315,7 @@ def _normalize_remote_payload(
     if flags.get('high_uncertainty'):
         warnings.append({'code': 'high_uncertainty', 'message': 'ICEA+ reported high uncertainty for this score.'})
     if non_scoring_status:
-        warning_code = result_status if result_status in NON_SCORING_REMOTE_STATUSES else raw_status
+        warning_code = next((item for item in result_statuses if item in NON_SCORING_REMOTE_STATUSES), raw_status)
         if not any(item.get('code') == warning_code for item in warnings if isinstance(item, dict)):
             warnings.append({'code': warning_code, 'message': f'ICEA+ did not produce an individual score: {warning_code}.'})
 

--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -29,6 +29,9 @@ from backend.api.pilot_control import is_pilot_feature_enabled
 DEFAULT_RETRYABLE_HTTP_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 STORED_BUNDLE_UNAVAILABLE_ERROR = 'stored_bundle_unavailable'
 REMOTE_STATUS_TIMEOUT_ERROR = 'remote_status_timeout'
+FEATURE_CONTRACT_VERSION = 'handover-icea-feature-v1'
+FEATURE_SOURCE_REPO = 'Luis195f/HANDOVER'
+NON_SCORING_REMOTE_STATUSES = frozenset({'contract_mismatch', 'insufficient_evidence', 'low_feature_coverage'})
 
 
 @dataclass(frozen=True)
@@ -652,13 +655,18 @@ def _build_icea_plus_score_request(bridge_request: IceaBridgeRequest, settings: 
 
     model_id = settings.model_id.strip()
     payload = bridge_request.payload_json if isinstance(bridge_request.payload_json, dict) else {}
-    context = payload.get('context') if isinstance(payload.get('context'), dict) else {}
-    return {
+    row = _build_icea_plus_score_row(payload, bridge_request=bridge_request)
+    request_payload = {
+        'contract_version': FEATURE_CONTRACT_VERSION,
+        'source_repo': FEATURE_SOURCE_REPO,
         'model_id': model_id,
-        'grain': 'window' if context.get('grain') == 'shift' else 'episode',
+        'grain': row['source_grain'],
         'from_db': False,
-        'rows': [_build_icea_plus_score_row(payload, bridge_request=bridge_request)],
+        'rows': [row],
+        'shadow_mode': True,
+        'non_individual_use': True,
     }
+    return _validate_icea_plus_score_request_contract(request_payload)
 
 
 def _build_icea_plus_score_row(payload: dict[str, Any], *, bridge_request: IceaBridgeRequest) -> dict[str, Any]:
@@ -692,44 +700,61 @@ def _build_icea_plus_score_row(payload: dict[str, Any], *, bridge_request: IceaB
     if isinstance(patient_key, str) and patient_key.strip().lower() == 'unknown':
         patient_key = None
 
-    row = {
-        'row_id': f'{grain}:{row_key}',
-        'episode_id': identity.get('episodeId') or identity.get('encounterId') or identity.get('bundleId'),
-        'patient_key': patient_key,
-        'unit_code': unit_id,
-        'unit_id': unit_id,
-        'age_years': _numeric_value(case_mix.get('ageYears')),
+    clinical_timestamp = window_end or window_start or context.get('timestamp')
+    recorded_timestamp = (provenance.get('generatedAt') if isinstance(provenance, dict) else None) or context.get('timestamp')
+    feature_values = {
+        'age_years': _optional_numeric_value(case_mix.get('ageYears')),
         'diagnosis_count': float(len(diagnoses)),
         'risk_flag_count': float(len(risk_flags)),
-        'braden': _numeric_value(baseline_scores.get('braden')),
-        'glasgow': _numeric_value(baseline_scores.get('glasgow')),
-        'pain_eva': _numeric_value(baseline_scores.get('painEva')),
-        'avpu_score': _avpu_score(baseline_scores.get('avpu')),
-        'documented_medication_count': _numeric_value(exposure.get('documentedMedicationCount')),
-        'documented_procedure_count': _numeric_value(exposure.get('documentedProcedureCount')),
-        'documented_device_use_count': _numeric_value(exposure.get('documentedDeviceUseCount')),
-        'documented_outcome_count': _numeric_value(exposure.get('documentedOutcomeCount')),
-        'documented_exam_count': _numeric_value(exposure.get('documentedExamCount')),
-        'abnormal_vital_count': _numeric_value(change_signals.get('abnormalVitalCount')),
-        'severity_weight': _numeric_value(exposure.get('severityWeight')),
-        'exposure_share': _numeric_value(exposure.get('exposureShare')),
-        'structured_completeness_rate': _numeric_value(quality.get('structuredCompletenessRate')),
-        'bedside_checklist_completion_rate': _numeric_value(quality.get('bedsideChecklistCompletionRate')),
-        'missingness_rate': _numeric_value(uncertainty.get('missingnessRate')),
-        'support_level': _numeric_value(uncertainty.get('supportLevel')),
+        'braden': _optional_numeric_value(baseline_scores.get('braden')),
+        'glasgow': _optional_numeric_value(baseline_scores.get('glasgow')),
+        'pain_eva': _optional_numeric_value(baseline_scores.get('painEva')),
+        'avpu_score': _optional_avpu_score(baseline_scores.get('avpu')),
+        'documented_medication_count': _optional_numeric_value(exposure.get('documentedMedicationCount')),
+        'documented_procedure_count': _optional_numeric_value(exposure.get('documentedProcedureCount')),
+        'documented_device_use_count': _optional_numeric_value(exposure.get('documentedDeviceUseCount')),
+        'documented_outcome_count': _optional_numeric_value(exposure.get('documentedOutcomeCount')),
+        'documented_exam_count': _optional_numeric_value(exposure.get('documentedExamCount')),
+        'abnormal_vital_count': _optional_numeric_value(change_signals.get('abnormalVitalCount')),
+        'severity_weight': _optional_numeric_value(exposure.get('severityWeight')),
+        'exposure_share': _optional_numeric_value(exposure.get('exposureShare')),
+        'structured_completeness_rate': _optional_numeric_value(quality.get('structuredCompletenessRate')),
+        'bedside_checklist_completion_rate': _optional_numeric_value(quality.get('bedsideChecklistCompletionRate')),
+        'missingness_rate': _optional_numeric_value(uncertainty.get('missingnessRate')),
+        'support_level': _optional_numeric_value(uncertainty.get('supportLevel')),
         'stale_data': 1.0 if uncertainty.get('staleData') else 0.0,
         'insufficient_evidence': 1.0 if uncertainty.get('insufficientEvidence') else 0.0,
         'closing_summary_present': 1.0 if change_signals.get('closingSummaryPresent') else 0.0,
         'sbar_present': 1.0 if change_signals.get('sbarPresent') else 0.0,
         'shift_closure_documented': 1.0 if quality.get('shiftClosureDocumented') else 0.0,
+        'documented_signature_count': _optional_numeric_value(attribution.get('signatureCount')),
+        'documented_cosigner_count': _optional_numeric_value(attribution.get('documentedCoSignerCount')),
+        'primary_actor_documented': 1.0 if attribution.get('primaryActorDocumented') else 0.0,
+    }
+    features = {key: value for key, value in feature_values.items() if value is not None}
+    missingness_flags = {key: value is None for key, value in feature_values.items()}
+    row = {
+        'contract_version': FEATURE_CONTRACT_VERSION,
+        'source_repo': FEATURE_SOURCE_REPO,
+        'source_grain': grain,
+        'row_id': f'{grain}:{row_key}',
+        'episode_id': identity.get('episodeId') or identity.get('encounterId') or identity.get('bundleId'),
+        'unit_id': unit_id,
+        'clinical_timestamp': clinical_timestamp,
+        'recorded_timestamp': recorded_timestamp,
+        'features': features,
+        'missingness_flags': missingness_flags,
+        'warnings': uncertainty.get('warnings') if isinstance(uncertainty.get('warnings'), list) else [],
+        'shadow_mode': True,
+        'non_individual_use': True,
+        'patient_key': patient_key,
+        'unit_code': unit_id,
+        **features,
         'window_start': window_start,
         'start_dt': window_start,
         'window_end': window_end,
         'end_dt': window_end,
         'shift': context.get('shift'),
-        'documented_signature_count': _numeric_value(attribution.get('signatureCount')),
-        'documented_cosigner_count': _numeric_value(attribution.get('documentedCoSignerCount')),
-        'primary_actor_documented': 1.0 if attribution.get('primaryActorDocumented') else 0.0,
         'lineage': {
             'request_id': identity.get('requestId') or bridge_request.request_id,
             'bundle_id': identity.get('bundleId') or bridge_request.bundle_id,
@@ -750,12 +775,59 @@ def _build_icea_plus_score_row(payload: dict[str, Any], *, bridge_request: IceaB
     return {key: value for key, value in row.items() if value not in (None, '', {})}
 
 
-def _numeric_value(value: Any) -> float:
+def _validate_icea_plus_score_request_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    rows = payload.get('rows')
+    if payload.get('contract_version') != FEATURE_CONTRACT_VERSION:
+        raise IceaPipelineConfigurationError('invalid_feature_contract')
+    if payload.get('source_repo') != FEATURE_SOURCE_REPO:
+        raise IceaPipelineConfigurationError('invalid_feature_source_repo')
+    if payload.get('shadow_mode') is not True or payload.get('non_individual_use') is not True:
+        raise IceaPipelineConfigurationError('invalid_feature_governance')
+    if not isinstance(rows, list) or len(rows) != 1:
+        raise IceaPipelineConfigurationError('invalid_feature_rows')
+    row = rows[0]
+    if not isinstance(row, dict):
+        raise IceaPipelineConfigurationError('invalid_feature_row')
+    for key in (
+        'contract_version',
+        'source_repo',
+        'source_grain',
+        'row_id',
+        'episode_id',
+        'unit_id',
+        'clinical_timestamp',
+        'recorded_timestamp',
+        'features',
+        'missingness_flags',
+        'warnings',
+        'shadow_mode',
+        'non_individual_use',
+    ):
+        if key not in row:
+            raise IceaPipelineConfigurationError(f'missing_feature_contract_field:{key}')
+    if row.get('contract_version') != FEATURE_CONTRACT_VERSION or row.get('source_repo') != FEATURE_SOURCE_REPO:
+        raise IceaPipelineConfigurationError('invalid_feature_row_contract')
+    if row.get('source_grain') != payload.get('grain'):
+        raise IceaPipelineConfigurationError('feature_grain_mismatch')
+    if not isinstance(row.get('features'), dict) or not isinstance(row.get('missingness_flags'), dict):
+        raise IceaPipelineConfigurationError('invalid_feature_payload')
+    if row.get('shadow_mode') is not True or row.get('non_individual_use') is not True:
+        raise IceaPipelineConfigurationError('invalid_feature_row_governance')
+    return payload
+
+
+def _optional_numeric_value(value: Any) -> float | None:
     if isinstance(value, bool):
         return 1.0 if value else 0.0
     if isinstance(value, (int, float)):
         return float(value)
-    return 0.0
+    return None
+
+
+def _optional_avpu_score(value: Any) -> float | None:
+    if not isinstance(value, str):
+        return None
+    return _avpu_score(value)
 
 
 def _avpu_score(value: Any) -> float:
@@ -1127,9 +1199,12 @@ def _normalize_remote_payload(
     first_result = next((item for item in results if isinstance(item, dict)), {})
     raw_status = str(payload.get('status') or payload.get('state') or payload.get('result') or '').strip().lower()
     result_status = str(first_result.get('status') or '').strip().lower()
+    non_scoring_status = raw_status in NON_SCORING_REMOTE_STATUSES or result_status in NON_SCORING_REMOTE_STATUSES
 
     score_summary = None
-    if isinstance(payload.get('scoreSummary'), dict):
+    if non_scoring_status:
+        score_summary = None
+    elif isinstance(payload.get('scoreSummary'), dict):
         score_summary = payload.get('scoreSummary')
     elif isinstance(payload.get('summary'), dict) and not results:
         score_summary = payload.get('summary')
@@ -1157,6 +1232,8 @@ def _normalize_remote_payload(
         status = IceaBridgeRequest.STATUS_SCORED
     elif raw_status == 'stale':
         status = IceaBridgeRequest.STATUS_STALE
+    elif non_scoring_status:
+        status = IceaBridgeRequest.STATUS_FAILED
     elif result_status in {'complete', 'completed', 'provisional', 'insufficient_evidence'}:
         status = IceaBridgeRequest.STATUS_SCORED
     elif score_summary is not None:
@@ -1180,11 +1257,16 @@ def _normalize_remote_payload(
         warnings.append({'code': 'missing_key_inputs', 'message': 'ICEA+ reported missing key inputs for scoring.'})
     if flags.get('high_uncertainty'):
         warnings.append({'code': 'high_uncertainty', 'message': 'ICEA+ reported high uncertainty for this score.'})
+    if non_scoring_status:
+        warning_code = result_status if result_status in NON_SCORING_REMOTE_STATUSES else raw_status
+        if not any(item.get('code') == warning_code for item in warnings if isinstance(item, dict)):
+            warnings.append({'code': warning_code, 'message': f'ICEA+ did not produce an individual score: {warning_code}.'})
 
     insufficient_evidence = (
         bool(payload.get('insufficientEvidence'))
         or bool(flags.get('insufficient_evidence'))
         or result_status == 'insufficient_evidence'
+        or non_scoring_status
         or any(
             str(item.get('code') or '').strip().lower() == 'insufficient_evidence'
             for item in warnings
@@ -1386,4 +1468,3 @@ def serialize_bridge_summary(bridge_request: IceaBridgeRequest) -> dict[str, Any
         'lastUpdated': bridge_request.updated_at.isoformat(),
         'source': SOURCE,
     }
-

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -16,6 +16,7 @@ from backend.api.icea_bridge_service import (
     REMOTE_STATUS_TIMEOUT_ERROR,
     STORED_BUNDLE_UNAVAILABLE_ERROR,
     _apply_remote_payload,
+    _build_icea_plus_score_request,
     _build_icea_plus_score_row,
     _mark_failed,
     _normalize_remote_payload,
@@ -43,10 +44,16 @@ HANDOVER_CONTEXT_SYSTEM = 'urn:handover-pro:context'
 HANDOVER_CONTEXT_COMPONENT_SYSTEM = 'urn:handover-pro:component'
 MODEL_ID = '11111111-1111-4111-8111-111111111111'
 FHIR_FIXTURE_DIR = Path(__file__).resolve().parents[3] / 'tests' / 'fixtures' / 'fhir'
+ICEA_CONTRACT_FIXTURE = Path(__file__).resolve().parents[3] / 'tests' / 'fixtures' / 'icea' / 'handover_icea_feature_contract_v1.json'
 
 
 def load_fhir_fixture(name: str) -> dict:
     with (FHIR_FIXTURE_DIR / name).open('r', encoding='utf-8') as handle:
+        return json.load(handle)
+
+
+def load_icea_contract_fixture() -> dict:
+    with ICEA_CONTRACT_FIXTURE.open('r', encoding='utf-8') as handle:
         return json.load(handle)
 
 
@@ -385,6 +392,26 @@ class IceaBridgeMapperTests(TestCase):
 
         row = _build_icea_plus_score_row(payload, bridge_request=bridge_request)
 
+        self.assertEqual(row['contract_version'], 'handover-icea-feature-v1')
+        self.assertEqual(row['source_repo'], 'Luis195f/HANDOVER')
+        self.assertEqual(row['source_grain'], 'window')
+        self.assertEqual(row['row_id'], 'window:enc-bridge-001')
+        self.assertEqual(row['episode_id'], 'enc-bridge-001')
+        self.assertEqual(row['unit_id'], 'icu-a')
+        self.assertEqual(row['clinical_timestamp'], '2026-03-08T15:00:00Z')
+        self.assertIn('recorded_timestamp', row)
+        self.assertEqual(row['features']['age_years'], 37.0)
+        self.assertEqual(row['features']['documented_medication_count'], 1.0)
+        self.assertFalse(row['missingness_flags']['age_years'])
+        self.assertTrue(row['missingness_flags']['glasgow'])
+        self.assertTrue(row['shadow_mode'])
+        self.assertTrue(row['non_individual_use'])
+        fixture = load_icea_contract_fixture()
+        self.assertEqual(row['contract_version'], fixture['contract_version'])
+        self.assertEqual(row['source_repo'], fixture['source_repo'])
+        self.assertEqual(row['source_grain'], fixture['source_grain'])
+        self.assertEqual(row['shadow_mode'], fixture['shadow_mode'])
+        self.assertEqual(row['non_individual_use'], fixture['non_individual_use'])
         self.assertTrue(row['lineage']['contextual_signal_present'])
         self.assertEqual(row['lineage']['contextual_contract_version'], 'handover-icea-context-v1')
         self.assertEqual(row['lineage']['contextual_signal']['profile_id'], 'critical-care')
@@ -392,6 +419,46 @@ class IceaBridgeMapperTests(TestCase):
         self.assertTrue(row['lineage']['staff_identifiers_redacted'])
         self.assertNotIn('nurse_shares', row)
         self.assertEqual(row['lineage']['contextual_signal']['case_mix_envelope']['therapeutic_load'], payload['contextualSignal']['case_mix_envelope']['therapeutic_load'])
+
+    @patch.dict(
+        os.environ,
+        {
+            'ENABLE_ICEA_BRIDGE': 'true',
+            'ENABLE_ICEA_IMMEDIATE_SCORING': 'true',
+            'ICEA_BRIDGE_MODEL_ID': MODEL_ID,
+        },
+        clear=False,
+    )
+    def test_bridge_score_request_wraps_valid_feature_contract(self):
+        payload = build_icea_bridge_payload(
+            build_bridge_bundle(),
+            request_id='req-bridge-contract-001',
+            scoring_mode='immediate_provisional',
+            unit_id='icu-a',
+        )
+        bridge_request = IceaBridgeRequest.objects.create(
+            bridge_request_id='req-bridge-contract-001:immediate_provisional',
+            request_id='req-bridge-contract-001',
+            bundle_id='bundle-bridge-001',
+            patient_id='pat-bridge-001',
+            unit_id='icu-a',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key='req-bridge-contract-001:immediate_provisional:ctx',
+            payload_hash='contract' * 8,
+            payload_json=payload,
+            status=IceaBridgeRequest.STATUS_QUEUED,
+        )
+
+        request_payload = _build_icea_plus_score_request(bridge_request, load_icea_bridge_settings())
+
+        self.assertEqual(request_payload['contract_version'], 'handover-icea-feature-v1')
+        self.assertEqual(request_payload['source_repo'], 'Luis195f/HANDOVER')
+        self.assertEqual(request_payload['grain'], 'window')
+        self.assertFalse(request_payload['from_db'])
+        self.assertTrue(request_payload['shadow_mode'])
+        self.assertTrue(request_payload['non_individual_use'])
+        self.assertEqual(request_payload['rows'][0]['contract_version'], 'handover-icea-feature-v1')
+        self.assertIsInstance(request_payload['rows'][0]['features'], dict)
 
     def test_bridge_projection_remains_backward_compatible_without_contextual_signal(self):
         payload = {
@@ -1334,6 +1401,43 @@ class IceaBridgeServiceTests(TestCase):
         )
 
         self.assertEqual(normalized['status'], IceaBridgeRequest.STATUS_STALE)
+
+    def test_normalize_remote_payload_suppresses_score_for_contract_mismatch(self):
+        bridge_request = IceaBridgeRequest.objects.create(
+            bridge_request_id='req-bridge-mismatch:immediate_provisional',
+            request_id='req-bridge-mismatch',
+            bundle_id='bundle-bridge-mismatch',
+            patient_id='pat-bridge-mismatch',
+            unit_id='icu-a',
+            episode_id='enc-bridge-mismatch',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key='req-bridge-mismatch:immediate_provisional:mismatch',
+            payload_hash='mismatch' * 8,
+            payload_json={'contractVersion': 'handover-icea-bridge-v1'},
+            status=IceaBridgeRequest.STATUS_SENT,
+        )
+
+        normalized = _normalize_remote_payload(
+            {
+                'summary': {'rows_requested': 1, 'rows_scored': 0},
+                'results': [
+                    {
+                        'row_id': 'window:bundle-bridge-mismatch',
+                        'status': 'contract_mismatch',
+                        'score': 99.0,
+                        'flags': {'contract_mismatch': True},
+                    }
+                ],
+            },
+            bridge_request=bridge_request,
+            http_status=200,
+            stale_after_seconds=60,
+        )
+
+        self.assertEqual(normalized['status'], IceaBridgeRequest.STATUS_FAILED)
+        self.assertTrue(normalized['insufficientEvidence'])
+        self.assertIsNone(normalized['scoreSummary'])
+        self.assertIn('contract_mismatch', {warning['code'] for warning in normalized['warnings']})
 
 
 class IceaBridgeApiTests(TestCase):
@@ -2313,4 +2417,3 @@ class IceaPatientRiskApiTests(TestCase):
         response = self.client.get(self.url, {'patientId': 'pat-risk-001'})
 
         self.assertEqual(response.status_code, 403)
-

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -483,10 +483,11 @@ class IceaBridgeMapperTests(TestCase):
             payload_json=payload,
             status=IceaBridgeRequest.STATUS_QUEUED,
         )
-        fallback_timestamp = datetime.datetime(2026, 3, 9, 10, 11, 12, tzinfo=datetime.timezone.utc)
+        created_timestamp = datetime.datetime(2026, 3, 9, 10, 11, 12, tzinfo=datetime.timezone.utc)
+        updated_timestamp = datetime.datetime(2026, 3, 9, 11, 12, 13, tzinfo=datetime.timezone.utc)
         IceaBridgeRequest.objects.filter(id=bridge_request.id).update(
-            created_at=fallback_timestamp,
-            updated_at=fallback_timestamp,
+            created_at=created_timestamp,
+            updated_at=updated_timestamp,
         )
         bridge_request.refresh_from_db()
 
@@ -495,8 +496,41 @@ class IceaBridgeMapperTests(TestCase):
         self.assertFalse(row['lineage']['contextual_signal_present'])
         self.assertIsNone(row['lineage']['contextual_contract_version'])
         self.assertIsNone(row['lineage']['contextual_signal'])
-        self.assertEqual(row['clinical_timestamp'], fallback_timestamp.isoformat())
-        self.assertEqual(row['recorded_timestamp'], fallback_timestamp.isoformat())
+        self.assertEqual(row['clinical_timestamp'], updated_timestamp.isoformat())
+        self.assertEqual(row['recorded_timestamp'], updated_timestamp.isoformat())
+        self.assertIn('legacy_timestamp_fallback', {warning['code'] for warning in row['warnings']})
+
+    def test_bridge_projection_legacy_timestamp_fallback_uses_created_at_without_updated_at(self):
+        payload = {
+            'contractVersion': 'handover-icea-bridge-v1',
+            'identity': {'bundleId': 'bundle-legacy-created', 'requestId': 'req-legacy-created', 'patientId': 'pat-legacy'},
+            'context': {'grain': 'episode', 'unitId': 'icu-a'},
+            'caseMix': {},
+            'nursingExposure': {},
+            'qualitySignals': {},
+            'uncertaintySignals': {},
+            'provenance': {'lineage': {'requestId': 'req-legacy-created'}},
+        }
+        created_timestamp = datetime.datetime(2026, 3, 9, 10, 11, 12, tzinfo=datetime.timezone.utc)
+        bridge_request = IceaBridgeRequest(
+            bridge_request_id='req-legacy-created:immediate_provisional',
+            request_id='req-legacy-created',
+            bundle_id='bundle-legacy-created',
+            patient_id='pat-legacy',
+            unit_id='icu-a',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key='req-legacy-created:immediate_provisional:legacy',
+            payload_hash='legacycreated' * 4,
+            payload_json=payload,
+            status=IceaBridgeRequest.STATUS_QUEUED,
+        )
+        bridge_request.created_at = created_timestamp
+        bridge_request.updated_at = None
+
+        row = _build_icea_plus_score_row(payload, bridge_request=bridge_request)
+
+        self.assertEqual(row['clinical_timestamp'], created_timestamp.isoformat())
+        self.assertEqual(row['recorded_timestamp'], created_timestamp.isoformat())
         self.assertIn('legacy_timestamp_fallback', {warning['code'] for warning in row['warnings']})
 
     def test_contextual_contract_regression_fixtures_cover_uci_ward_ed_and_oncology(self):

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -1573,6 +1573,8 @@ class IceaBridgeServiceTests(TestCase):
 
         self.assertEqual(result.status, IceaBridgeRequest.STATUS_SCORED)
         self.assertEqual(bridge_request.status, IceaBridgeRequest.STATUS_SCORED)
+        self.assertEqual(result.detail, 'ok')
+        self.assertEqual(bridge_request.last_error, '')
         self.assertTrue(bridge_request.insufficient_evidence)
         self.assertEqual(
             bridge_request.score_summary_json,
@@ -1707,6 +1709,13 @@ class IceaBridgeServiceTests(TestCase):
 
                 self.assertEqual(result.status, expected_status)
                 self.assertEqual(bridge_request.status, expected_status)
+                if expected_status == IceaBridgeRequest.STATUS_FAILED:
+                    self.assertEqual(bridge_request.last_error, remote_status)
+                    self.assertIn(f'non-scoring contract failure: {remote_status}', result.detail)
+                    self.assertNotEqual(result.detail, 'ok')
+                else:
+                    self.assertEqual(bridge_request.last_error, '')
+                    self.assertEqual(result.detail, 'ok')
                 self.assertEqual(
                     bridge_request.score_summary_json,
                     {'redacted': True, 'reason': 'score_summary_redacted_due_to_non_scoring_status'},
@@ -1725,7 +1734,7 @@ class IceaBridgeServiceTests(TestCase):
     def test_apply_remote_payload_keeps_redacted_false_for_non_scoring_without_numeric_score_material(self):
         bridge_request = self._create_bridge_request_for_remote_payload('non-scoring-no-score')
 
-        _apply_remote_payload(
+        result = _apply_remote_payload(
             bridge_request,
             {
                 'status': 'completed',
@@ -1742,6 +1751,9 @@ class IceaBridgeServiceTests(TestCase):
         bridge_request.refresh_from_db()
         serialized = serialize_bridge_request(bridge_request)
 
+        self.assertEqual(result.status, IceaBridgeRequest.STATUS_FAILED)
+        self.assertEqual(result.detail, 'ICEA+ returned non-scoring contract failure: contract_mismatch')
+        self.assertEqual(bridge_request.last_error, 'contract_mismatch')
         self.assertIsNone(bridge_request.score_summary_json)
         self.assertIsNone(serialized['scoreSummary'])
         self.assertFalse(serialized['scoreSummaryRedacted'])

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -621,6 +621,21 @@ class IceaBridgeServiceTests(TestCase):
             expires_at=HandoverBundleRecord.default_expiry(),
         )
 
+    def _create_bridge_request_for_remote_payload(self, suffix: str) -> IceaBridgeRequest:
+        return IceaBridgeRequest.objects.create(
+            bridge_request_id=f'req-bridge-{suffix}:immediate_provisional',
+            request_id=f'req-bridge-{suffix}',
+            bundle_id=f'bundle-bridge-{suffix}',
+            patient_id=f'pat-bridge-{suffix}',
+            unit_id='icu-a',
+            episode_id=f'enc-bridge-{suffix}',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key=f'req-bridge-{suffix}:immediate_provisional:remote',
+            payload_hash=(suffix.replace('_', '') * 8)[:64],
+            payload_json={'contractVersion': 'handover-icea-bridge-v1'},
+            status=IceaBridgeRequest.STATUS_SENT,
+        )
+
     @patch.dict(
         os.environ,
         {
@@ -1559,8 +1574,18 @@ class IceaBridgeServiceTests(TestCase):
         self.assertEqual(result.status, IceaBridgeRequest.STATUS_SCORED)
         self.assertEqual(bridge_request.status, IceaBridgeRequest.STATUS_SCORED)
         self.assertTrue(bridge_request.insufficient_evidence)
-        self.assertIsNone(bridge_request.score_summary_json)
+        self.assertEqual(
+            bridge_request.score_summary_json,
+            {'redacted': True, 'reason': 'score_summary_redacted_due_to_non_scoring_status'},
+        )
+        serialized = serialize_bridge_request(bridge_request)
+        self.assertIsNone(serialized['scoreSummary'])
+        self.assertTrue(serialized['scoreSummaryRedacted'])
         self.assertIn('insufficient_evidence', {warning['code'] for warning in bridge_request.warnings_json})
+        self.assertIn(
+            'score_summary_redacted_due_to_non_scoring_status',
+            {warning['code'] for warning in bridge_request.warnings_json},
+        )
 
     def test_normalize_remote_payload_does_not_mark_insufficient_evidence_for_low_feature_coverage(self):
         bridge_request = IceaBridgeRequest.objects.create(
@@ -1636,6 +1661,94 @@ class IceaBridgeServiceTests(TestCase):
                 self.assertFalse(normalized['insufficientEvidence'])
                 self.assertIsNone(normalized['scoreSummary'])
                 self.assertIn(remote_status, {warning['code'] for warning in normalized['warnings']})
+
+    def test_apply_remote_payload_redacts_numeric_score_material_for_non_scoring_statuses(self):
+        scenarios = [
+            (
+                'contract_mismatch',
+                {'status': 'contract_mismatch'},
+                {'scoreSummary': {'score': 99.0}},
+                IceaBridgeRequest.STATUS_FAILED,
+            ),
+            (
+                'low_feature_coverage',
+                {'status': 'low_feature_coverage', 'score': 41.0},
+                {},
+                IceaBridgeRequest.STATUS_FAILED,
+            ),
+            (
+                'insufficient_evidence',
+                {'status': 'insufficient_evidence', 'raw_score': 0.52},
+                {},
+                IceaBridgeRequest.STATUS_SCORED,
+            ),
+        ]
+
+        for remote_status, result_payload, root_payload, expected_status in scenarios:
+            with self.subTest(remote_status=remote_status):
+                bridge_request = self._create_bridge_request_for_remote_payload(f'redacted-{remote_status}')
+
+                result = _apply_remote_payload(
+                    bridge_request,
+                    {
+                        **root_payload,
+                        'summary': {'rows_requested': 1, 'rows_scored': 0},
+                        'results': [
+                            {
+                                'row_id': f'window:bundle-bridge-redacted-{remote_status}',
+                                **result_payload,
+                            }
+                        ],
+                    },
+                    200,
+                )
+                bridge_request.refresh_from_db()
+                serialized = serialize_bridge_request(bridge_request)
+
+                self.assertEqual(result.status, expected_status)
+                self.assertEqual(bridge_request.status, expected_status)
+                self.assertEqual(
+                    bridge_request.score_summary_json,
+                    {'redacted': True, 'reason': 'score_summary_redacted_due_to_non_scoring_status'},
+                )
+                self.assertIsNone(serialized['scoreSummary'])
+                self.assertTrue(serialized['scoreSummaryRedacted'])
+                self.assertNotIn('score', json.dumps(serialized['scoreSummary']))
+                self.assertNotIn('99.0', json.dumps(serialized))
+                self.assertNotIn('41.0', json.dumps(serialized))
+                self.assertNotIn('0.52', json.dumps(serialized))
+                self.assertIn(
+                    'score_summary_redacted_due_to_non_scoring_status',
+                    {warning['code'] for warning in bridge_request.warnings_json},
+                )
+
+    def test_apply_remote_payload_keeps_redacted_false_for_non_scoring_without_numeric_score_material(self):
+        bridge_request = self._create_bridge_request_for_remote_payload('non-scoring-no-score')
+
+        _apply_remote_payload(
+            bridge_request,
+            {
+                'status': 'completed',
+                'summary': {'rows_requested': 1, 'rows_scored': 0},
+                'results': [
+                    {
+                        'row_id': 'window:bundle-bridge-non-scoring-no-score',
+                        'status': 'contract_mismatch',
+                    }
+                ],
+            },
+            200,
+        )
+        bridge_request.refresh_from_db()
+        serialized = serialize_bridge_request(bridge_request)
+
+        self.assertIsNone(bridge_request.score_summary_json)
+        self.assertIsNone(serialized['scoreSummary'])
+        self.assertFalse(serialized['scoreSummaryRedacted'])
+        self.assertNotIn(
+            'score_summary_redacted_due_to_non_scoring_status',
+            {warning['code'] for warning in bridge_request.warnings_json},
+        )
 
 
 class IceaBridgeApiTests(TestCase):

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -483,12 +483,21 @@ class IceaBridgeMapperTests(TestCase):
             payload_json=payload,
             status=IceaBridgeRequest.STATUS_QUEUED,
         )
+        fallback_timestamp = datetime.datetime(2026, 3, 9, 10, 11, 12, tzinfo=datetime.timezone.utc)
+        IceaBridgeRequest.objects.filter(id=bridge_request.id).update(
+            created_at=fallback_timestamp,
+            updated_at=fallback_timestamp,
+        )
+        bridge_request.refresh_from_db()
 
         row = _build_icea_plus_score_row(payload, bridge_request=bridge_request)
 
         self.assertFalse(row['lineage']['contextual_signal_present'])
         self.assertIsNone(row['lineage']['contextual_contract_version'])
         self.assertIsNone(row['lineage']['contextual_signal'])
+        self.assertEqual(row['clinical_timestamp'], fallback_timestamp.isoformat())
+        self.assertEqual(row['recorded_timestamp'], fallback_timestamp.isoformat())
+        self.assertIn('legacy_timestamp_fallback', {warning['code'] for warning in row['warnings']})
 
     def test_contextual_contract_regression_fixtures_cover_uci_ward_ed_and_oncology(self):
         scenarios = [
@@ -1511,6 +1520,45 @@ class IceaBridgeServiceTests(TestCase):
         self.assertFalse(normalized['insufficientEvidence'])
         self.assertIsNone(normalized['scoreSummary'])
         self.assertIn('low_feature_coverage', {warning['code'] for warning in normalized['warnings']})
+
+    def test_normalize_remote_payload_completed_status_does_not_override_contract_failures(self):
+        for remote_status in ('contract_mismatch', 'low_feature_coverage'):
+            with self.subTest(remote_status=remote_status):
+                bridge_request = IceaBridgeRequest.objects.create(
+                    bridge_request_id=f'req-bridge-completed-{remote_status}:immediate_provisional',
+                    request_id=f'req-bridge-completed-{remote_status}',
+                    bundle_id=f'bundle-bridge-completed-{remote_status}',
+                    patient_id=f'pat-bridge-completed-{remote_status}',
+                    unit_id='icu-a',
+                    episode_id=f'enc-bridge-completed-{remote_status}',
+                    scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+                    idempotency_key=f'req-bridge-completed-{remote_status}:immediate_provisional:contract',
+                    payload_hash=(remote_status.replace('_', '') * 4)[:32],
+                    payload_json={'contractVersion': 'handover-icea-bridge-v1'},
+                    status=IceaBridgeRequest.STATUS_SENT,
+                )
+
+                normalized = _normalize_remote_payload(
+                    {
+                        'status': 'completed',
+                        'summary': {'rows_requested': 1, 'rows_scored': 0},
+                        'results': [
+                            {
+                                'row_id': f'window:bundle-bridge-completed-{remote_status}',
+                                'status': remote_status,
+                                'score': 99.0,
+                            }
+                        ],
+                    },
+                    bridge_request=bridge_request,
+                    http_status=200,
+                    stale_after_seconds=60,
+                )
+
+                self.assertEqual(normalized['status'], IceaBridgeRequest.STATUS_FAILED)
+                self.assertFalse(normalized['insufficientEvidence'])
+                self.assertIsNone(normalized['scoreSummary'])
+                self.assertIn(remote_status, {warning['code'] for warning in normalized['warnings']})
 
 
 class IceaBridgeApiTests(TestCase):

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -1435,9 +1435,82 @@ class IceaBridgeServiceTests(TestCase):
         )
 
         self.assertEqual(normalized['status'], IceaBridgeRequest.STATUS_FAILED)
-        self.assertTrue(normalized['insufficientEvidence'])
+        self.assertFalse(normalized['insufficientEvidence'])
         self.assertIsNone(normalized['scoreSummary'])
         self.assertIn('contract_mismatch', {warning['code'] for warning in normalized['warnings']})
+
+    def test_apply_remote_payload_keeps_insufficient_evidence_out_of_failed_status(self):
+        bridge_request = IceaBridgeRequest.objects.create(
+            bridge_request_id='req-bridge-insufficient:immediate_provisional',
+            request_id='req-bridge-insufficient',
+            bundle_id='bundle-bridge-insufficient',
+            patient_id='pat-bridge-insufficient',
+            unit_id='icu-a',
+            episode_id='enc-bridge-insufficient',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key='req-bridge-insufficient:immediate_provisional:insufficient',
+            payload_hash='insufficient' * 5 + 'abcd',
+            payload_json={'contractVersion': 'handover-icea-bridge-v1'},
+            status=IceaBridgeRequest.STATUS_SENT,
+        )
+
+        result = _apply_remote_payload(
+            bridge_request,
+            {
+                'summary': {'rows_requested': 1, 'rows_scored': 0},
+                'results': [
+                    {
+                        'row_id': 'window:bundle-bridge-insufficient',
+                        'status': 'insufficient_evidence',
+                        'score': 52.0,
+                    }
+                ],
+            },
+            200,
+        )
+        bridge_request.refresh_from_db()
+
+        self.assertEqual(result.status, IceaBridgeRequest.STATUS_SCORED)
+        self.assertEqual(bridge_request.status, IceaBridgeRequest.STATUS_SCORED)
+        self.assertTrue(bridge_request.insufficient_evidence)
+        self.assertIsNone(bridge_request.score_summary_json)
+        self.assertIn('insufficient_evidence', {warning['code'] for warning in bridge_request.warnings_json})
+
+    def test_normalize_remote_payload_does_not_mark_insufficient_evidence_for_low_feature_coverage(self):
+        bridge_request = IceaBridgeRequest.objects.create(
+            bridge_request_id='req-bridge-coverage:immediate_provisional',
+            request_id='req-bridge-coverage',
+            bundle_id='bundle-bridge-coverage',
+            patient_id='pat-bridge-coverage',
+            unit_id='icu-a',
+            episode_id='enc-bridge-coverage',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key='req-bridge-coverage:immediate_provisional:coverage',
+            payload_hash='coverage' * 8,
+            payload_json={'contractVersion': 'handover-icea-bridge-v1'},
+            status=IceaBridgeRequest.STATUS_SENT,
+        )
+
+        normalized = _normalize_remote_payload(
+            {
+                'summary': {'rows_requested': 1, 'rows_scored': 0},
+                'results': [
+                    {
+                        'row_id': 'window:bundle-bridge-coverage',
+                        'status': 'low_feature_coverage',
+                        'score': 41.0,
+                    }
+                ],
+            },
+            bridge_request=bridge_request,
+            http_status=200,
+            stale_after_seconds=60,
+        )
+
+        self.assertEqual(normalized['status'], IceaBridgeRequest.STATUS_FAILED)
+        self.assertFalse(normalized['insufficientEvidence'])
+        self.assertIsNone(normalized['scoreSummary'])
+        self.assertIn('low_feature_coverage', {warning['code'] for warning in normalized['warnings']})
 
 
 class IceaBridgeApiTests(TestCase):
@@ -2149,6 +2222,31 @@ class IceaPatientRiskApiTests(TestCase):
         summary = response.json()['results'][0]
         self.assertTrue(summary['stale'])
         self.assertIn('desactualizado', summary['message'].lower())
+
+    @patch.dict(
+        os.environ,
+        {
+            'ENABLE_ICEA_BRIDGE': 'true',
+            'ENABLE_ICEA_PATIENT_RISK': 'true',
+        },
+        clear=False,
+    )
+    def test_patient_risk_surfaces_insufficient_evidence_without_failed_status(self):
+        self._auth(roles=['nurse'], unit_ids=['icu-a'])
+        IceaBridgeRequest.objects.filter(id=self.bridge_request.id).update(
+            status=IceaBridgeRequest.STATUS_SCORED,
+            provisional=False,
+            insufficient_evidence=True,
+            score_summary_json=None,
+            warnings_json=[{'code': 'insufficient_evidence', 'message': 'Not enough data'}],
+        )
+
+        response = self.client.get(self.url, {'patientId': 'pat-risk-001'})
+
+        self.assertEqual(response.status_code, 200)
+        summary = response.json()['results'][0]
+        self.assertEqual(summary['clinicalStatus'], 'insufficient_evidence')
+        self.assertIn('evidencia insuficiente', summary['message'].lower())
 
     @patch.dict(
         os.environ,

--- a/backend/api/tests/test_icea_bridge.py
+++ b/backend/api/tests/test_icea_bridge.py
@@ -496,6 +496,49 @@ class IceaBridgeMapperTests(TestCase):
         self.assertFalse(row['lineage']['contextual_signal_present'])
         self.assertIsNone(row['lineage']['contextual_contract_version'])
         self.assertIsNone(row['lineage']['contextual_signal'])
+        self.assertEqual(row['clinical_timestamp'], created_timestamp.isoformat())
+        self.assertEqual(row['recorded_timestamp'], created_timestamp.isoformat())
+        self.assertIn('legacy_timestamp_fallback', {warning['code'] for warning in row['warnings']})
+
+        IceaBridgeRequest.objects.filter(id=bridge_request.id).update(
+            updated_at=datetime.datetime(2026, 3, 9, 12, 13, 14, tzinfo=datetime.timezone.utc),
+        )
+        bridge_request.refresh_from_db()
+        retry_row = _build_icea_plus_score_row(payload, bridge_request=bridge_request)
+
+        self.assertEqual(retry_row['clinical_timestamp'], row['clinical_timestamp'])
+        self.assertEqual(retry_row['recorded_timestamp'], row['recorded_timestamp'])
+        self.assertIn('legacy_timestamp_fallback', {warning['code'] for warning in retry_row['warnings']})
+
+    def test_bridge_projection_legacy_timestamp_fallback_uses_updated_at_without_created_at(self):
+        payload = {
+            'contractVersion': 'handover-icea-bridge-v1',
+            'identity': {'bundleId': 'bundle-legacy-updated', 'requestId': 'req-legacy-updated', 'patientId': 'pat-legacy'},
+            'context': {'grain': 'episode', 'unitId': 'icu-a'},
+            'caseMix': {},
+            'nursingExposure': {},
+            'qualitySignals': {},
+            'uncertaintySignals': {},
+            'provenance': {'lineage': {'requestId': 'req-legacy-updated'}},
+        }
+        updated_timestamp = datetime.datetime(2026, 3, 9, 11, 12, 13, tzinfo=datetime.timezone.utc)
+        bridge_request = IceaBridgeRequest(
+            bridge_request_id='req-legacy-updated:immediate_provisional',
+            request_id='req-legacy-updated',
+            bundle_id='bundle-legacy-updated',
+            patient_id='pat-legacy',
+            unit_id='icu-a',
+            scoring_mode=IceaBridgeRequest.SCORING_MODE_IMMEDIATE,
+            idempotency_key='req-legacy-updated:immediate_provisional:legacy',
+            payload_hash='legacyupdated' * 4,
+            payload_json=payload,
+            status=IceaBridgeRequest.STATUS_QUEUED,
+        )
+        bridge_request.created_at = None
+        bridge_request.updated_at = updated_timestamp
+
+        row = _build_icea_plus_score_row(payload, bridge_request=bridge_request)
+
         self.assertEqual(row['clinical_timestamp'], updated_timestamp.isoformat())
         self.assertEqual(row['recorded_timestamp'], updated_timestamp.isoformat())
         self.assertIn('legacy_timestamp_fallback', {warning['code'] for warning in row['warnings']})

--- a/docs/icea-bridge.md
+++ b/docs/icea-bridge.md
@@ -26,69 +26,51 @@ Principios aplicados:
 
 ## Payload analitico v1
 
-Contrato actual (`contractVersion=handover-icea-bridge-v1`):
+HANDOVER mantiene internamente el payload puente `contractVersion=handover-icea-bridge-v1`, construido desde el Bundle FHIR y persistido en `IceaBridgeRequest.payload_json`. Al enviar a ICEA+, el runtime no publica ese payload crudo: proyecta una solicitud de feature contract versionada `handover-icea-feature-v1`.
+
+Sobre POST real a ICEA+:
 
 ```json
 {
-  "contractVersion": "handover-icea-bridge-v1",
-  "source": "HANDOVER",
-  "scoringMode": "immediate_provisional",
-  "provisional": true,
-  "identity": {
-    "handoverId": "bundle-bridge-001",
-    "bundleId": "bundle-bridge-001",
-    "requestId": "req-bridge-001",
-    "patientId": "pat-bridge-001",
-    "episodeId": "enc-bridge-001",
-    "encounterId": "enc-bridge-001",
-    "compositionId": "comp-bridge-001"
-  },
-  "context": {
-    "grain": "shift",
-    "timestamp": "2026-03-08T07:10:00Z",
-    "windowStart": "2026-03-08T07:00:00Z",
-    "windowEnd": "2026-03-08T15:00:00Z",
-    "unitId": "icu-a",
-    "teamId": null,
-    "primaryActorDocumented": true,
-    "documentedAuthorPresent": true,
-    "documentedCoSignerCount": 0,
-    "documentedActorCount": 1,
-    "shift": "Manana"
-  },
-  "caseMix": {},
-  "nursingExposure": {},
-  "qualitySignals": {},
-  "uncertaintySignals": {},
-  "provenance": {},
-  "governance": {
-    "displayPolicy": "shadow_aggregated_no_individual_score",
-    "staffIdentifiersRedacted": true,
-    "individualScoreVisible": false,
-    "causalSummaryVisible": false
-  },
-  "contextualSignal": {
-    "contract_version": "handover-icea-context-v1",
-    "profile_id": "critical-care",
-    "overlay_ids": ["neuro"],
-    "case_mix_envelope": {
-      "baseline_complexity": 0.58,
-      "surveillance_intensity": 0.47,
-      "therapeutic_load": 0.31,
-      "temporal_criticality": 0.44,
-      "continuity_risk": 0.29,
-      "dependency_load": 0.34,
-      "coordination_complexity": 0.39,
-      "explainability_summary": "Deterministic stratification only; not causal attribution.",
-      "observed_fields": {},
-      "derived_fields": {},
-      "pending_hospital_source_fields": []
-    }
-  }
+  "contract_version": "handover-icea-feature-v1",
+  "source_repo": "Luis195f/HANDOVER",
+  "model_id": "11111111-1111-4111-8111-111111111111",
+  "grain": "window",
+  "from_db": false,
+  "rows": [],
+  "shadow_mode": true,
+  "non_individual_use": true
 }
 ```
 
-Familias de campos implementadas:
+Campos obligatorios del sobre:
+- `contract_version`: version del contrato de features enviado a ICEA+; actualmente `handover-icea-feature-v1`.
+- `source_repo`: repo emisor del contrato; actualmente `Luis195f/HANDOVER`.
+- `model_id`: UUID configurado en `ICEA_BRIDGE_MODEL_ID`.
+- `grain`: debe coincidir con `rows[0].source_grain`.
+- `from_db`: siempre `false` en este bridge; HANDOVER envia una proyeccion desde el handover persistido, no una consulta directa a una base ICEA.
+- `rows`: lista de una fila proyectada desde el payload HANDOVER.
+- `shadow_mode`: obligatorio `true`.
+- `non_individual_use`: obligatorio `true`.
+
+Estructura obligatoria de cada `row`:
+- `contract_version`: debe coincidir con el feature contract del sobre.
+- `source_repo`: debe coincidir con el repo emisor del sobre.
+- `source_grain`: `window` para handovers con ventana de turno, `episode` cuando no hay ventana de turno usable.
+- `row_id`: identificador tecnico estable de la fila, formado como `<source_grain>:<episode|encounter|bundle|bridge_request>`.
+- `episode_id`: episodio, encounter o bundle usado como ancla clinica de la fila.
+- `unit_id`: unidad de cuidado resuelta por HANDOVER.
+- `clinical_timestamp`: timestamp clinico de referencia para la fila.
+- `recorded_timestamp`: timestamp de registro/proyeccion de la fila.
+- `features`: diccionario numerico con las features disponibles.
+- `missingness_flags`: diccionario paralelo que marca features ausentes.
+- `warnings`: advertencias trazables, sin PHI libre.
+- `shadow_mode`: obligatorio `true`.
+- `non_individual_use`: obligatorio `true`.
+
+La fila puede incluir campos aditivos compatibles, como `patient_key`, `unit_code`, `window_start`, `window_end`, `start_dt`, `end_dt`, `shift`, features numericas aplanadas y `lineage`. El envelope contextual `handover-icea-context-v1` viaja dentro de `row.lineage.contextual_signal`; no sustituye el contrato de features ni habilita uso individual.
+
+Familias de datos de origen usadas para construir `features` y `lineage`:
 - `identity`: bundle, request, paciente, episodio y composicion.
 - `context`: grano (`handover`, `episode`, `shift`), ventana temporal, unidad, presencia/conteo de actores documentados y carga resumida del cambio de turno, sin IDs nominales de profesional.
 - `caseMix`: edad, sexo, diagnosticos estructurados, risk flags y escalas basales si existen en el Bundle.
@@ -130,8 +112,22 @@ La entrega analitica actual del bridge se alinea con el repo ICEA+ verificado en
 - no se ha encontrado un endpoint real de status de score en ese upstream, por lo que HANDOVER no inventa polling remoto;
 - si ICEA+ responde con aliases de contrato (`status`/`state`/`result`, `formulaVersion`/`formula_version`, `warnings`/`issues`), HANDOVER los normaliza sin renombrar el contrato publico del bridge;
 - la fila enviada a ICEA+ mantiene las features numericas actuales y agrega el envelope contextual dentro de `rows[].lineage.contextual_signal` para trazabilidad y capas analiticas posteriores;
+- `clinical_timestamp` prefiere `context.windowEnd`, `context.windowStart`, `context.timestamp` y timestamps clinicos del payload si existen; `recorded_timestamp` prefiere `context.recordedTimestamp` y `context.timestamp`;
+- payloads legacy que no traen timestamps requeridos se proyectan con un fallback conservador y estable desde `IceaBridgeRequest.created_at`, luego `updated_at` solo si falta `created_at`, para preservar idempotencia entre reintentos con el mismo payload hash e Idempotency-Key;
+- cuando HANDOVER usa ese fallback de timestamp, agrega warning `legacy_timestamp_fallback`;
 - GET /api/icea/bridge/status/<handoverId>?refresh=true solo intenta refresco remoto si ICEA_BRIDGE_STATUS_PATH esta configurado explicitamente;
 - cuando no existe ese path, HANDOVER responde `remoteStatusSupported=false`, `remoteRefreshAttempted=false` y `localStatusIsAuthoritative=true` con estado local visible.
+
+## Respuestas no-scoring
+
+HANDOVER trata estos estados remotos como resultados sin score individual procesable:
+- `contract_mismatch`: ICEA+ no pudo procesar la fila porque el contrato o la configuracion esperada no coinciden. HANDOVER lo persiste como fallo del bridge/contrato y conserva warnings trazables.
+- `low_feature_coverage`: ICEA+ rechazo o no puntuo por cobertura insuficiente del contrato de features. HANDOVER lo persiste como fallo del bridge/cobertura y conserva warnings trazables.
+- `insufficient_evidence`: ICEA+ produjo un resultado analitico valido sin score concluyente por evidencia insuficiente. HANDOVER no lo clasifica como fallo tecnico; lo marca como `insufficientEvidence=true`.
+
+Para los tres estados, HANDOVER suprime `scoreSummary` aunque la respuesta remota incluya campos numericos. En respuestas publicas del bridge y resumenes derivados, `scoreSummary` permanece `null`; `scoreSummaryRedacted=true` solo indica que existio material interno suprimido, no visibilidad clinica de un score individual.
+
+`contract_mismatch` y `low_feature_coverage` no se convierten en `insufficientEvidence` salvo que ICEA+ lo indique de forma explicita mediante `insufficientEvidence`, flags o warnings de `insufficient_evidence`.
 
 ## Scoring inmediato vs enriquecido
 
@@ -267,4 +263,3 @@ No debe usarse jamas como evaluacion individual:
 - El modo `enriched_followup` requiere disponibilidad de datos posteriores; HANDOVER no los inventa.
 - La vista admin actual expone resumen del bridge, no un dashboard analitico completo.
 - Sigue existiendo una advertencia heredada no relacionada en `backend/api/views.py` por `datetime.utcnow()` usada en auditoria existente.
-

--- a/docs/icea-bridge.md
+++ b/docs/icea-bridge.md
@@ -37,7 +37,38 @@ Sobre POST real a ICEA+:
   "model_id": "11111111-1111-4111-8111-111111111111",
   "grain": "window",
   "from_db": false,
-  "rows": [],
+  "rows": [
+    {
+      "contract_version": "handover-icea-feature-v1",
+      "source_repo": "Luis195f/HANDOVER",
+      "source_grain": "window",
+      "row_id": "window:enc-bridge-001",
+      "episode_id": "enc-bridge-001",
+      "unit_id": "icu-a",
+      "clinical_timestamp": "2026-03-08T15:00:00Z",
+      "recorded_timestamp": "2026-03-08T15:03:00Z",
+      "features": {
+        "age_years": 37.0,
+        "documented_medication_count": 1.0,
+        "documented_procedure_count": 1.0,
+        "structured_completeness_rate": 0.82,
+        "missingness_rate": 0.18,
+        "shift_closure_documented": 1.0
+      },
+      "missingness_flags": {
+        "age_years": false,
+        "documented_medication_count": false,
+        "documented_procedure_count": false,
+        "structured_completeness_rate": false,
+        "missingness_rate": false,
+        "shift_closure_documented": false,
+        "glasgow": true
+      },
+      "warnings": [],
+      "shadow_mode": true,
+      "non_individual_use": true
+    }
+  ],
   "shadow_mode": true,
   "non_individual_use": true
 }
@@ -49,7 +80,7 @@ Campos obligatorios del sobre:
 - `model_id`: UUID configurado en `ICEA_BRIDGE_MODEL_ID`.
 - `grain`: debe coincidir con `rows[0].source_grain`.
 - `from_db`: siempre `false` en este bridge; HANDOVER envia una proyeccion desde el handover persistido, no una consulta directa a una base ICEA.
-- `rows`: lista de una fila proyectada desde el payload HANDOVER.
+- `rows`: lista con exactamente una fila proyectada desde el payload HANDOVER; `rows: []` es invalido para este bridge.
 - `shadow_mode`: obligatorio `true`.
 - `non_individual_use`: obligatorio `true`.
 

--- a/tests/fixtures/icea/handover_icea_feature_contract_v1.json
+++ b/tests/fixtures/icea/handover_icea_feature_contract_v1.json
@@ -1,0 +1,29 @@
+{
+  "contract_version": "handover-icea-feature-v1",
+  "source_repo": "Luis195f/HANDOVER",
+  "source_grain": "window",
+  "row_id": "window:enc-bridge-001",
+  "episode_id": "enc-bridge-001",
+  "unit_id": "icu-a",
+  "clinical_timestamp": "2026-03-08T15:00:00Z",
+  "recorded_timestamp": "2026-03-08T15:03:00Z",
+  "features": {
+    "age_years": 37.0,
+    "documented_medication_count": 1.0,
+    "documented_procedure_count": 1.0,
+    "severity_weight": 0.2,
+    "structured_completeness_rate": 0.8,
+    "shift_closure_documented": 1.0
+  },
+  "missingness_flags": {
+    "age_years": false,
+    "documented_medication_count": false,
+    "documented_procedure_count": false,
+    "severity_weight": false,
+    "structured_completeness_rate": false,
+    "shift_closure_documented": false
+  },
+  "warnings": [],
+  "shadow_mode": true,
+  "non_individual_use": true
+}


### PR DESCRIPTION
Adds a versioned HANDOVER to ICEA bridge feature contract, validates payloads before ICEA+ score requests, preserves shadow/non-individual-use flags, and suppresses scoreSummary when ICEA returns contract_mismatch, insufficient_evidence, or low_feature_coverage. Submit FHIR and offline queue unchanged. Verified backend bridge tests and PatientList priority tests.