### PR TITLE
fix(icea): reject individual score material across response aliases

### DIFF
--- a/backend/api/icea_bridge_service.py
+++ b/backend/api/icea_bridge_service.py
@@ -35,6 +35,8 @@ NON_SCORING_REMOTE_STATUSES = frozenset({'contract_mismatch', 'insufficient_evid
 NON_SCORING_CONTRACT_FAILURE_REMOTE_STATUSES = frozenset({'contract_mismatch', 'low_feature_coverage'})
 SCORE_SUMMARY_REDACTED_WARNING = 'score_summary_redacted_due_to_non_scoring_status'
 SCORE_SUMMARY_REDACTED_MARKER = {'redacted': True, 'reason': SCORE_SUMMARY_REDACTED_WARNING}
+REMOTE_SCORE_SUMMARY_KEYS = ('scoreSummary', 'score_summary')
+REMOTE_SCORE_VALUE_KEYS = ('score', 'raw_score', 'rawScore', 'riskScore', 'value')
 
 
 @dataclass(frozen=True)
@@ -1260,11 +1262,15 @@ def _contains_numeric_score_material(value: Any) -> bool:
     return False
 
 
-def _remote_payload_has_redactable_score_material(payload: dict[str, Any], first_result: dict[str, Any]) -> bool:
-    if _contains_numeric_score_material(payload.get('scoreSummary')):
-        return True
-    for key in ('score', 'raw_score', 'rawScore', 'riskScore', 'value'):
-        if _numeric_score_value(payload.get(key)) or _numeric_score_value(first_result.get(key)):
+def remote_payload_has_individual_score_material(
+    payload: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    for key in REMOTE_SCORE_SUMMARY_KEYS:
+        if _contains_numeric_score_material(payload.get(key)) or _contains_numeric_score_material(result.get(key)):
+            return True
+    for key in REMOTE_SCORE_VALUE_KEYS:
+        if _numeric_score_value(payload.get(key)) or _numeric_score_value(result.get(key)):
             return True
     return False
 
@@ -1309,7 +1315,7 @@ def _normalize_remote_payload(
         if contract_failure_code
         else ''
     )
-    redacted_score_material = non_scoring_status and _remote_payload_has_redactable_score_material(payload, first_result)
+    redacted_score_material = non_scoring_status and remote_payload_has_individual_score_material(payload, first_result)
 
     score_summary = None
     if non_scoring_status:

--- a/backend/api/icea_shadow_verification.py
+++ b/backend/api/icea_shadow_verification.py
@@ -16,6 +16,7 @@ from backend.api.icea_bridge_service import (
     build_icea_bridge_idempotency_key,
     build_icea_plus_score_request,
     load_icea_bridge_settings,
+    remote_payload_has_individual_score_material,
     score_configuration_error_code,
 )
 from backend.api.icea_payload_mapper import build_icea_bridge_payload, compute_payload_hash
@@ -293,8 +294,13 @@ def _validate_remote_response(body: Any) -> tuple[list[dict[str, str]], dict[str
             )
         )
 
+    individual_score_material = any(
+        remote_payload_has_individual_score_material(body, row)
+        for row in rows
+    )
     individual_result_redacted = (
-        body.get("score_summary") is None
+        not individual_score_material
+        and body.get("score_summary") is None
         and body.get("score_summary_redacted") is True
         and body.get("summary_redacted") is True
         and all(

--- a/backend/api/tests/test_icea_shadow_verification.py
+++ b/backend/api/tests/test_icea_shadow_verification.py
@@ -139,20 +139,45 @@ class IceaShadowVerificationTests(SimpleTestCase):
         self.assertFalse(any(check["status"] == FAIL for check in result["checks"]))
 
     @patch("backend.api.icea_bridge_service.httpx.request")
-    def test_individual_score_material_is_fail(self, mock_request):
-        unsafe_body = shadow_response()
-        unsafe_body["results"][0]["score"] = 72.4
-        mock_request.return_value = httpx.Response(200, json=unsafe_body)
+    def test_recognized_individual_score_aliases_are_fail(self, mock_request):
+        cases = (
+            ("score_summary", "root", {"score": 72.4}),
+            ("scoreSummary", "root", {"score": 72.4}),
+            ("score", "result", 72.4),
+            ("raw_score", "result", 0.724),
+            ("rawScore", "result", 0.724),
+            ("riskScore", "result", 72.4),
+            ("value", "result", 72.4),
+        )
+
+        for score_key, location, numeric_value in cases:
+            with self.subTest(score_key=score_key, location=location):
+                unsafe_body = shadow_response()
+                target = unsafe_body if location == "root" else unsafe_body["results"][0]
+                target[score_key] = numeric_value
+                mock_request.return_value = httpx.Response(200, json=unsafe_body)
+
+                with patch.dict(os.environ, BRIDGE_ENV, clear=False):
+                    result = verify_synthetic_icea_shadow_bridge()
+
+                self.assertEqual(result["status"], FAIL)
+                self.assertFalse(result["governance"]["no_individual_result"])
+                self.assertIn(
+                    "no_individual_result",
+                    {check["name"] for check in result["checks"] if check["status"] == FAIL},
+                )
+
+    @patch("backend.api.icea_bridge_service.httpx.request")
+    def test_numeric_value_outside_score_context_is_not_rejected(self, mock_request):
+        safe_body = shadow_response()
+        safe_body["metadata"] = {"value": 1}
+        mock_request.return_value = httpx.Response(200, json=safe_body)
 
         with patch.dict(os.environ, BRIDGE_ENV, clear=False):
             result = verify_synthetic_icea_shadow_bridge()
 
-        self.assertEqual(result["status"], FAIL)
-        self.assertFalse(result["governance"]["no_individual_result"])
-        self.assertIn(
-            "no_individual_result",
-            {check["name"] for check in result["checks"] if check["status"] == FAIL},
-        )
+        self.assertEqual(result["status"], PASS)
+        self.assertTrue(result["governance"]["no_individual_result"])
 
     @patch("backend.api.icea_bridge_service.httpx.request")
     def test_forbidden_non_individual_response_fields_are_fail(self, mock_request):


### PR DESCRIPTION
# Summary
- 

# Scope
- 

# How to test
```
# Pilot-grade quality gates
pnpm -w quality:pilot

# Focused reruns when needed
pnpm -w test:pilot:coverage
pnpm -w test:smoke:forms
pnpm -w gate:any-sensitive
pnpm -w validate:fhir:fixture
```

# Coverage
- Note: pilot-grade coverage runs through `vitest.pilot.config.ts`.
- Note: If coverage fails due to registry access for `@vitest/coverage-v8`, note it here.

# PHI/Security
- [ ] No PHI in logs/snapshots
- [ ] No PHI in fixtures/test data
- [ ] No PHI in screenshots

# Reviewer checklist
- [ ] Scope matches summary and is limited to intended changes
- [ ] Tests/commands in this PR are documented and results reported
- [ ] Coverage expectations and gaps are clearly stated
- [ ] No PHI or sensitive data introduced

